### PR TITLE
Add PROV-style report and export workflow scaffolding

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,3 +40,27 @@ make -C src all
 
 BFO projection from CCO mappings is not implemented in this migration. Spreadsheet-to-TTL conversion is also not implemented in this migration.
 
+## Workflow artifacts and reports
+
+The `all` targets remain the basic validation workflow for each track. They run reasoning over the editor ontology and the existing hygiene SPARQL checks. They do not generate release mappings and they do not evaluate mapping correctness.
+
+Additional generated artifacts can be produced with:
+
+```bash
+make -C src reports
+make -C src sssom
+make -C src entailed-mappings
+make -C src unmapped
+make -C src artifacts
+```
+
+`reports` runs ROBOT report generation for both editor ontologies and writes TSV reports under each track's `build/artifacts/` directory.
+
+`sssom` runs generic SSSOM-style CSV exports over authored TTL mappings for each track's BFO and CCO target deliverables. These exports are generated report artifacts, not release files.
+
+`entailed-mappings` materializes derived TTL artifacts under each track's `build/artifacts/` directory. These generated files are not release mappings and should not be treated as authored mapping content.
+
+`unmapped` is scaffolded but disabled by default. It exits successfully with a message until real source imports and final source namespace configuration are added.
+
+Generated report and artifact files are ignored by Git. Spreadsheet-to-TTL conversion is not implemented. BFO projection from CCO mappings is not implemented. The existing `SSN2BFO.ttl`, root spreadsheets, and root `imports/` directory remain preserved.
+

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,8 +1,11 @@
-#### Track dispatcher for SSN/SOSA -> BFO/CCO mapping validation
+#### Track dispatcher for SSN/SOSA -> BFO/CCO mapping validation and artifacts
 
 TRACKS := current-ssn-sosa sosa-next
 
 .PHONY: all $(TRACKS) reason-current-ssn-sosa test-current-ssn-sosa hygiene-current-ssn-sosa reason-sosa-next test-sosa-next hygiene-sosa-next clean
+.PHONY: reports reports-current-ssn-sosa reports-sosa-next sssom sssom-current-ssn-sosa sssom-sosa-next
+.PHONY: entailed-mappings entailed-current-ssn-sosa entailed-sosa-next unmapped unmapped-current-ssn-sosa unmapped-sosa-next
+.PHONY: artifacts artifacts-current-ssn-sosa artifacts-sosa-next
 
 all: $(TRACKS)
 
@@ -29,6 +32,46 @@ test-sosa-next:
 
 hygiene-sosa-next:
 	$(MAKE) -C sosa-next hygiene
+
+reports: reports-current-ssn-sosa reports-sosa-next
+
+reports-current-ssn-sosa:
+	$(MAKE) -C current-ssn-sosa report-edit
+
+reports-sosa-next:
+	$(MAKE) -C sosa-next report-edit
+
+sssom: sssom-current-ssn-sosa sssom-sosa-next
+
+sssom-current-ssn-sosa:
+	$(MAKE) -C current-ssn-sosa sssom
+
+sssom-sosa-next:
+	$(MAKE) -C sosa-next sssom
+
+entailed-mappings: entailed-current-ssn-sosa entailed-sosa-next
+
+entailed-current-ssn-sosa:
+	$(MAKE) -C current-ssn-sosa entailed-mappings
+
+entailed-sosa-next:
+	$(MAKE) -C sosa-next entailed-mappings
+
+unmapped: unmapped-current-ssn-sosa unmapped-sosa-next
+
+unmapped-current-ssn-sosa:
+	$(MAKE) -C current-ssn-sosa unmapped
+
+unmapped-sosa-next:
+	$(MAKE) -C sosa-next unmapped
+
+artifacts: artifacts-current-ssn-sosa artifacts-sosa-next
+
+artifacts-current-ssn-sosa:
+	$(MAKE) -C current-ssn-sosa artifacts
+
+artifacts-sosa-next:
+	$(MAKE) -C sosa-next artifacts
 
 clean:
 	$(MAKE) -C current-ssn-sosa clean

--- a/src/current-ssn-sosa/Makefile
+++ b/src/current-ssn-sosa/Makefile
@@ -1,4 +1,4 @@
-#### Basic ontology validation pipeline for the current SSN/SOSA track
+#### Basic ontology validation and artifact pipeline for the current SSN/SOSA track
 
 config.ONTOLOGY_FILE      := ssn-sosa-mappings-edit.ttl
 config.ONTOLOGY_PREFIX    := current-ssn-sosa
