### PR TITLE
Add current-track BFO-only projection workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ make -C src/sosa-next all
 make -C src all
 ```
 
-BFO projection from CCO mappings is not implemented in this migration. Spreadsheet-to-TTL conversion is also not implemented in this migration.
+Release-file BFO projection from CCO mappings is not implemented in this migration. Spreadsheet-to-TTL conversion is also not implemented in this migration.
 
 ## Workflow artifacts and reports
 
@@ -62,5 +62,24 @@ make -C src artifacts
 
 `unmapped` is scaffolded but disabled by default. It exits successfully with a message until real source imports and final source namespace configuration are added.
 
-Generated report and artifact files are ignored by Git. Spreadsheet-to-TTL conversion is not implemented. BFO projection from CCO mappings is not implemented. The existing `SSN2BFO.ttl`, root spreadsheets, and root `imports/` directory remain preserved.
+Generated report and artifact files are ignored by Git. Spreadsheet-to-TTL conversion is not implemented. Release-file BFO projection from CCO mappings is not implemented. The existing `SSN2BFO.ttl`, root spreadsheets, and root `imports/` directory remain preserved.
+
+## Current SSN/SOSA CCO mapping and BFO-only projection
+
+Under this project's convention, a mapping file counts as a CCO direct mapping when its target vocabulary includes CCO terms, even when it also includes BFO terms, because CCO imports and extends BFO. A BFO direct mapping is BFO-only: its mapping targets should be BFO IRIs and not CCO IRIs.
+
+The root `SSN2BFO.ttl` file is preserved unchanged as the authored current SSN/SOSA to CCO direct mapping candidate. It has not been moved, split, renamed, normalized, or overwritten.
+
+The current SSN/SOSA track includes a generated-artifact workflow for deriving a review-only BFO-only artifact from `SSN2BFO.ttl` and `imports/cco.ttl`:
+
+```bash
+make -C src/current-ssn-sosa derive-bfo-from-cco
+make -C src derive-bfo-from-cco
+```
+
+The generated BFO-only artifact is written to `src/current-ssn-sosa/build/artifacts/current-ssn-sosa-bfo-only-generated.ttl`. It combines direct BFO-target mappings already present in `SSN2BFO.ttl` with conservative BFO projections from direct named CCO targets that have explicit CCO to BFO superclass or superproperty paths in `imports/cco.ttl`.
+
+The skipped-target report is written to `src/current-ssn-sosa/build/artifacts/current-ssn-sosa-bfo-only-skipped-cco-targets.csv`. CCO targets without explicit BFO paths are reported there rather than guessed.
+
+This generated artifact is not a release file. The BFO release placeholder is not populated by this workflow. Complex blank-node expressions, restrictions, intersections, unions, property chains, labels, comments, definitions, natural-language notes, and mapping justifications are skipped. Spreadsheet-to-TTL conversion is not implemented, and no `sosa-next` projection is implemented yet.
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -5,7 +5,7 @@ TRACKS := current-ssn-sosa sosa-next
 .PHONY: all $(TRACKS) reason-current-ssn-sosa test-current-ssn-sosa hygiene-current-ssn-sosa reason-sosa-next test-sosa-next hygiene-sosa-next clean
 .PHONY: reports reports-current-ssn-sosa reports-sosa-next sssom sssom-current-ssn-sosa sssom-sosa-next
 .PHONY: entailed-mappings entailed-current-ssn-sosa entailed-sosa-next unmapped unmapped-current-ssn-sosa unmapped-sosa-next
-.PHONY: artifacts artifacts-current-ssn-sosa artifacts-sosa-next
+.PHONY: artifacts artifacts-current-ssn-sosa artifacts-sosa-next derive-bfo-from-cco derive-bfo-from-cco-current-ssn-sosa
 
 all: $(TRACKS)
 
@@ -72,6 +72,11 @@ artifacts-current-ssn-sosa:
 
 artifacts-sosa-next:
 	$(MAKE) -C sosa-next artifacts
+
+derive-bfo-from-cco: derive-bfo-from-cco-current-ssn-sosa
+
+derive-bfo-from-cco-current-ssn-sosa:
+	$(MAKE) -C current-ssn-sosa derive-bfo-from-cco
 
 clean:
 	$(MAKE) -C current-ssn-sosa clean

--- a/src/current-ssn-sosa/Makefile
+++ b/src/current-ssn-sosa/Makefile
@@ -10,11 +10,14 @@ config.REPORTS_DIR        := $(config.TEMP_DIR)
 config.QUERIES_DIR        := sparql
 config.EXPORT_QUERIES_DIR := $(config.QUERIES_DIR)/export
 config.REPORT_QUERIES_DIR := $(config.QUERIES_DIR)/report
+config.CONSTRUCT_QUERIES_DIR := $(config.QUERIES_DIR)/construct
 config.LIBRARY_DIR        := ../../build/lib
 
 config.FAIL_ON_TEST_FAILURES := false
 config.REPORT_FAIL_ON        := none
 config.ENABLE_UNMAPPED_REPORTS := false
+config.AUTHORED_CCO_MAPPING_FILE := ../../SSN2BFO.ttl
+config.CCO_IMPORT_FILE := ../../imports/cco.ttl
 
 TODAY     := $(shell date +%Y-%m-%d)
 TIMESTAMP := $(shell date +'%Y-%m-%d %H:%M')
@@ -27,8 +30,14 @@ BFO_SSSOM_FILE     := $(config.REPORTS_DIR)/$(config.ONTOLOGY_PREFIX)-bfo-mappin
 CCO_SSSOM_FILE     := $(config.REPORTS_DIR)/$(config.ONTOLOGY_PREFIX)-cco-mappings.sssom.csv
 ENTAILED_MAPPINGS_FILE := $(config.REPORTS_DIR)/$(config.ONTOLOGY_PREFIX)-entailed-mappings.ttl
 UNMAPPED_TERMS_FILE := $(config.REPORTS_DIR)/$(config.ONTOLOGY_PREFIX)-unmapped-terms.csv
+BFO_ONLY_GENERATED_FILE := $(config.REPORTS_DIR)/$(config.ONTOLOGY_PREFIX)-bfo-only-generated.ttl
+BFO_ONLY_SKIPPED_CCO_TARGETS_FILE := $(config.REPORTS_DIR)/$(config.ONTOLOGY_PREFIX)-bfo-only-skipped-cco-targets.csv
+PROJECTION_CATALOG_FILE := $(config.REPORTS_DIR)/$(config.ONTOLOGY_PREFIX)-projection-catalog.xml
 
-REQUIRED_DIRS      := $(sort $(config.TEMP_DIR) $(config.LIBRARY_DIR) $(config.QUERIES_DIR) $(config.EXPORT_QUERIES_DIR) $(config.REPORT_QUERIES_DIR) $(config.REPORTS_DIR))
+REQUIRED_DIRS      := $(sort $(config.TEMP_DIR) $(config.LIBRARY_DIR) $(config.QUERIES_DIR) $(config.EXPORT_QUERIES_DIR) $(config.REPORT_QUERIES_DIR) $(config.CONSTRUCT_QUERIES_DIR) $(config.REPORTS_DIR))
+
+ROBOT_FILE := $(config.LIBRARY_DIR)/robot.jar
+ROBOT := java -jar $(ROBOT_FILE)
 
 .PHONY: all hygiene
 all: reason-edit hygiene
@@ -43,7 +52,7 @@ test-edit: verify
 report-edit: report
 explain-edit: explain
 
-.PHONY: sssom-bfo sssom-cco sssom entailed-mappings unmapped artifacts
+.PHONY: sssom-bfo sssom-cco sssom entailed-mappings unmapped artifacts derive-bfo-from-cco
 sssom: sssom-bfo sssom-cco
 artifacts: report-edit sssom entailed-mappings unmapped
 
@@ -65,6 +74,12 @@ ifeq ($(config.ENABLE_UNMAPPED_REPORTS),true)
 else
 	@echo "Unmapped-term reports are disabled for $(config.ONTOLOGY_PREFIX). Enable config.ENABLE_UNMAPPED_REPORTS only after real source imports and final source namespace configuration are added."
 endif
+
+derive-bfo-from-cco: $(config.AUTHORED_CCO_MAPPING_FILE) $(config.CCO_IMPORT_FILE) $(PROJECTION_CATALOG_FILE) $(config.CONSTRUCT_QUERIES_DIR)/derive-bfo-from-cco.rq $(config.REPORT_QUERIES_DIR)/unprojectable-cco-targets.rq | $(config.TEMP_DIR) $(ROBOT_FILE)
+	$(ROBOT) merge --catalog $(PROJECTION_CATALOG_FILE) --collapse-import-closure false --input $(config.AUTHORED_CCO_MAPPING_FILE) --input $(config.CCO_IMPORT_FILE) \
+	query --query $(config.CONSTRUCT_QUERIES_DIR)/derive-bfo-from-cco.rq $(BFO_ONLY_GENERATED_FILE)
+	$(ROBOT) merge --catalog $(PROJECTION_CATALOG_FILE) --collapse-import-closure false --input $(config.AUTHORED_CCO_MAPPING_FILE) --input $(config.CCO_IMPORT_FILE) \
+	query --query $(config.REPORT_QUERIES_DIR)/unprojectable-cco-targets.rq $(BFO_ONLY_SKIPPED_CCO_TARGETS_FILE) --format csv
 
 .PHONY: output-release-filepaths
 output-release-filepaths:
@@ -88,6 +103,9 @@ $(REQUIRED_DIRS):
 ROBOT_FILE := $(config.LIBRARY_DIR)/robot.jar
 $(ROBOT_FILE): | $(config.LIBRARY_DIR)
 	curl -L -o $@ https://github.com/ontodev/robot/releases/download/v1.9.5/robot.jar
+
+$(PROJECTION_CATALOG_FILE): | $(config.TEMP_DIR)
+	printf '%s\n' '<?xml version="1.0" encoding="UTF-8"?>' '<catalog prefer="public" xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog">' '  <uri name="https://www.commoncoreontologies.org/2024-11-06/CommonCoreOntologiesMerged" uri="$(abspath ../../imports/cco.ttl)"/>' '  <uri name="https://www.commoncoreontologies.org/CommonCoreOntologiesMerged" uri="$(abspath ../../imports/cco.ttl)"/>' '  <uri name="http://www.w3.org/ns/ssn/" uri="$(abspath ../../imports/ssn.ttl)"/>' '  <uri name="http://www.w3.org/ns/ssn/systems/" uri="$(abspath ../../imports/ssn-systems.ttl)"/>' '</catalog>' > $@
 
 ROBOT := java -jar $(ROBOT_FILE)
 

--- a/src/current-ssn-sosa/sparql/construct/derive-bfo-from-cco.rq
+++ b/src/current-ssn-sosa/sparql/construct/derive-bfo-from-cco.rq
@@ -1,0 +1,57 @@
+PREFIX owl: <http://www.w3.org/2002/07/owl#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+
+CONSTRUCT {
+  ?source ?projected_predicate ?bfo_target .
+}
+WHERE {
+  FILTER(isIRI(?source))
+  FILTER(
+    STRSTARTS(STR(?source), "http://www.w3.org/ns/sosa/")
+    || STRSTARTS(STR(?source), "http://www.w3.org/ns/ssn/")
+  )
+
+  {
+    ?source rdfs:subClassOf ?bfo_target .
+    FILTER(isIRI(?bfo_target))
+    FILTER(STRSTARTS(STR(?bfo_target), "http://purl.obolibrary.org/obo/BFO_"))
+    BIND(rdfs:subClassOf AS ?projected_predicate)
+  }
+  UNION
+  {
+    ?source rdfs:subPropertyOf ?bfo_target .
+    FILTER(isIRI(?bfo_target))
+    FILTER(STRSTARTS(STR(?bfo_target), "http://purl.obolibrary.org/obo/BFO_"))
+    BIND(rdfs:subPropertyOf AS ?projected_predicate)
+  }
+  UNION
+  {
+    ?source rdfs:subClassOf ?cco_target .
+    FILTER(isIRI(?cco_target))
+    FILTER(STRSTARTS(STR(?cco_target), "https://www.commoncoreontologies.org/ont"))
+    ?cco_target rdfs:subClassOf+ ?bfo_target .
+    FILTER(isIRI(?bfo_target))
+    FILTER(STRSTARTS(STR(?bfo_target), "http://purl.obolibrary.org/obo/BFO_"))
+    BIND(rdfs:subClassOf AS ?projected_predicate)
+  }
+  UNION
+  {
+    ?source owl:equivalentClass ?cco_target .
+    FILTER(isIRI(?cco_target))
+    FILTER(STRSTARTS(STR(?cco_target), "https://www.commoncoreontologies.org/ont"))
+    ?cco_target rdfs:subClassOf+ ?bfo_target .
+    FILTER(isIRI(?bfo_target))
+    FILTER(STRSTARTS(STR(?bfo_target), "http://purl.obolibrary.org/obo/BFO_"))
+    BIND(rdfs:subClassOf AS ?projected_predicate)
+  }
+  UNION
+  {
+    ?source rdfs:subPropertyOf ?cco_target .
+    FILTER(isIRI(?cco_target))
+    FILTER(STRSTARTS(STR(?cco_target), "https://www.commoncoreontologies.org/ont"))
+    ?cco_target rdfs:subPropertyOf+ ?bfo_target .
+    FILTER(isIRI(?bfo_target))
+    FILTER(STRSTARTS(STR(?bfo_target), "http://purl.obolibrary.org/obo/BFO_"))
+    BIND(rdfs:subPropertyOf AS ?projected_predicate)
+  }
+}

--- a/src/current-ssn-sosa/sparql/report/unprojectable-cco-targets.rq
+++ b/src/current-ssn-sosa/sparql/report/unprojectable-cco-targets.rq
@@ -1,0 +1,44 @@
+PREFIX owl: <http://www.w3.org/2002/07/owl#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+
+SELECT DISTINCT ?source ?predicate ?cco_target ?reason WHERE {
+  VALUES ?predicate {
+    rdfs:subClassOf
+    rdfs:subPropertyOf
+    owl:equivalentClass
+  }
+
+  ?source ?predicate ?cco_target .
+
+  FILTER(isIRI(?source))
+  FILTER(isIRI(?cco_target))
+  FILTER(
+    STRSTARTS(STR(?source), "http://www.w3.org/ns/sosa/")
+    || STRSTARTS(STR(?source), "http://www.w3.org/ns/ssn/")
+  )
+  FILTER(STRSTARTS(STR(?cco_target), "https://www.commoncoreontologies.org/ont"))
+
+  FILTER NOT EXISTS {
+    {
+      FILTER(?predicate IN (rdfs:subClassOf, owl:equivalentClass))
+      ?cco_target rdfs:subClassOf+ ?bfo_target .
+      FILTER(isIRI(?bfo_target))
+      FILTER(STRSTARTS(STR(?bfo_target), "http://purl.obolibrary.org/obo/BFO_"))
+    }
+    UNION
+    {
+      FILTER(?predicate = rdfs:subPropertyOf)
+      ?cco_target rdfs:subPropertyOf+ ?bfo_target .
+      FILTER(isIRI(?bfo_target))
+      FILTER(STRSTARTS(STR(?bfo_target), "http://purl.obolibrary.org/obo/BFO_"))
+    }
+  }
+
+  BIND(
+    IF(?predicate = rdfs:subPropertyOf,
+      "No explicit BFO superproperty path for named CCO target.",
+      "No explicit BFO superclass path for named CCO target."
+    ) AS ?reason
+  )
+}
+ORDER BY ?predicate ?source ?cco_target


### PR DESCRIPTION
Adds a generated review-only workflow for producing a BFO-only current SSN/SOSA artifact from the preserved root SSN2BFO.ttl and the imported CCO hierarchy.

The generated artifact is written only under src/current-ssn-sosa/build/artifacts/ and is not a release file. SSN2BFO.ttl, root spreadsheets, root imports, and all release placeholders are preserved.

Validation run:
- make -C src/current-ssn-sosa derive-bfo-from-cco
- make -C src derive-bfo-from-cco
- make -C src/current-ssn-sosa all
- make -C src all

Generated artifact inspection:
- 33 generated triples
- 0 CCO IRI triples in the BFO-only artifact
- 1 skipped CCO target row reported