### PR TITLE
Restrict BFO projection to most specific targets

### DIFF
--- a/src/current-ssn-sosa/sparql/construct/derive-bfo-from-cco.rq
+++ b/src/current-ssn-sosa/sparql/construct/derive-bfo-from-cco.rq
@@ -32,6 +32,13 @@ WHERE {
     ?cco_target rdfs:subClassOf+ ?bfo_target .
     FILTER(isIRI(?bfo_target))
     FILTER(STRSTARTS(STR(?bfo_target), "http://purl.obolibrary.org/obo/BFO_"))
+    FILTER NOT EXISTS {
+      ?cco_target rdfs:subClassOf+ ?more_specific_bfo .
+      ?more_specific_bfo rdfs:subClassOf+ ?bfo_target .
+      FILTER(isIRI(?more_specific_bfo))
+      FILTER(STRSTARTS(STR(?more_specific_bfo), "http://purl.obolibrary.org/obo/BFO_"))
+      FILTER(?more_specific_bfo != ?bfo_target)
+    }
     BIND(rdfs:subClassOf AS ?projected_predicate)
   }
   UNION
@@ -42,6 +49,13 @@ WHERE {
     ?cco_target rdfs:subClassOf+ ?bfo_target .
     FILTER(isIRI(?bfo_target))
     FILTER(STRSTARTS(STR(?bfo_target), "http://purl.obolibrary.org/obo/BFO_"))
+    FILTER NOT EXISTS {
+      ?cco_target rdfs:subClassOf+ ?more_specific_bfo .
+      ?more_specific_bfo rdfs:subClassOf+ ?bfo_target .
+      FILTER(isIRI(?more_specific_bfo))
+      FILTER(STRSTARTS(STR(?more_specific_bfo), "http://purl.obolibrary.org/obo/BFO_"))
+      FILTER(?more_specific_bfo != ?bfo_target)
+    }
     BIND(rdfs:subClassOf AS ?projected_predicate)
   }
   UNION
@@ -52,6 +66,13 @@ WHERE {
     ?cco_target rdfs:subPropertyOf+ ?bfo_target .
     FILTER(isIRI(?bfo_target))
     FILTER(STRSTARTS(STR(?bfo_target), "http://purl.obolibrary.org/obo/BFO_"))
+    FILTER NOT EXISTS {
+      ?cco_target rdfs:subPropertyOf+ ?more_specific_bfo .
+      ?more_specific_bfo rdfs:subPropertyOf+ ?bfo_target .
+      FILTER(isIRI(?more_specific_bfo))
+      FILTER(STRSTARTS(STR(?more_specific_bfo), "http://purl.obolibrary.org/obo/BFO_"))
+      FILTER(?more_specific_bfo != ?bfo_target)
+    }
     BIND(rdfs:subPropertyOf AS ?projected_predicate)
   }
 }


### PR DESCRIPTION
Refines the current-track BFO-only projection query so CCO-derived BFO targets use the most specific available BFO superclass or superproperty rather than all transitive BFO ancestors.

Validation run:
- make -C src/current-ssn-sosa derive-bfo-from-cco
- make -C src/current-ssn-sosa all
- make -C src all

Generated artifact inspection:
- generated triples changed from 33 to 29
- ssn:Output now maps only to BFO_0000031
- 0 CCO IRIs remain in the generated BFO-only artifact
- skipped CCO target report still reports ssn:wasOriginatedBy to cco:ont00001962

No release files, SSN2BFO.ttl, root imports, or spreadsheets were modified.