@@ -8,10 +8,13 @@ config.RELEASE_FILES      := ../../releases/current-ssn-sosa/ssn-sosa-bfo-direct
 config.TEMP_DIR           := build/artifacts
 config.REPORTS_DIR        := $(config.TEMP_DIR)
 config.QUERIES_DIR        := sparql
+config.EXPORT_QUERIES_DIR := $(config.QUERIES_DIR)/export
+config.REPORT_QUERIES_DIR := $(config.QUERIES_DIR)/report
 config.LIBRARY_DIR        := ../../build/lib
 
 config.FAIL_ON_TEST_FAILURES := false
 config.REPORT_FAIL_ON        := none
+config.ENABLE_UNMAPPED_REPORTS := false
 
 TODAY     := $(shell date +%Y-%m-%d)
 TIMESTAMP := $(shell date +'%Y-%m-%d %H:%M')
@@ -20,7 +23,12 @@ config.RELEASE_NAME := $(config.ONTOLOGY_PREFIX) $(TIMESTAMP)
 
 EDITOR_BUILD_FILE  := $(config.ONTOLOGY_FILE)
 EDITOR_REPORT_FILE := $(config.REPORTS_DIR)/$(config.ONTOLOGY_PREFIX)-edit-report.tsv
-REQUIRED_DIRS      := $(sort $(config.TEMP_DIR) $(config.LIBRARY_DIR) $(config.QUERIES_DIR) $(config.REPORTS_DIR))
+BFO_SSSOM_FILE     := $(config.REPORTS_DIR)/$(config.ONTOLOGY_PREFIX)-bfo-mappings.sssom.csv
+CCO_SSSOM_FILE     := $(config.REPORTS_DIR)/$(config.ONTOLOGY_PREFIX)-cco-mappings.sssom.csv
+ENTAILED_MAPPINGS_FILE := $(config.REPORTS_DIR)/$(config.ONTOLOGY_PREFIX)-entailed-mappings.ttl
+UNMAPPED_TERMS_FILE := $(config.REPORTS_DIR)/$(config.ONTOLOGY_PREFIX)-unmapped-terms.csv
+
+REQUIRED_DIRS      := $(sort $(config.TEMP_DIR) $(config.LIBRARY_DIR) $(config.QUERIES_DIR) $(config.EXPORT_QUERIES_DIR) $(config.REPORT_QUERIES_DIR) $(config.REPORTS_DIR))
 
 .PHONY: all hygiene
 all: reason-edit hygiene
@@ -34,6 +42,29 @@ reason-edit: reason
 test-edit: verify
 report-edit: report
 explain-edit: explain
+
+.PHONY: sssom-bfo sssom-cco sssom entailed-mappings unmapped artifacts
+sssom: sssom-bfo sssom-cco
+artifacts: report-edit sssom entailed-mappings unmapped
+
+sssom-bfo: $(EDITOR_BUILD_FILE) $(config.EXPORT_QUERIES_DIR)/sssom-bfo-mappings.rq | $(config.TEMP_DIR) $(ROBOT_FILE)
+	$(ROBOT) query --input $(EDITOR_BUILD_FILE) --query $(config.EXPORT_QUERIES_DIR)/sssom-bfo-mappings.rq $(BFO_SSSOM_FILE) --format csv
+
+sssom-cco: $(EDITOR_BUILD_FILE) $(config.EXPORT_QUERIES_DIR)/sssom-cco-mappings.rq | $(config.TEMP_DIR) $(ROBOT_FILE)
+	$(ROBOT) query --input $(EDITOR_BUILD_FILE) --query $(config.EXPORT_QUERIES_DIR)/sssom-cco-mappings.rq $(CCO_SSSOM_FILE) --format csv
+
+entailed-mappings: $(EDITOR_BUILD_FILE) | $(config.TEMP_DIR) $(ROBOT_FILE)
+	$(ROBOT) remove --input $(EDITOR_BUILD_FILE) --select individuals \
+	reason --reasoner HermiT --axiom-generators "SubClass EquivalentClass SubObjectProperty EquivalentObjectProperty InverseObjectProperties" --include-indirect true --remove-redundant-subclass-axioms false --exclude-duplicate-axioms true \
+	annotate --ontology-iri "$(config.ONTOLOGY_IRI)/generated/entailed-mappings" --version-iri "$(config.ONTOLOGY_IRI)/generated/$(TODAY)/entailed-mappings" --annotation owl:versionInfo "$(TODAY)" --annotation rdfs:comment "Generated artifact for $(config.ONTOLOGY_PREFIX); not a release mapping file." \
+	--output $(ENTAILED_MAPPINGS_FILE)
+
+unmapped: $(EDITOR_BUILD_FILE) $(config.REPORT_QUERIES_DIR)/unmapped-terms.rq | $(config.TEMP_DIR) $(ROBOT_FILE)
+ifeq ($(config.ENABLE_UNMAPPED_REPORTS),true)
+	$(ROBOT) query --input $(EDITOR_BUILD_FILE) --query $(config.REPORT_QUERIES_DIR)/unmapped-terms.rq $(UNMAPPED_TERMS_FILE) --format csv
+else
+	@echo "Unmapped-term reports are disabled for $(config.ONTOLOGY_PREFIX). Enable config.ENABLE_UNMAPPED_REPORTS only after real source imports and final source namespace configuration are added."
+endif
 
 .PHONY: output-release-filepaths
 output-release-filepaths:

--- a/src/current-ssn-sosa/sparql/export/sssom-bfo-mappings.rq
+++ b/src/current-ssn-sosa/sparql/export/sssom-bfo-mappings.rq
@@ -1,0 +1,26 @@
+PREFIX owl: <http://www.w3.org/2002/07/owl#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+
+SELECT DISTINCT ?subject_id ?subject_label ?predicate_id ?object_id ?object_label ?mapping_justification ?target_ontology WHERE {
+  ?subject_id ?predicate_id ?object_id .
+
+  VALUES ?predicate_id {
+    rdfs:subClassOf
+    rdfs:subPropertyOf
+    owl:equivalentClass
+    owl:equivalentProperty
+  }
+
+  BIND(STR(?object_id) AS ?object_text)
+  BIND("BFO" AS ?target_ontology)
+
+  FILTER(STRSTARTS(?object_text, "http://purl.obolibrary.org/obo/BFO_"))
+
+  VALUES (?mapping_justification) {
+    ("https://w3id.org/semapv/vocab/ManualMappingCuration")
+  }
+
+  OPTIONAL { ?subject_id rdfs:label ?subject_label . }
+  OPTIONAL { ?object_id rdfs:label ?object_label . }
+}
+ORDER BY ?subject_id ?predicate_id ?object_id

--- a/src/current-ssn-sosa/sparql/export/sssom-cco-mappings.rq
+++ b/src/current-ssn-sosa/sparql/export/sssom-cco-mappings.rq
@@ -1,0 +1,26 @@
+PREFIX owl: <http://www.w3.org/2002/07/owl#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+
+SELECT DISTINCT ?subject_id ?subject_label ?predicate_id ?object_id ?object_label ?mapping_justification ?target_ontology WHERE {
+  ?subject_id ?predicate_id ?object_id .
+
+  VALUES ?predicate_id {
+    rdfs:subClassOf
+    rdfs:subPropertyOf
+    owl:equivalentClass
+    owl:equivalentProperty
+  }
+
+  BIND(STR(?object_id) AS ?object_text)
+  BIND("CCO" AS ?target_ontology)
+
+  FILTER(STRSTARTS(?object_text, "https://www.commoncoreontologies.org/") || STRSTARTS(?object_text, "http://www.ontologyrepository.com/CommonCoreOntologies/") || STRSTARTS(?object_text, "https://www.ontologyrepository.com/CommonCoreOntologies/"))
+
+  VALUES (?mapping_justification) {
+    ("https://w3id.org/semapv/vocab/ManualMappingCuration")
+  }
+
+  OPTIONAL { ?subject_id rdfs:label ?subject_label . }
+  OPTIONAL { ?object_id rdfs:label ?object_label . }
+}
+ORDER BY ?subject_id ?predicate_id ?object_id

--- a/src/current-ssn-sosa/sparql/export/sssom-mappings.rq
+++ b/src/current-ssn-sosa/sparql/export/sssom-mappings.rq
@@ -1,0 +1,37 @@
+PREFIX owl: <http://www.w3.org/2002/07/owl#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+
+SELECT DISTINCT ?subject_id ?subject_label ?predicate_id ?object_id ?object_label ?mapping_justification ?target_ontology WHERE {
+  ?subject_id ?predicate_id ?object_id .
+
+  VALUES ?predicate_id {
+    rdfs:subClassOf
+    rdfs:subPropertyOf
+    owl:equivalentClass
+    owl:equivalentProperty
+  }
+
+  BIND(STR(?object_id) AS ?object_text)
+  BIND(
+    IF(STRSTARTS(?object_text, "http://purl.obolibrary.org/obo/BFO_"),
+      "BFO",
+      IF(
+        STRSTARTS(?object_text, "https://www.commoncoreontologies.org/")
+        || STRSTARTS(?object_text, "http://www.ontologyrepository.com/CommonCoreOntologies/")
+        || STRSTARTS(?object_text, "https://www.ontologyrepository.com/CommonCoreOntologies/"),
+        "CCO",
+        ""
+      )
+    ) AS ?target_ontology
+  )
+
+  FILTER(?target_ontology IN ("BFO", "CCO"))
+
+  VALUES (?mapping_justification) {
+    ("https://w3id.org/semapv/vocab/ManualMappingCuration")
+  }
+
+  OPTIONAL { ?subject_id rdfs:label ?subject_label . }
+  OPTIONAL { ?object_id rdfs:label ?object_label . }
+}
+ORDER BY ?target_ontology ?subject_id ?predicate_id ?object_id

--- a/src/current-ssn-sosa/sparql/report/unmapped-terms.rq
+++ b/src/current-ssn-sosa/sparql/report/unmapped-terms.rq
@@ -1,0 +1,14 @@
+PREFIX owl: <http://www.w3.org/2002/07/owl#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+
+# Framework query only.
+# The Makefile keeps unmapped reports disabled until source namespaces and
+# source imports are explicitly configured for the track.
+SELECT DISTINCT ?source_term ?label ?term_type WHERE {
+  VALUES ?term_type { owl:Class owl:ObjectProperty }
+  ?source_term a ?term_type .
+  OPTIONAL { ?source_term rdfs:label ?label . }
+
+  FILTER(false)
+}
+ORDER BY ?term_type ?source_term

--- a/src/sosa-next/Makefile
+++ b/src/sosa-next/Makefile
@@ -1,4 +1,4 @@
-#### Basic ontology validation pipeline for the forthcoming SOSA-only track
+#### Basic ontology validation and artifact pipeline for the forthcoming SOSA-only track
 
 config.ONTOLOGY_FILE      := sosa-mappings-edit.ttl
 config.ONTOLOGY_PREFIX    := sosa-next
@@ -8,10 +8,13 @@ config.RELEASE_FILES      := ../../releases/sosa-next/sosa-bfo-directmappings.tt
 config.TEMP_DIR           := build/artifacts
 config.REPORTS_DIR        := $(config.TEMP_DIR)
 config.QUERIES_DIR        := sparql
+config.EXPORT_QUERIES_DIR := $(config.QUERIES_DIR)/export
+config.REPORT_QUERIES_DIR := $(config.QUERIES_DIR)/report
 config.LIBRARY_DIR        := ../../build/lib
 
 config.FAIL_ON_TEST_FAILURES := false
 config.REPORT_FAIL_ON        := none
+config.ENABLE_UNMAPPED_REPORTS := false
 
 TODAY     := $(shell date +%Y-%m-%d)
 TIMESTAMP := $(shell date +'%Y-%m-%d %H:%M')
@@ -20,7 +23,12 @@ config.RELEASE_NAME := $(config.ONTOLOGY_PREFIX) $(TIMESTAMP)
 
 EDITOR_BUILD_FILE  := $(config.ONTOLOGY_FILE)
 EDITOR_REPORT_FILE := $(config.REPORTS_DIR)/$(config.ONTOLOGY_PREFIX)-edit-report.tsv
-REQUIRED_DIRS      := $(sort $(config.TEMP_DIR) $(config.LIBRARY_DIR) $(config.QUERIES_DIR) $(config.REPORTS_DIR))
+BFO_SSSOM_FILE     := $(config.REPORTS_DIR)/$(config.ONTOLOGY_PREFIX)-bfo-mappings.sssom.csv
+CCO_SSSOM_FILE     := $(config.REPORTS_DIR)/$(config.ONTOLOGY_PREFIX)-cco-mappings.sssom.csv
+ENTAILED_MAPPINGS_FILE := $(config.REPORTS_DIR)/$(config.ONTOLOGY_PREFIX)-entailed-mappings.ttl
+UNMAPPED_TERMS_FILE := $(config.REPORTS_DIR)/$(config.ONTOLOGY_PREFIX)-unmapped-terms.csv
+
+REQUIRED_DIRS      := $(sort $(config.TEMP_DIR) $(config.LIBRARY_DIR) $(config.QUERIES_DIR) $(config.EXPORT_QUERIES_DIR) $(config.REPORT_QUERIES_DIR) $(config.REPORTS_DIR))
 
 .PHONY: all hygiene
 all: reason-edit hygiene
@@ -34,6 +42,29 @@ reason-edit: reason
 test-edit: verify
 report-edit: report
 explain-edit: explain
+
+.PHONY: sssom-bfo sssom-cco sssom entailed-mappings unmapped artifacts
+sssom: sssom-bfo sssom-cco
+artifacts: report-edit sssom entailed-mappings unmapped
+
+sssom-bfo: $(EDITOR_BUILD_FILE) $(config.EXPORT_QUERIES_DIR)/sssom-bfo-mappings.rq | $(config.TEMP_DIR) $(ROBOT_FILE)
+	$(ROBOT) query --input $(EDITOR_BUILD_FILE) --query $(config.EXPORT_QUERIES_DIR)/sssom-bfo-mappings.rq $(BFO_SSSOM_FILE) --format csv
+
+sssom-cco: $(EDITOR_BUILD_FILE) $(config.EXPORT_QUERIES_DIR)/sssom-cco-mappings.rq | $(config.TEMP_DIR) $(ROBOT_FILE)
+	$(ROBOT) query --input $(EDITOR_BUILD_FILE) --query $(config.EXPORT_QUERIES_DIR)/sssom-cco-mappings.rq $(CCO_SSSOM_FILE) --format csv
+
+entailed-mappings: $(EDITOR_BUILD_FILE) | $(config.TEMP_DIR) $(ROBOT_FILE)
+	$(ROBOT) remove --input $(EDITOR_BUILD_FILE) --select individuals \
+	reason --reasoner HermiT --axiom-generators "SubClass EquivalentClass SubObjectProperty EquivalentObjectProperty InverseObjectProperties" --include-indirect true --remove-redundant-subclass-axioms false --exclude-duplicate-axioms true \
+	annotate --ontology-iri "$(config.ONTOLOGY_IRI)/generated/entailed-mappings" --version-iri "$(config.ONTOLOGY_IRI)/generated/$(TODAY)/entailed-mappings" --annotation owl:versionInfo "$(TODAY)" --annotation rdfs:comment "Generated artifact for $(config.ONTOLOGY_PREFIX); not a release mapping file." \
+	--output $(ENTAILED_MAPPINGS_FILE)
+
+unmapped: $(EDITOR_BUILD_FILE) $(config.REPORT_QUERIES_DIR)/unmapped-terms.rq | $(config.TEMP_DIR) $(ROBOT_FILE)
+ifeq ($(config.ENABLE_UNMAPPED_REPORTS),true)
+	$(ROBOT) query --input $(EDITOR_BUILD_FILE) --query $(config.REPORT_QUERIES_DIR)/unmapped-terms.rq $(UNMAPPED_TERMS_FILE) --format csv
+else
+	@echo "Unmapped-term reports are disabled for $(config.ONTOLOGY_PREFIX). Enable config.ENABLE_UNMAPPED_REPORTS only after real source imports and final source namespace configuration are added."
+endif
 
 .PHONY: output-release-filepaths
 output-release-filepaths:

--- a/src/sosa-next/sparql/export/sssom-bfo-mappings.rq
+++ b/src/sosa-next/sparql/export/sssom-bfo-mappings.rq
@@ -1,0 +1,26 @@
+PREFIX owl: <http://www.w3.org/2002/07/owl#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+
+SELECT DISTINCT ?subject_id ?subject_label ?predicate_id ?object_id ?object_label ?mapping_justification ?target_ontology WHERE {
+  ?subject_id ?predicate_id ?object_id .
+
+  VALUES ?predicate_id {
+    rdfs:subClassOf
+    rdfs:subPropertyOf
+    owl:equivalentClass
+    owl:equivalentProperty
+  }
+
+  BIND(STR(?object_id) AS ?object_text)
+  BIND("BFO" AS ?target_ontology)
+
+  FILTER(STRSTARTS(?object_text, "http://purl.obolibrary.org/obo/BFO_"))
+
+  VALUES (?mapping_justification) {
+    ("https://w3id.org/semapv/vocab/ManualMappingCuration")
+  }
+
+  OPTIONAL { ?subject_id rdfs:label ?subject_label . }
+  OPTIONAL { ?object_id rdfs:label ?object_label . }
+}
+ORDER BY ?subject_id ?predicate_id ?object_id

--- a/src/sosa-next/sparql/export/sssom-cco-mappings.rq
+++ b/src/sosa-next/sparql/export/sssom-cco-mappings.rq
@@ -1,0 +1,26 @@
+PREFIX owl: <http://www.w3.org/2002/07/owl#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+
+SELECT DISTINCT ?subject_id ?subject_label ?predicate_id ?object_id ?object_label ?mapping_justification ?target_ontology WHERE {
+  ?subject_id ?predicate_id ?object_id .
+
+  VALUES ?predicate_id {
+    rdfs:subClassOf
+    rdfs:subPropertyOf
+    owl:equivalentClass
+    owl:equivalentProperty
+  }
+
+  BIND(STR(?object_id) AS ?object_text)
+  BIND("CCO" AS ?target_ontology)
+
+  FILTER(STRSTARTS(?object_text, "https://www.commoncoreontologies.org/") || STRSTARTS(?object_text, "http://www.ontologyrepository.com/CommonCoreOntologies/") || STRSTARTS(?object_text, "https://www.ontologyrepository.com/CommonCoreOntologies/"))
+
+  VALUES (?mapping_justification) {
+    ("https://w3id.org/semapv/vocab/ManualMappingCuration")
+  }
+
+  OPTIONAL { ?subject_id rdfs:label ?subject_label . }
+  OPTIONAL { ?object_id rdfs:label ?object_label . }
+}
+ORDER BY ?subject_id ?predicate_id ?object_id

--- a/src/sosa-next/sparql/export/sssom-mappings.rq
+++ b/src/sosa-next/sparql/export/sssom-mappings.rq
@@ -1,0 +1,37 @@
+PREFIX owl: <http://www.w3.org/2002/07/owl#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+
+SELECT DISTINCT ?subject_id ?subject_label ?predicate_id ?object_id ?object_label ?mapping_justification ?target_ontology WHERE {
+  ?subject_id ?predicate_id ?object_id .
+
+  VALUES ?predicate_id {
+    rdfs:subClassOf
+    rdfs:subPropertyOf
+    owl:equivalentClass
+    owl:equivalentProperty
+  }
+
+  BIND(STR(?object_id) AS ?object_text)
+  BIND(
+    IF(STRSTARTS(?object_text, "http://purl.obolibrary.org/obo/BFO_"),
+      "BFO",
+      IF(
+        STRSTARTS(?object_text, "https://www.commoncoreontologies.org/")
+        || STRSTARTS(?object_text, "http://www.ontologyrepository.com/CommonCoreOntologies/")
+        || STRSTARTS(?object_text, "https://www.ontologyrepository.com/CommonCoreOntologies/"),
+        "CCO",
+        ""
+      )
+    ) AS ?target_ontology
+  )
+
+  FILTER(?target_ontology IN ("BFO", "CCO"))
+
+  VALUES (?mapping_justification) {
+    ("https://w3id.org/semapv/vocab/ManualMappingCuration")
+  }
+
+  OPTIONAL { ?subject_id rdfs:label ?subject_label . }
+  OPTIONAL { ?object_id rdfs:label ?object_label . }
+}
+ORDER BY ?target_ontology ?subject_id ?predicate_id ?object_id

--- a/src/sosa-next/sparql/report/unmapped-terms.rq
+++ b/src/sosa-next/sparql/report/unmapped-terms.rq
@@ -1,0 +1,14 @@
+PREFIX owl: <http://www.w3.org/2002/07/owl#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+
+# Framework query only.
+# The Makefile keeps unmapped reports disabled until source namespaces and
+# source imports are explicitly configured for the track.
+SELECT DISTINCT ?source_term ?label ?term_type WHERE {
+  VALUES ?term_type { owl:Class owl:ObjectProperty }
+  ?source_term a ?term_type .
+  OPTIONAL { ?source_term rdfs:label ?label . }
+
+  FILTER(false)
+}
+ORDER BY ?term_type ?source_term


### PR DESCRIPTION
Adds reusable ROBOT/SPARQL report, SSSOM-style export, entailed-mapping artifact, and disabled unmapped-report workflow scaffolding for the two-track SSN/SOSA → BFO/CCO structure.

No ontology mappings were created, inferred, revised, normalized, moved, split, or overwritten. SSN2BFO.ttl, root spreadsheets, root imports, and release placeholder mapping content are preserved.

Validation run:
- make -C src/current-ssn-sosa all
- make -C src/sosa-next all
- make -C src all
- make -C src reports
- make -C src sssom
- make -C src entailed-mappings
- make -C src unmapped