### PR TITLE
Add current SSN/SOSA example instance data

### DIFF
--- a/src/current-ssn-sosa/examples/sosa-instance-data/Beer-Full-IBS-TH2.ttl
+++ b/src/current-ssn-sosa/examples/sosa-instance-data/Beer-Full-IBS-TH2.ttl
@@ -1,0 +1,230 @@
+@prefix rdf:  <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
+@prefix xsd:  <http://www.w3.org/2001/XMLSchema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix qudt: <http://qudt.org/schema/qudt/> .
+@prefix unit: <http://qudt.org/vocab/unit/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix schema: <http://schema.org/> .
+@prefix gs1: <https://gs1.org/voc/> .
+@prefix prov: <http://www.w3.org/ns/prov#> .
+@prefix rel: <http://id.loc.gov/vocabulary/relators/> .
+@prefix sosa-env: <http://www.w3.org/ns/sosa/system-environment-properties#> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix geosparql: <http://www.opengis.net/ont/geosparql#> .
+@prefix org: <http://www.w3.org/ns/org#> .
+@prefix beer: <https://rdf.ag/o/beer#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix sosa: <http://www.w3.org/ns/sosa/> .
+@prefix ex: <http://example.org/> .
+@prefix sensor: <https://example.org/sensor/> .
+@base <http://example.org/data/> .
+# This example represents a specific InkBird IBS-TH2 sensor that is performing
+# measurements in multiple locations where the results are owned by different
+# entities. In the scenario used here a local brewery makes use of the sensor to track the 
+# temperature of their beer as it is packaged, stored, shipped and displayed for sale.
+
+<acmeBreweryCo> a org:Organization, beer:Brewery ;
+	foaf:name "Acme Brewery Co." .
+
+<acmeBrewerCooler> a ex:Cooler .
+
+<alice> a foaf:Person, prov:Agent ;
+	foaf:name "Alice" .
+
+<acmeDelivery> a org:Organization ;
+	foaf:name "Acme Delivery Co." .
+
+<acmeTruck> a ex:RefrigeratedTruck .
+
+<acmeSupermarket> a <org:Organization> ;
+	foaf:name "Acme Supermarket Co." .
+
+<acmeSupermarketCooler> a <ex:Cooler> .
+
+# A six pack as packaged and sold by Acme Brewery Co.
+
+<acmePorterSixPack> a beer:Porter, gs1:Product, schema:Product ;
+    skos:definition "A six pack of Acme Porter."@en .
+
+# A specific (instance) six pack of Acme Porter Beers
+# We use GS1-style lot and serial numbers as part of the 
+# identifier to highlight that the carton is a physical instance.
+ 
+<10/PO202402/21/0001/acmePorterSixPack> a schema:IndividualProduct;
+    rdfs:subClassOf <acmePorterSixPack>;
+    gs1:packaging <0001/ProductPackaging>;
+    gs1:hasBatchLotNumber "PO202402" ;
+    gs1:hasSerialNumber "0001" .
+
+# A sample of air within the six pack
+<10/PO202402/21/0001/acmePorterSixPackAirSample> a sosa:Sample ;
+    rdfs:label "Air within the six pack"@en ;
+    sosa:isSampleOf <10/PO202402/21/0001/acmePorterSixPack> .
+
+# A (virtual) sample of the beer from the six pack, implicitly assumes that the
+# sample is representative from all bottles. 
+<10/PO202402/21/0001/acmePorterSixPackBeerSample> a  sosa:FeatureOfInterest, sosa:Sample, beer:Porter ;
+    rdfs:label "A (virtual) sample of beer within the six pack"@en ;
+    sosa:isSampleOf <10/PO202402/21/0001/acmePorterSixPack> .
+
+<0001/ProductPackaging> a gs1:PackagingDetails, sosa:FeatureOfInterest ;  
+    rdfs:label "An instance of a beer carton used to package a six pack."@en .
+
+# We define this as the beer temperature, but ontologically it is a 
+# generic definition for the temperature of the sample.
+<10/PO202402/21/0001/BeerTemperature> a sosa:Property ;
+    qudt:hasUnit unit:DEG_C ;
+    sosa:isPropertyOf <10/PO202402/21/0001/acmePorterSixPackBeerSample> ;
+    rdfs:label "Biertemperatur"@de, "Beer Temperature"@en, "Température de la bière"@fr ;
+    skos:definition "Temperature of Beer."@en .
+
+# Alice packages the Beer.
+
+<12345/someTH2> a sensor:IBS-TH2-Plus, schema:IndividualProduct ;
+    rel:own <acmeBreweryCo> ; # Sensor may be returned.
+    rdfs:label "InkBird Sensor that Alice bought to track beer storage."@en ;
+    sosa:hasSubSystem <12345/HumiditySensor>, <12345/TemperatureSensor> ;
+    gs1:hasSerialNumber "12345" ;
+    ex:deviceAddress "12:34:56:12:34:56" .
+
+<00001/packingSixPack> a prov:Activity, sosa:Deployment ;
+    rdfs:comment "When Alice packaged Porter bottles into the box, she added an InkBird logger to check that the beer wasn't getting too warm in transit or storage." ;    
+    prov:wasAssociatedWith <alice> ;
+    prov:used <12345/someTH2> ;
+    prov:used <0001/ProductPackaging> ;
+    prov:startedAtTime "2024-02-20T01:35:00Z"^^xsd:dateTime;
+    prov:endedAtTime   "2024-02-20T01:40:00Z"^^xsd:dateTime;   
+    prov:atLocation <acmeBreweryCo> ;
+    prov:generated <10/PO202402/21/0001/acmePorterSixPack> .
+
+# These definitions look redundant; but they represent the specific, physical instantiation of the sensors.
+
+<12345/HumiditySensor> a sensor:IBS-TH2-Plus-H ;
+    rdf:comment "This is the instance of the humidity sensor instance."@en .
+
+<12345/TemperatureSensor> a sensor:IBS-TH2-Plus-T ;
+    rdf:comment "This is the instance of the temperature sensor instance."@en .
+#
+# Sensor activates and records temperature while in the brewery cooler.
+    
+<1a/observation> a sosa:Observation ;
+    rel:own <acmeBreweryCo> ;
+    sosa:observedProperty sosa-env:AmbientTemperature ;
+    sosa:hasUltimateFeatureOfInterest <10/PO202402/21/0001/acmePorterSixPackBeerSample> ; 
+    sosa:madeBySensor <12345/TemperatureSensor>  ;
+    sosa:hasFeatureOfInterest <10/PO202402/21/0001/acmePorterSixPackAirSample> ;
+    sosa:resultTime "2024-02-20T01:35:45Z"^^xsd:dateTime ;
+    sosa:hasResult [
+      a qudt:QuantityValue ;
+      qudt:hasUnit unit:DEG_C ;
+      qudt:value 12.0 ;
+    ] ;
+.
+<1b/observation> rdf:type sosa:Observation ;
+    rel:own <acmeBreweryCo> ;
+    sosa:observedProperty sosa-env:AmbientHumidity;
+    sosa:hasUltimateFeatureOfInterest <0001/ProductPackaging>;
+    sosa:madeBySensor <12345/HumiditySensor>  ;
+    sosa:hasFeatureOfInterest <10/PO202402/21/0001/acmePorterSixPackAirSample> ;
+    sosa:resultTime "2024-02-20T01:35:45Z"^^xsd:dateTime ;
+    sosa:hasResult [
+      a qudt:QuantityValue ;
+      qudt:hasUnit unit:PERCENT ;
+      qudt:value 60 ;
+    ] ;
+.
+<breweryObserver> a prov:Activity ;
+    rdfs:comment "Brewery operating system logging process." ;
+    prov:atLocation <acmeBreweryCo> ;
+    prov:generated <1a/observation> ;
+    prov:generated <1b/observation> ;
+    prov:wasStartedBy <alice> . # She turned it on last time.     
+
+#
+# Product is loaded on the truck
+#
+
+    
+<67a/observation> a sosa:Observation, prov:Entity ;
+    rel:own <acmeBreweryCo> ;
+    rel:own <acmeDelivery> ;
+    sosa:observedProperty <10/PO202402/21/0001/BeerTemperature> ;
+    sosa:hasUltimateFeatureOfInterest <10/PO202402/21/0001/acmePorterSixPackBeerSample> ;
+    sosa:madeBySensor <12345/TemperatureSensor>  ;
+    sosa:hasFeatureOfInterest <10/PO202402/21/0001/acmePorterSixPackAirSample> ;
+    sosa:resultTime "2024-02-22T04:15:05Z"^^xsd:dateTime ;
+    sosa:hasResult  [
+      a qudt:QuantityValue ;
+      qudt:hasUnit unit:DEG_C ;
+      qudt:value 19.0 ;
+    ] ;
+.
+<67b/observation> rdf:type sosa:Observation,prov:Entity ;
+    rel:own <acmeBreweryCo> ;
+    rel:own <acmeDelivery> ;
+    sosa:observedProperty ex:airRelativeHumidity ;
+    sosa:hasUltimateFeatureOfInterest <0001/ProductPackaging>;
+    sosa:madeBySensor <12345/HumiditySensor>  ;
+    sosa:hasFeatureOfInterest <10/PO202402/21/0001/acmePorterSixPackAirSample> ;
+    sosa:resultTime "2024-02-22T04:15:05Z"^^xsd:dateTime ;
+    sosa:hasResult [
+      a qudt:QuantityValue ;
+      qudt:hasUnit unit:PERCENT ;
+      qudt:value 74 ;
+    ] ;
+.
+<123/TruckObserver> a prov:Activity ;
+    rdfs:comment "Truck onboard monitoring system" ;
+    prov:used <acmeTruck> ;
+    prov:generated <67a/observation> ;
+    prov:generated <67b/observation> ;
+    prov:startedAtTime "2024-02-22T04:15:05Z"^^xsd:dateTime ;
+    prov:endedAtTime "2024-02-22T05:55:38Z"^^xsd:dateTime ;
+    prov:wasStartedBy <driver> ;
+    prov:atLocation <gpsLocation> .
+
+# This is the output from the truck's GPS receiver. We only get coordinates
+# from it.
+
+<gpsLocation> a prov:Location, geosparql:Geometry; 
+   geosparql:asWKT "POINT(-79.35553 43.66372)"^^geosparql:wktLiteral .
+
+# 
+# Product is now in display cooler at supermarket. Ownership of product has
+# changed and observation data is now only being recorded / owned by supermarket.
+#
+    
+<98a/observation> rdf:type sosa:Observation,prov:Entity ;
+    rel:own <acmeSupermarket> ;
+    sosa:observedProperty <10/PO202402/21/0001/BeerTemperature> ;
+    sosa:hasUltimateFeatureOfInterest <10/PO202402/21/0001/acmePorterSixPackBeerSample> ;    
+    sosa:madeBySensor <12345/TemperatureSensor>  ;
+    sosa:hasFeatureOfInterest <10/PO202402/21/0001/acmePorterSixPackAirSample> ;
+    sosa:resultTime "2024-02-22T06:00:13Z"^^xsd:dateTime ;
+    sosa:hasResult [
+      a qudt:QuantityValue ;
+      qudt:hasUnit unit:DEG_C ;
+      qudt:value 12 ;
+    ] ;
+.
+<98b/observation> rdf:type sosa:Observation,prov:Entity ;
+    rel:own <acmeSupermarket> ;
+    sosa:observedProperty ex:airRelativeHumidity ;
+    sosa:hasUltimateFeatureOfInterest <0001/ProductPackaging> ;
+    sosa:madeBySensor <12345/HumiditySensor>  ;
+    sosa:hasFeatureOfInterest <10/PO202402/21/0001/acmePorterSixPackAirSample> ;
+    sosa:resultTime "2024-02-22T06:00:13Z"^^xsd:dateTime ;
+    sosa:hasResult [
+      a qudt:QuantityValue ;
+      qudt:hasUnit unit:PERCENT ;
+      qudt:value 55 ;
+    ] ;
+.
+<CoolerMonitoringProcess> a prov:Activity ;
+    rdfs:comment "Smart cooler monitoring system" ;
+    prov:startedAtTime "2024-02-22T06:00:13Z"^^xsd:dateTime ;
+    prov:atLocation <acmeSupermarketCooler> ;
+    prov:generated <98a/observation> ;
+    prov:generated <98b/observation> ;
+    prov:wasStartedBy <acmeSupermarket> .

--- a/src/current-ssn-sosa/examples/sosa-instance-data/IDEAS.ttl
+++ b/src/current-ssn-sosa/examples/sosa-instance-data/IDEAS.ttl
@@ -1,0 +1,61 @@
+@prefix ex: <https://example.org/data/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix qk: <http://qudt.org/vocab/quantitykind/> .
+@prefix qudt: <http://qudt.org/schema/qudt/>.
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
+@prefix sosa: <http://www.w3.org/ns/sosa#> .
+@prefix unit: <http://qudt.org/vocab/unit/>.
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@base <https://example.org/data/IDEA/> .
+
+# Temperature and Humidity at Coal Oil Point Reserve
+
+ ex:COPR a sosa:FeatureOfInterest ;
+   sosa:hasSample ex:COPR_SL ;
+   rdfs:comment "Coal Oil Point Reserve: UC Santa Barbara Natural Reserve System"@en ;
+   rdfs:label "Coal Oil Point Reserve"@en ;
+.
+ex:COPR_SL a sosa:Sample ;
+   rdfs:label "Air around COPR Station"@en ;
+   sosa:isSampleOf ex:COPR ;
+.
+ex:COPR_Station a sosa:Platform ;
+   rdfs:comment "Station at Coal Oil Point Reserve, CA (see http://www.geog.ucsb.edu/ideas/COPR.html for details)"@en ;
+   rdfs:label "Coal Oil Point Reserve Wx Station"@en ;
+   rdfs:seeAlso <http://www.geog.ucsb.edu/ideas/COPR.html> ;
+   sosa:hosts ex:COPR-HMP45C-L ;
+.
+ex:COPR-HMP45C-L a sosa:Platform ;
+   rdfs:label "HMP45C-L Temperature and Relative Humidity Probe at Coal Oil Point, UCSB, CA"@en ;
+   sosa:hosts ex:HUMICAP-H ;
+   sosa:isHostedBy ex:COPR_Station ;
+.
+ex:HUMICAP-H a sosa:Sensor ;
+   rdfs:label "Vaisala HUMICAP H-chip"@en ;
+   sosa:observes ex:RelativeHumidity ;
+   sosa:isHostedBy ex:COPR-HMP45C-L ;
+.
+ex:RelativeHumidity a sosa:Property ;
+   rdfs:comment "Humidity is a measure of the moisture content of air."@en ;
+   rdfs:label "Relative Humidity"@en ;
+   skos:exactMatch qk:RelativeHumidity ;
+.
+ex:MeasuringRelativeHumidity a sosa:ObservingProcedure ;
+   rdfs:comment "Instructions for measuring relative humidity"@en ;
+   rdfs:comment "Relative humidity as averaged over 15min."@en ;
+.
+ex:RH_avg_1_COPR_15min_201706020300PM a sosa:Observation ;
+   rdfs:label "Relative humidity, AVG, 15min, COPR, 06.02.2017, 3:00 PM"@en ;
+   sosa:madeBySensor ex:HUMICAP-H ;
+   sosa:hasFeatureOfInterest ex:COPR_SL ;
+   sosa:hasResult [
+      a qudt:QuantityValue ;
+      qudt:hasUnit unit:PERCENT ;
+      qudt:value 92.5 ;
+   ] ;
+   sosa:resultTime "2017-06-02T15:00:00-07:00"^^xsd:dateTime ;
+   sosa:observedProperty ex:RelativeHumidity ;
+   sosa:usedProcedure ex:MeasuringRelativeHumidity ;
+.

--- a/src/current-ssn-sosa/examples/sosa-instance-data/apartment-134.ttl
+++ b/src/current-ssn-sosa/examples/sosa-instance-data/apartment-134.ttl
@@ -1,0 +1,86 @@
+@prefix ex: <https://example.org/data/> .
+@prefix rdf:  <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix time: <http://www.w3.org/2006/time#> .
+@prefix sosa: <http://www.w3.org/ns/sosa/> .
+@prefix xsd:  <http://www.w3.org/2001/XMLSchema#> .
+@prefix qudt: <http://qudt.org/schema/qudt/> .
+@prefix unit: <http://qudt.org/vocab/unit/> .
+@base <https://example.org/data/apt134/> .
+
+# Electricity consumption of apartment #134
+
+# The electric consumption of apartment #134 on April 15 2017 was 22.4 kWh as 
+# observed by sensor #926. The result was available 12 seconds later
+
+ex:Observation_235714 rdf:type sosa:Observation ;
+  sosa:observedProperty  ex:Apartment_134_electricConsumption ;
+  sosa:madeBySensor ex:sensor_926 ; 
+  sosa:hasResult [
+     rdf:type qudt:QuantityValue ;
+     qudt:value "22.4"^^xsd:decimal ;
+     qudt:hasUnit unit:KiloW-HR ] ;
+  sosa:phenomenonTime [
+    time:hasBeginning [ 
+      time:inXSDDateTimeStamp "2017-04-15T23:59:30+00:00"^^xsd:dateTime ] ;
+    time:hasEnd [ 
+      time:inXSDDateTimeStamp "2017-04-16T00:00:00+00:00"^^xsd:dateTime ] ] ;
+  sosa:resultTime "2017-04-16T00:00:12+00:00"^^xsd:dateTime ;
+.
+# Sensor #926 observes the electric consumption of apartment #134, and we know that 
+# it made some observations
+
+ex:sensor_926 rdf:type sosa:Sensor ;
+  sosa:observes  ex:Apartment_134_electricConsumption ;
+  sosa:madeObservation ex:Observation_235714, ex:Observation_235715, ex:Observation_235716 ;
+.
+# mobile sensor tempSensor #23 observes the temperature in its surroundings, and we know 
+# that it made some observations. 
+
+ex:tempSensor_23 rdf:type sosa:Sensor ;
+  sosa:observes  ex:tempSensor_23_temperature ;
+  sosa:madeObservation ex:tempSensor_23_4572, ex:tempSensor_23_4573, ex:tempSensor_23_4574 ;
+.
+# Sensor #926 observes the electric consumption of apartment #134
+
+ex:sensor_926 rdf:type sosa:Sensor ;
+  sosa:observes  ex:Apartment_134_electricConsumption ;
+.
+# This is equivalent to saying that the electric consumption of apartment #134 is 
+# observed by Sensor #926
+
+ex:Apartment_134_electricConsumption rdf:type sosa:Property ;
+  sosa:isObservedBy ex:sensor_926  ;
+.
+# This is equivalent to saying that these observations have been made by sensor #926
+
+ex:Observation_235714 rdf:type sosa:Observation ;
+  sosa:madeBySensor ex:sensor_926 ;
+.
+ex:Observation_235754 rdf:type sosa:Observation ;
+  sosa:madeBySensor ex:sensor_926 ;
+.
+# Actuation
+# the window opening state is a Property
+# SSN allows to explicitly say that ex:window_104#state is a property of ex:window
+
+ex:window rdf:type sosa:FeatureOfInterest ;
+  sosa:hasProperty ex:window_104_state ;
+.
+ex:window_104_state rdf:type sosa:Property ;
+  sosa:wasActedOnBy ex:actuation_188 ;
+.
+# WindowCloser #987 made actuation #188
+# SSN allows to explicitly say that ex:windowCloser_987 is designed to automatically open and close window #104
+
+ex:windowCloser_987 rdf:type sosa:Actuator ;
+  sosa:madeActuation ex:actuation_188 ;
+  sosa:actsOn ex:window_104_state ;
+.
+# Actuation #188 acted on the state of window #104 and returned 'true'
+
+ex:actuation_188 rdf:type sosa:Actuation ;
+  sosa:actsOnProperty ex:window_104_state ;
+  sosa:madeByActuator ex:windowCloser_987 ; 
+  sosa:hasSimpleResult true ;
+  sosa:resultTime "2017-04-18T17:24:00+02:00"^^xsd:dateTime ;
+.  

--- a/src/current-ssn-sosa/examples/sosa-instance-data/dht22-deployment.ttl
+++ b/src/current-ssn-sosa/examples/sosa-instance-data/dht22-deployment.ttl
@@ -1,0 +1,92 @@
+@prefix ex: <https://example.org/data/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix qk: <http://qudt.org/vocab/quantitykind/> .
+@prefix qudt: <http://qudt.org/schema/qudt/> .
+@prefix rdf:  <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix schema: <http://schema.org/> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix sosa: <http://www.w3.org/ns/sosa/> .
+@prefix time: <http://www.w3.org/2006/time#> .
+@prefix unit: <http://qudt.org/vocab/unit/> .
+@prefix xsd:  <http://www.w3.org/2001/XMLSchema#> .
+@base <https://example.org/data/dht22d/> .
+
+#     This example shows how the conditions (temperature and humidity) in a room can be measured using one or
+#     more sensors.
+#     Each sensor observes the conditions in its immediate vicinity, and the values are then used to characterize
+#     the room. 
+#
+# In Room 145, one of the walls is external in the building, so there is expected to be a temperature gradient
+#     across the room, and there are two sensors on different walls.
+#     In Room 245, there is one sensor on the south wall.
+#     Each of these locations corresponds to a sosa:Sample of the entire room.
+#     The wall also serves as a sosa:Platform on which the sensors are mounted. 
+
+
+ex:Room145 a sosa:FeatureOfInterest ;
+  rdfs:label "Room #145"@en ;
+  sosa:hasSample ex:Room145_east ;
+  sosa:hasSample ex:Room145_south ;
+.
+ex:Room145_east a sosa:Sample , sosa:FeatureOfInterest , sosa:Platform ;
+  rdfs:label "East wall of room #145."@en ;
+  rdfs:comment "This wall hosts PCB Board 1 with DHT22 temperature and humidity sensor #4578."@en ;
+  sosa:hosts ex:PCBBoard1 ;
+.
+ex:Room145_south a sosa:Sample , sosa:FeatureOfInterest , sosa:Platform ;
+  rdfs:label "South wall of room #145."@en ;
+  rdfs:comment "This wall hosts PCB Board 2 with DHT22 temperature and humidity sensor #4579."@en ;
+  sosa:hosts ex:PCBBoard2 ;
+.
+ex:Room245 a sosa:FeatureOfInterest ;
+  rdfs:label "Room #245"@en ;
+  sosa:hasProperty qk:Temperature , qk:RelativeHumidity ;
+  sosa:hasSample ex:Room245_south ;
+.
+ex:Room245_south a sosa:Sample , sosa:FeatureOfInterest , sosa:Platform ;
+  rdfs:label "South wall of room #245."@en ;
+  sosa:hosts ex:PCBBoard3 ;
+.
+ex:PCBBoard1 a sosa:System , sosa:Platform ;
+  rdfs:label "PCB Board 1"@en ;
+  rdfs:comment "PCB Board 1 hosts DHT22 temperature and humidity sensor #4578 permanently, one can say it has it as one of its subsystems."@en ;
+  sosa:hosts ex:DHT22_4578 ;
+  sosa:hasSubSystem ex:DHT22_4578 ;
+.
+ex:DHT22_4578 a sosa:System ;
+  rdfs:label "DHT22 sensor #4578"@en ;
+  sosa:isHostedBy ex:PCBBoard1 ;
+.
+ex:PCBBoard2 a sosa:System , sosa:Platform ;
+  rdfs:label "PCB Board 2"@en ;
+  rdfs:comment "PCB Board 2 hosts DHT22 temperature and humidity sensor #4579 permanently, one can say it has it as one of its subsystems."@en ;
+  sosa:hosts ex:DHT22_4578 ;
+  sosa:hasSubSystem ex:DHT22_4578 ;
+.
+ex:DHT22_4579 a sosa:System ;
+  rdfs:label "DHT22 sensor #4579."@en ;
+  sosa:isHostedBy ex:PCBBoard2 ;
+.
+ex:PCBBoard3 a sosa:System , sosa:Platform ;
+  rdfs:label "PCB Board 3"@en ;
+  rdfs:comment "PCB Board 3 hosts DHT22 temperature and humidity sensor #4580 permanently, one can say it has it as one of its subsystems."@en ;
+  sosa:hosts ex:DHT22_4578 ;
+  sosa:hasSubSystem ex:DHT22_4578 ;
+.
+ex:DHT22_4580 a sosa:System ;
+  rdfs:label "DHT22 sensor #4580."@en ;
+  sosa:isHostedBy ex:PCBBoard3 ;
+.
+ex:Room245Deployment a sosa:Deployment ;
+  rdfs:comment "Deployment of PCB Board 3 on the south wall of room #245 for the purpose of observing the temperature and humidity of room #245."@en ;
+  sosa:deployedOnPlatform ex:Room245_south ;
+  sosa:deployedSystem ex:PCBBoard3 ;
+  sosa:forProperty qk:Temperature , qk:RelativeHumidity ;
+.
+ex:Room145Deployment a sosa:Deployment ;
+  rdfs:comment "Deployment of PCB Board 1 and 2 on the east and south wall of room #145, respectively, for the purpose of observing the temperature and humidity of room #145."@en ;
+  sosa:deployedOnPlatform ex:Room245_east , ex:Room245_south ;
+  sosa:deployedSystem ex:PCBBoard1 , ex:PCBBoard2 ;
+  sosa:forProperty qk:Temperature , qk:RelativeHumidity ;
+.

--- a/src/current-ssn-sosa/examples/sosa-instance-data/dht22.ttl
+++ b/src/current-ssn-sosa/examples/sosa-instance-data/dht22.ttl
@@ -1,0 +1,341 @@
+@prefix ex:     <https://example.org/data/> .
+@prefix et:     <http://vocabs.lter-europe.net/EnvThes/> .
+@prefix owl:    <http://www.w3.org/2002/07/owl#> .
+@prefix iop:    <https://w3id.org/iadopt/ont/1.1.0> .
+@prefix uom:    <http://www.ontology-of-units-of-measure.org/resource/om-2/> .
+@prefix qudt:   <http://qudt.org/schema/qudt/> .
+@prefix qk:     <http://qudt.org/vocab/quantitykind/> .
+@prefix rdf:    <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs:   <http://www.w3.org/2000/01/rdf-schema#>.
+@prefix schema: <http://schema.org/>.
+@prefix skos:   <http://www.w3.org/2004/02/skos/core#> .
+@prefix sosa:   <http://www.w3.org/ns/sosa/> .
+@prefix time:   <http://www.w3.org/2006/time#>.
+@prefix unit:   <http://qudt.org/vocab/unit/> .
+@prefix xsd:    <http://www.w3.org/2001/XMLSchema#> .
+@prefix dct:    <http://purl.org/dc/terms/> .
+@prefix prof:   <http://www.w3.org/ns/dx/prof/> .
+@prefix role:   <http://www.w3.org/ns/dx/prof/role/> .
+@base <https://example.org/data/dht22/> .
+
+# Complex sensor capabilities -- DHT22
+
+ex:DHT22_Procedure
+    a              sosa:ObservingProcedure ;
+    sosa:hasOutput ex:DHT22_output ;
+.
+
+ex:DHT22_output
+    # specify the encoding format - which is not necessary constrained by the model for the content
+    dct:format     <https://w3id.org/mediatype/text/turtle> ;
+    rdfs:comment   "The output is a RDF Graph that describes both the temperature and the humidity. It can be validated by a SHACL shapes graph."@en ;
+    dct:conformsTo ex:myProfile
+.
+
+
+
+ex:myProfile
+    a                prof:Profile ;
+    prof:hasResource [ a                prof:ResourceDescriptor ;
+                       # it's in Turtle format
+                       dct:format       <https://w3id.org/mediatype/text/turtle> ;
+                       # it conforms to SHACL, here refered to by its namespace URI as a Profile
+                       dct:conformsTo   <https://www.w3.org/TR/shacl/> ;
+                       # this profile resource plays the role of "Validation" as well as defining a "schema"
+                       prof:hasRole     role:validation , role:schema ;
+                       # this profile resource's actual file
+                       prof:hasArtifact <http://example.org/profile/x/resource/validator.ttl> ] ;
+.
+
+
+# System objects; a DHT22 sensor instance, serial number 4578
+ex:DHT22_4578
+    a                           sosa:System ;
+    rdfs:comment                "DHT22 sensor #4578 contains a humidity and a temperature sensor."@en ;
+    rdfs:seeAlso                <https://www.sparkfun.com/datasheets/Sensors/Temperature/DHT22.pdf> ;
+    sosa:hasSubSystem           ex:DHT22_4578_TemperatureSensor, ex:DHT22_4578_HumiditySensor ;
+    sosa:hasOperatingConditions ex:DHT22_4578_TemperatureSensorNormalOperatingConditions,
+                                ex:DHT22_4578_HumiditySensorNormalOperatingConditions ;
+    ex:serialNumber             "4578" ;
+.
+
+ex:DHT22_4578_TemperatureSensor
+    a                           sosa:Sensor, sosa:System ;
+    rdfs:comment                "The embedded temperature sensor, a specific instance of temperature sensor."@en ;
+    sosa:hasSystemCapability    ex:DHT22_4578_TemperatureSensorCapabilities ;
+    sosa:hasOperatingConditions ex:DHT22_4578_TemperatureSensorNormalOperatingConditions ;
+    sosa:implements             ex:DHT22_Procedure ;
+.
+
+ex:DHT22_4578_HumiditySensor
+    a                           sosa:Sensor, sosa:System ;
+    rdfs:comment                "The embedded humidity sensor, a specific instance of humidity sensor."@en ;
+    sosa:hasSystemCapability    ex:DHT22_4578_HumiditySensorCapabilities ;
+    sosa:hasOperatingConditions ex:DHT22_4578_HumiditySensorNormalOperatingConditions ;
+    sosa:implements             ex:DHT22_Procedure ;
+.
+
+# These are operating conditions under which the sensor can properly function. These are seperate from capabilites in that not
+# all of the condition observations may be sensed by the sensor itself, e.g., supply voltage. 
+
+ex:DHT22_4578_HumiditySensorNormalOperatingConditions
+    a              sosa:ObservationCollection ;
+    rdf:type       sosa:NormalOperatingConditions ;
+    rdfs:comment   "The conditions in which the DHT22 system is expected to operate."@en ;
+    sosa:hasMember ex:minimumOperatingTemperature, ex:maximumOperatingTemperature, ex:minimumOperatingHumidity,
+                   ex:maximumOperatingHumidity, ex:mimimalOperatingInputVoltage, ex:maximumOperatingInputVoltage,
+                   ex:nominalOperatingInputVoltage .
+
+ex:DHT22_4578_TemperatureSensorNormalOperatingConditions
+    a              sosa:ObservationCollection ;
+    rdf:type       sosa:NormalOperatingConditions ;
+    rdfs:comment   "The conditions in which the DHT22 system is expected to operate."@en ;
+    sosa:hasMember ex:minimumOperatingTemperature, ex:maximumOperatingTemperature, ex:mimimalOperatingInputVoltage,
+                   ex:maximumOperatingInputVoltage, ex:nominalOperatingInputVoltage .
+
+# The minimum / maxinum operating temperatures in this case are the temperature of the System itself
+# as heat transfer from the mechanical mounting will directly impact the sensor rather than the
+# ambient air. 
+
+ex:minimumOperatingTemperature
+    a                         sosa:Observation ;
+    sosa:hasFeatureOfInterest ex:DHT22_4578 ;
+    sosa:observedProperty     ex:minimumSensorTemperatureLimit ;
+    sosa:hasSimpleResult      "-40.0"^^xsd:decimal ;
+    qudt:hasUnit              unit:DEG_C .
+
+ex:minimumSensorTemperatureLimit
+    a                          iop:Variable, sosa:Property ;
+    iop:hasStatisticalModifier uom:minimum ;
+    iop:hasObjectOfInterest    ex:DHT22_4578 ;
+    iop:hasProperty            qk:Temperature .
+
+ex:maximumOperatingTemperature
+    a                         sosa:Observation ;
+    sosa:hasFeatureOfInterest ex:DHT22_4578 ;
+    sosa:observedProperty     ex:maximumSensorTemperatureLimit ;
+    sosa:hasResult            [ qudt:value   80.0 ;
+                                qudt:hasUnit unit:DEG_C ] .
+
+ex:maximumSensorTemperatureLimit
+    a                          iop:Variable, sosa:Property ;
+    iop:hasStatisticalModifier uom:maximum ;
+    iop:hasObjectOfInterest    ex:DHT22_4578 ;
+    iop:hasProperty            qk:Temperature .
+
+# Unlike temperature, the operating condition of the System are affected by the relative humidity of the air around the sensor. 
+# Percentage is not a unit, however this is present in QUDT and used here as a convinience for display purposes.
+
+
+ex:minimumOperatingHumidity
+    a                         sosa:Observation ;
+    sosa:hasFeatureOfInterest ex:DHT22_4578 ;
+    sosa:observedProperty     ex:minSensorEnvironmentHumidityLimit ;
+    sosa:hasResult            [ qudt:value   0.0 ;
+                                qudt:hasUnit unit:PERCENT ] .
+
+ex:minSensorEnvironmentHumidityLimit
+    a                          iop:Variable, sosa:Property ;
+    iop:hasStatisticalModifier uom:minimum ;
+    iop:hasObjectOfInterest    ex:airAround_DHT22_4578 ;
+    iop:hasProperty            qk:RelativeHumidity .
+
+ex:maximumOperatingHumidity
+    a                         sosa:Observation ;
+    sosa:hasFeatureOfInterest ex:DHT22_4578 ;
+    sosa:observedProperty     ex:maxSensorEnvironmentHumidityLimit ;
+    sosa:hasResult            [ qudt:value   100.0 ;
+                                qudt:hasUnit unit:PERCENT ] .
+
+ex:maxSensorEnvironmentHumidityLimit
+    a                          iop:Variable, sosa:Property ;
+    iop:hasStatisticalModifier uom:maximum ;
+    iop:hasObjectOfInterest    ex:airAround_DHT22_4578 ;
+    iop:hasProperty            qk:RelativeHumidity .
+
+ex:airAround_DHT22_4578
+    skos:broader et:23 ;
+    rdfs:label   "The air immediatly around the DHT22 sensor."
+.
+
+et:23
+    rdfs:label "air" .
+
+#
+#
+ex:DHT22_4578_inputVoltage
+    a            sosa:FeatureOfInterest ;
+    rdfs:comment "The DC voltage being supplied to the sensor"@en ; .
+
+ex:mimimalOperatingInputVoltage
+    a                         sosa:Observation ;
+    sosa:hasFeatureOfInterest ex:DHT22_4578_inputVoltage ;
+    sosa:observedProperty     ex:mimOperatingInputVoltageRestriction ;
+    sosa:hasSimpleResult      3.3 ;
+    qudt:hasUnit              unit:V .
+
+ex:mimOperatingInputVoltageRestriction
+    a                          iop:Variable, sosa:Property ;
+    iop:hasStatisticalModifier uom:minimum ;
+    iop:hasObjectOfInterest    ex:DHT22_4578 ;
+    iop:hasProperty            qk:Voltage .
+
+ex:maximumOperatingInputVoltage
+    a                         sosa:Observation ;
+    sosa:hasFeatureOfInterest ex:DHT22_4578_inputVoltage ;
+    sosa:observedProperty     ex:maxOperatingInputVoltageRestriction ;
+    sosa:hasSimpleResult      6.0 ;
+    qudt:hasUnit              unit:V .
+
+ex:maxOperatingInputVoltageRestriction
+    a                          iop:Variable, sosa:Property ;
+    iop:hasStatisticalModifier uom:maximum ;
+    iop:hasObjectOfInterest    ex:DHT22_4578 ;
+    iop:hasProperty            qk:Voltage .
+
+ex:nominalOperatingInputVoltage
+    a                         sosa:Observation ;
+    sosa:hasFeatureOfInterest ex:DHT22_4578_inputVoltage ;
+    sosa:observedProperty     ex:nominalOperatingInputVoltageRestriction ;
+    sosa:hasSimpleResult      5.0 ;
+    qudt:hasUnit              unit:V .
+
+# A complaint may be that the time period of the averaging period is unspecified; 
+ex:nominalOperatingInputVoltageRestriction
+    a                          iop:Variable, sosa:Property ;
+    iop:hasStatisticalModifier uom:average ;
+    iop:hasObjectOfInterest    ex:DHT22_4578 ;
+    iop:hasProperty            qk:Voltage .
+
+#
+# These are the system capabilities
+#
+
+ex:DHT22_4578_TemperatureSensorCapabilities
+    a                       sosa:ObservationCollection ;
+    sosa:hasValidityContext ex:DHT22_4578_TemperatureSensorNormalOperatingConditions ;
+    sosa:hasMember          ex:DHT22_4578_minimumMeasureableTemperature, ex:DHT22_4578_maximumMeasureableTemperature,
+                            ex:DHT22_4578_TemperatureMeasurementAccuracy,
+                            ex:DHT22_4578_TemperatureMeasurementSensitivity,
+                            ex:DHT22_4578_TemperatureMeasurementFrequency .
+
+ex:DHT22_4578_HumiditySensorCapabilities
+    a                       sosa:ObservationCollection ;
+    sosa:hasValidityContext ex:DHT22_4578_HumiditySensorNormalOperatingConditions ;
+    sosa:hasMember          ex:DHT22_4578_minimumMeasureableRelativeHumidity,
+                            ex:DHT22_4578_maximumMeasureableRelativeHumidity, ex:DHT22_4578_RelativeHumidityFrequency .
+
+ex:DHT22_4578_minimumMeasureableTemperature
+    a                         sosa:Observation ;
+    sosa:hasFeatureOfInterest ex:DHT22_4578_TemperatureSensor ;
+    sosa:observedProperty     ex:DHT22_4578_minimumMeasureableTemperatureLimit ;
+    sosa:hasSimpleResult      "-40.0"^^xsd:decimal ;
+    qudt:hasUnit              unit:DEG_C .
+
+ex:DHT22_4578_minimumMeasureableTemperatureLimit
+    a                          iop:Variable, sosa:Property ;
+    iop:hasStatisticalModifier uom:minimum ;
+    iop:hasObjectOfInterest    ex:airAround_DHT22_4578 ;
+    iop:hasProperty            qk:Temperature .
+
+ex:DHT22_4578_maximumMeasureableTemperature
+    a                         sosa:Observation ;
+    sosa:hasFeatureOfInterest ex:DHT22_4578_TemperatureSensor ;
+    sosa:observedProperty     ex:DHT22_4578_maximumMeasureableTemperatureLimit ;
+    sosa:hasResult            [ qudt:value   80.0 ;
+                                qudt:hasUnit unit:DEG_C ] .
+
+ex:DHT22_4578_maximumMeasureableTemperatureLimit
+    a                          iop:Variable, sosa:Property ;
+    iop:hasStatisticalModifier uom:maximum ;
+    iop:hasObjectOfInterest    ex:airAround_DHT22_4578 ;
+    iop:hasProperty            qk:Temperature .
+
+ex:DHT22_4578_TemperatureMeasurementAccuracy
+    a                         sosa:Observation ;
+    sosa:hasFeatureOfInterest ex:DHT22_4578_TemperatureSensor ;
+    sosa:observedProperty     ex:Accuracy ;
+    sosa:hasResult            [ qudt:value   0.5 ;
+                                qudt:hasUnit unit:DEG_C ] .
+
+
+ex:DHT22_4578_TemperatureMeasurementSensitivity
+    a                         sosa:Observation ;
+    sosa:hasFeatureOfInterest ex:DHT22_4578_TemperatureSensor ;
+    sosa:observedProperty     ex:Sensitivity, ex:Resolution ;
+    sosa:hasResult            [ qudt:value   0.1 ;
+                                qudt:hasUnit unit:DEG_C ] .
+
+ex:DHT22_4578_TemperatureMeasurementFrequency
+    a                         sosa:Observation ;
+    rdfs:comment              "The smallest possible time between one observation and the next is 2 s on average."@en ;
+    sosa:hasFeatureOfInterest ex:DHT22_4578_TemperatureSensor ;
+    sosa:observedProperty     ex:DHT22_4578_TemperatureMeasurementFrequencyLimit ;
+    sosa:hasResult            [ qudt:value   2.0 ;
+                                qudt:hasUnit unit:SEC ] .
+
+# TODO Likely wrong
+
+ex:DHT22_4578_TemperatureMeasurementFrequencyLimit
+    a                          iop:Variable, sosa:Property ;
+    iop:hasStatisticalModifier uom:average ;
+    iop:hasObjectOfInterest    ex:airAround_DHT22_4578 ;
+    iop:hasProperty            qk:Period .
+
+# These are very close to the system conditions and the same limits can be reused.
+ex:DHT22_4578_minimumMeasureableRelativeHumidity
+    a                         sosa:Observation ;
+    sosa:hasFeatureOfInterest ex:DHT22_4578_HumiditySensor ;
+    sosa:observedProperty     ex:minSensorEnvironmentHumidityLimit ;
+    sosa:hasResult            [ qudt:value   0.0 ;
+                                qudt:hasUnit unit:PERCENT ] .
+
+ex:DHT22_4578_maximumMeasureableRelativeHumidity
+    a                         sosa:Observation ;
+    sosa:hasFeatureOfInterest ex:DHT22_4578_HumiditySensor ;
+    sosa:observedProperty     ex:maxSensorEnvironmentHumidityLimit ;
+    sosa:hasResult            [ qudt:value   100.0 ;
+                                qudt:hasUnit unit:PERCENT ] .
+
+ex:DHT22_4578_RelativeHumidityFrequency
+    a                         sosa:Observation ;
+    rdfs:comment              "The smallest possible time between one observation and the next is 2 s on average."@en ;
+    sosa:hasFeatureOfInterest ex:DHT22_4578_HumiditySensor ;
+    sosa:observedProperty     ex:DHT22_4578_RelativeHumidityFrequencyLimit ;
+    sosa:hasResult            [ qudt:value   2.0 ;
+                                qudt:hasUnit unit:SEC ] .
+
+ex:DHT22_4578_RelativeHumidityFrequencyLimit
+    a                          iop:Variable, sosa:Property ;
+    iop:hasStatisticalModifier uom:average ;
+    iop:hasObjectOfInterest    ex:DHT22_4578_HumiditySensor ;
+    iop:hasProperty            qk:Period .
+
+# Some results
+ex:observation_1087
+    rdf:type              sosa:Observation ;
+    sosa:observedProperty et:23 ;
+    sosa:madeBySensor     ex:DHT22_4578_TemperatureSensor ;
+    sosa:usedProcedure    ex:DHT22_Procedure ;
+    sosa:resultQuality    ex:observation_1087_quality ;
+    sosa:hasResult        [ qudt:hasUnit unit:DEG_C ;
+                            qudt:value   21.4 ] ;
+.
+
+# use some other ontology to further qualify this quality
+
+ex:observation_1087_quality
+    ex:evaluatedBy     ex:Tom ;
+    ex:confidenceValue "6"^^xsd:integer ;
+    rdfs:comment       """Tom gave a confidence value of 6 out of 10 on this observation."""@en ;
+.
+# use some quantity ontology
+
+@prefix qudt: <http://qudt.org/schema/qudt/> .
+@prefix unit: <http://qudt.org/vocab/unit/> .
+
+ex:observation_1087_quality
+    rdf:type           qudt:Quantity ;
+    qudt:quantityValue [ rdf:type     qudt:QuantityValue ;
+                         qudt:value   98.4 ;
+                         qudt:hasUnit unit:PERCENT ] .

--- a/src/current-ssn-sosa/examples/sosa-instance-data/ip68.ttl
+++ b/src/current-ssn-sosa/examples/sosa-instance-data/ip68.ttl
@@ -1,0 +1,120 @@
+@prefix ex: <https://example.org/data/> .
+@prefix geo: <http://www.opengis.net/ont/geosparql#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix qk: <http://qudt.org/vocab/quantitykind/> .
+@prefix qudt: <http://qudt.org/schema/qudt/> .
+@prefix rdf:  <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
+@prefix schema: <http://schema.org/>.
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix sosa: <http://www.w3.org/ns/sosa/> .
+@prefix time: <http://www.w3.org/2006/time#>.
+@prefix unit: <http://qudt.org/vocab/unit/> .
+@prefix xsd:  <http://www.w3.org/2001/XMLSchema#> .
+@prefix gr: <http://purl.org/goodrelations/v1#> .
+@prefix prov: <http://www.w3.org/ns/prov#>.
+@prefix seas: <https://w3id.org/seas/>.
+@prefix sosa-cap: <http://www.w3.org/ns/sosa/system-capability-properties#> .
+@prefix sosa-env: <http://www.w3.org/ns/sosa/system-environment-properties#> .
+@base <https://data.grandlyon.com/> .
+
+# This example describes the IP68 Smart Sensor that and some of its capabilities and operating ranges.
+# A specific IP68 Smart Sensor observes the air temperature, and its own battery state.
+
+ex:Organization_1 a prov:Organization ;
+    skos:exactMatch <http://dbpedia.org/page/Metropolis_of_Lyon> ;
+.
+ex:Air a sosa:FeatureOfInterest ;
+  rdfs:label "The air."@en ;
+  skos:exactMatch <https://www.wikidata.org/wiki/Q3230> ;
+. 
+ex:IP68_Outdoor_Temperature_Sensor a owl:Class , gr:ProductOrServiceModel ;
+  rdfs:label "IP68 Outdoor Temperature Sensor"@en ;
+  rdfs:subClassOf [
+    owl:onProperty sosa:hasOperatingConditions ;
+    owl:hasValue ex:IP68_Outdoor_Temperature_Sensor_operatingRange ] ;
+  rdfs:subClassOf [
+    owl:onProperty sosa:hasSystemCapability ;
+    owl:hasValue ex:IP68_Outdoor_Temperature_Sensor_systemCapability ] ;
+.
+ex:Sensor_SL-T-P1_battery a sosa:Battery;
+ rdfs:label "The battery powering the IP68 Outdoor Temperature Sensor"@en .
+
+ex:IP68_Outdoor_Temperature_Sensor_operatingRange a sosa:ObservationCollection , sosa:NormalOperatingConditions ;
+    rdfs:comment "An environment temperature range of -20 to 70 Celsius."@en ;
+    sosa:hasMember [
+      sosa:observedProperty sosa-env:MinAmbientTemperature ;
+      sosa:hasResult [ 
+        qudt:value -20.0 ;
+        qudt:hasUnit unit:DEG_C ;
+      ] ;
+    ] , [
+      sosa:observedProperty sosa-env:MaxAmbientTemperature ;
+      sosa:hasResult [ 
+        qudt:value 70.0 ;
+        qudt:hasUnit unit:DEG_C ;
+      ] ;
+    ]
+.
+ex:IP68_Outdoor_Temperature_Sensor_systemCapability a sosa:ObservationCollection ;
+  rdfs:comment "The sensor capability in normal operating conditions."@en ;
+  sosa:hasMember [
+    sosa:observedProperty sosa-cap:RFSensitivity ;
+    sosa:hasResult [ qudt:value -137.0 ; qudt:hasUnit unit:DeciB-MilliW ] ;
+  ] , [
+    sosa:observedProperty sosa-cap:TemperatureAccuracy ;
+    sosa:hasResult [ qudt:value 0.2 ; qudt:hasUnit unit:DEG_C ] ;
+  ] , [ 
+    sosa:observedProperty sosa-cap:TemperatureResolution ;
+    sosa:hasResult [ qudt:value 0.0625 ; qudt:hasUnit unit:DEG_C ] ;
+  ] , [ 
+    sosa:observedProperty sosa-cap:BatteryResolution ;
+    sosa:hasResult [ qudt:value 3.937e-3 ; qudt:hasUnit unit:PERCENT ] ;
+  ] ;
+  sosa:hasValidityContext ex:IP68_Outdoor_Temperature_Sensor_operatingRange ;
+.
+ex:Air_4575_485 a sosa:Sample ;
+  rdfs:label "The air at lat 45.75 and long 4.85."@en ;
+  sosa:isSampleOf ex:Air ;
+  geo:hasGeometry [ 
+    a geo:Point ;
+    geo:asWKT "POINT (4.85 45.75)"^^geo:WktLiteral ;
+  ] ;
+  sosa:hasProperty qk:Temperature ;
+.
+ex:Sensor_SL-T-P1 a gr:ProductOrService, sosa:Sensor , seas:LoRaCommunicationDevice , ex:IP68_Outdoor_Temperature_Sensor ;
+    gr:hasBrand [ a gr:Brand ; gr:name "Sensing Labs"@en ] ;
+    geo:alt 100.0 ;
+    geo:lat 45.75 ;
+    geo:lon 4.85 ;
+    sosa:implements ex:IP68_Outdoor_Temperature_Sensor_temperatureSensingProcedure ;
+    sosa:implements ex:IP68_Outdoor_Temperature_Sensor_batterySensingProcedure ;
+    sosa:observes ex:Sensor_SL-T-P1_battery ;
+    sosa:observes qk:Temperature ;
+.
+ex:Deployment_SL-T-P1_2017-06-06 a sosa:Deployment ;
+  sosa:deployedSystem ex:Sensor_SL-T-P1 ;
+  sosa:startTime "2017-06-06"^^xsd:date ;
+  prov:wasAssociatedWith ex:Organization_1 ;
+  sosa:deployedOnPlatform ex:Tree_1 ;
+.
+ex:Observation_5872357_temperature a sosa:Observation ;
+    sosa:hasResult [
+      qudt:hasUnit unit:DEG_C ;
+      qudt:value 64.5244681928429 ;
+    ] ;
+    sosa:madeBySensor ex:Sensor_SL-T-P1 ;
+    sosa:hasFeatureOfInterest ex:Air_4575_485 ;
+    sosa:observedProperty qk:Temperature ;
+    sosa:resultTime "2017-06-20T21:49:18+00:00"^^xsd:dateTime ;
+.
+ex:Observation_5872357_battery a sosa:Observation ;
+    sosa:hasResult [
+      qudt:hasUnit unit:PERCENT ;
+      qudt:value 73.2 ;
+    ] ;
+    sosa:madeBySensor ex:Sensor_SL-T-P1 ;
+    sosa:hasFeatureOfInterest ex:Sensor_SL-T-P1 ;
+    sosa:observedProperty ex:Sensor_SL-T-P1_battery ;
+    sosa:resultTime "2017-06-20T21:49:18+00:00"^^xsd:dateTime ;
+.

--- a/src/current-ssn-sosa/examples/sosa-instance-data/iphone_barometer-sosa.ttl
+++ b/src/current-ssn-sosa/examples/sosa-instance-data/iphone_barometer-sosa.ttl
@@ -1,0 +1,65 @@
+@prefix ex: <https://example.org/data/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix qudt: <http://qudt.org/schema/qudt/> .
+@prefix qk: <http://qudt.org/vocab/quantitykind/> .
+@prefix rdf:  <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
+@prefix sosa: <http://www.w3.org/ns/sosa/> .
+@prefix unit: <http://qudt.org/vocab/unit/> .
+@prefix xsd:  <http://www.w3.org/2001/XMLSchema#> .
+@base <https://example.org/data/iphone_barometer/> .
+
+# iPhone Barometer
+
+ex:iphone_barometer-sosa 
+  a owl:Ontology ;
+  rdfs:comment "The barometric readings from a Bosch Sensortec BMP282 sensor in an Apple IPhone 7 observed on June 6 2017 using only the SOSA core."@en ;
+.
+# The barometric readings from a Bosch Sensortec BMP282 sensor in an Apple IPhone 7 observed on June 6 2017
+# using only the SOSA core
+
+ex:EarthAtmosphere 
+  a sosa:FeatureOfInterest ;
+  rdfs:label "Atmosphere of Earth"@en ;
+.
+# An iPhone 7 as the Platform that hosts several sensors, among others the Bosch Sensortec BMP282 atmospheric pressure sensor
+
+ex:iphone7_35-207306-844818-0 
+  a sosa:Platform ;
+  rdfs:label "IPhone 7 - IMEI 35-207306-844818-0"@en ;
+  rdfs:comment "IPhone 7 - IMEI 35-207306-844818-0 - John Doe"@en ;
+  sosa:hosts ex:sensor_35-207306-844818-0_BMP282 ;
+.
+ex:sensor_35-207306-844818-0_BMP282 
+  a sosa:Sensor ;
+  rdfs:label "Bosch Sensortec BMP282"@en ;
+  sosa:observes qk:AtmosphericPressure ;
+.
+# An observation made by the Bosch Sensortec BMP282 atmospheric pressure sensor
+
+ex:Observation_346344 
+  a sosa:Observation ;
+  sosa:observedProperty qk:AtmosphericPressure ;
+  sosa:hasFeatureOfInterest ex:EarthAtmosphere ;
+  sosa:madeBySensor ex:sensor_35-207306-844818-0_BMP282 ;
+  sosa:hasResult [
+      a qudt:QuantityValue ;
+      qudt:hasUnit unit:HectoPA ;
+      qudt:value 1021.45 ;
+  ] ;
+  sosa:resultTime "2017-06-06T12:36:12+00:00"^^xsd:dateTime ;
+.
+# Another observation made a second later by the Bosch Sensortec BMP282 atmospheric pressure sensor
+
+<Observation/346345> 
+  a sosa:Observation ;
+  sosa:observedProperty qk:AtmosphericPressure ;
+  sosa:hasFeatureOfInterest ex:EarthAtmosphere ;
+  sosa:madeBySensor ex:sensor_35-207306-844818-0_BMP282 ;
+  sosa:hasResult [
+    a qudt:QuantityValue ;
+    qudt:value "101936"^^xsd:decimal ;
+    qudt:hasUnit unit:PA 
+  ] ;
+  sosa:resultTime "2017-06-06T12:36:13+00:00"^^xsd:dateTime ;
+.

--- a/src/current-ssn-sosa/examples/sosa-instance-data/seismograph.ttl
+++ b/src/current-ssn-sosa/examples/sosa-instance-data/seismograph.ttl
@@ -1,0 +1,49 @@
+@prefix ex: <https://example.org/data/> .
+@prefix geo: <http://www.opengis.net/ont/geosparql#> .
+@prefix qk: <http://qudt.org/vocab/quantitykind/> .
+@prefix qudt: <http://qudt.org/schema/qudt/> .
+@prefix rdf:  <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix sosa: <http://www.w3.org/ns/sosa/> .
+@prefix unit: <http://qudt.org/vocab/unit/> .
+@prefix xsd:  <http://www.w3.org/2001/XMLSchema#> .
+@base <https://example.org/data/seis/> .
+
+# Seismograph measuring ground displacement speed
+#
+# Observation #358 of seismograph VCAB DP1 BP 40 (Vineyard Canyon, Parkfield, Ca) measured
+# a earth displacement speed of 0.000500 cm/sec at 8:23 am on April 18, 2017, Pacific
+# Daylight Time
+
+ex:VCAB-DP1-BP-40 a sosa:Sensor ;
+  rdfs:label "seismograph VCAB DP1 BP 40 (Vineyard Canyon, Parkfield, Ca)"@en ;
+  rdfs:seeAlso <https://earthquake.usgs.gov/monitoring/seismograms/153> ;
+  sosa:observes ex:groundDisplacementSpeed ;
+.
+ex:VCAB-DP1-BP-40_location a sosa:Sample ;
+  rdfs:label "location of VCAB-DP1-BP-40"@en ;
+  geo:hasGeometry [ 
+    a geo:Point ;
+    geo:asWKT "POINT (-120.6195831 35.8648067)"^^geo:WktLiteral ;
+  ] ;
+  sosa:isSampleOf ex:Earth ;
+.
+ex:Earth a sosa:FeatureOfInterest ;
+  skos:exactMatch <https://www.wikidata.org/wiki/Q2> ;
+  rdfs:label "Earth" ;
+.
+ex:groundDisplacementSpeed a sosa:Property ;
+  rdfs:label "ground displacement speed"@en ;
+  skos:broader qk:Speed ;
+.
+ex:VCAB-DP1-BP-40_t2017-04-18T08%3A23%3A00-07%3A00 a sosa:Observation ;
+  sosa:madeBySensor ex:VCAB-DP1-BP-40 ; 
+  sosa:hasFeatureOfInterest ex:VCAB-DP1-BP-40_location ;
+  sosa:observedProperty ex:groundDisplacementSpeed ;
+  sosa:hasResult [
+     rdf:type qudt:QuantityValue ;
+     qudt:value "5e-4"^^xsd:double ;
+     qudt:hasUnit unit:CentiM-PER-SEC ] ;
+  sosa:resultTime "2017-04-18T08:23:00-07:00"^^xsd:dateTime ;
+.

--- a/src/current-ssn-sosa/examples/sosa-instance-data/spinning-cups.ttl
+++ b/src/current-ssn-sosa/examples/sosa-instance-data/spinning-cups.ttl
@@ -1,0 +1,66 @@
+@prefix ex: <https://example.org/data/> .
+@prefix qk: <http://qudt.org/vocab/quantitykind/> .
+@prefix qudt: <http://qudt.org/schema/qudt/>.
+@prefix rdf:  <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix sosa: <http://www.w3.org/ns/sosa/> .
+@prefix time: <http://www.w3.org/2006/time#>.
+@prefix unit: <http://qudt.org/vocab/unit/>.
+@prefix xsd:  <http://www.w3.org/2001/XMLSchema#> .
+@base <https://example.org/data/wind/> .
+
+# Wind sensor spinning cups
+#
+# movements of spinning cups on wind sensor #14 serves as proxies for the wind speed
+# at the location of the wind sensor
+
+ex:windSensor_14 rdf:type sosa:Sensor ;
+  sosa:observes ex:windSpeed ;
+.
+ex:windSpeed a sosa:Property ;
+  rdfs:label "wind speed"@en ;
+  skos:broader qk:Speed ;
+.
+ex:location_4687 a sosa:Platform ;
+  sosa:hosts ex:windSensor_14 ;
+.
+# observation #147 was originated by the movement of the spinning cups of sensor #14
+
+ex:observation_147 rdf:type sosa:Observation ;
+  sosa:observedProperty ex:windSpeed ;
+  sosa:madeBySensor ex:windSensor_14 ;
+  sosa:wasOriginatedBy ex:observation_147_spinningCupsMovement ;
+  sosa:resultTime "2017-04-12T12:00:00+00:00"^^xsd:dateTime ;
+  sosa:hasResult [
+      a qudt:QuantityValue ;
+      qudt:hasUnit unit:KiloM-PER-HR ;
+      qudt:value 47.0 ;
+  ] ;
+.
+# wind sensor #14 detected some movement of spinning cups, from which originated the
+# observations #147 and #148
+
+ex:windSensor_14 rdf:type sosa:Sensor ;
+  sosa:madeObservation ex:observation_147 , ex:observation_148 ; 
+  sosa:detects ex:observation_147_spinningCupsMovement , ex:observation_148_spinningCupsMovement ;
+.
+# observation #147 was originated by the movement of the spinning cups of sensor #14
+
+ex:observation_147_spinningCupsMovement rdf:type sosa:Stimulus ;
+  sosa:isProxyFor ex:windSpeed ;
+.
+ex:observation_148 rdf:type sosa:Observation ;
+  sosa:observedProperty ex:windSpeed ;
+  sosa:madeBySensor ex:windSensor_14 ;
+  sosa:wasOriginatedBy ex:observation_148_spinningCupsMovement ;
+  sosa:resultTime "2017-04-12T12:01:00+00:00"^^xsd:dateTime ;
+  sosa:hasResult [
+      a qudt:QuantityValue ;
+      qudt:hasUnit unit:KiloM-PER-HR ;
+      qudt:value 47.0 ;
+  ] ;
+.
+ex:observation_148_spinningCupsMovement rdf:type sosa:Stimulus ;
+  sosa:isProxyFor ex:windSpeed ;
+.

--- a/src/current-ssn-sosa/examples/sosa-instance-data/sunspots.ttl
+++ b/src/current-ssn-sosa/examples/sosa-instance-data/sunspots.ttl
@@ -1,0 +1,30 @@
+@prefix ex: <https://example.org/data/> .
+@prefix qk: <http://qudt.org/vocab/quantitykind/> .
+@prefix rdf:  <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix sosa: <http://www.w3.org/ns/sosa/> .
+@prefix time: <http://www.w3.org/2006/time#>.
+@prefix xsd:  <http://www.w3.org/2001/XMLSchema#> .
+@base <https://example.org/data/sunspot/> .
+
+# Number of sunspots
+# The result of an observation of the sunspot number is available a few minutes 
+# after the phenomenon time, due to the light travel duration
+
+<Observation/7536> rdf:type sosa:Observation ;
+  sosa:observedProperty  ex:sunspotCount ;
+  sosa:hasFeatureOfInterest ex:Sun ;
+  sosa:hasSimpleResult 66 ;
+  sosa:phenomenonTime [
+    rdf:type time:Instant ;
+    time:inXSDDateTimeStamp "2017-03-31T11:51:42+00:00"^^xsd:dateTime ] ;
+  sosa:resultTime "2017-03-31T12:00:00+00:00"^^xsd:dateTime ;
+.
+ex:sunspotCount rdf:type sosa:Property ;
+  skos:broader qk:Count ;
+.
+ex:Sun a sosa:FeatureOfInterest ;
+  skos:exactMatch <https://www.wikidata.org/wiki/Q525> ;
+  rdfs:label "Sun" ;
+.

--- a/src/current-ssn-sosa/examples/sosa-instance-data/tree-height.ttl
+++ b/src/current-ssn-sosa/examples/sosa-instance-data/tree-height.ttl
@@ -1,0 +1,30 @@
+@prefix ex: <https://example.org/data/> .
+@prefix rdf:  <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
+@prefix sosa: <http://www.w3.org/ns/sosa/> .
+@prefix xsd:  <http://www.w3.org/2001/XMLSchema#> .
+@prefix qk: <http://qudt.org/vocab/quantitykind/> .
+@prefix qudt: <http://qudt.org/schema/qudt/> .
+@prefix unit: <http://qudt.org/vocab/unit/> .
+@base <https://example.org/data/tree/> .
+
+# Tree height measurement
+
+ex:rangefinder_30 a sosa:Sensor ;
+  rdfs:label "rangefinder #30"@en ;
+  rdfs:comment "rangefinder #30 is a laser range finder sensor."@en ;
+.
+ex:observation_1087 a sosa:Observation ;
+  rdfs:label "observation #1087"@en ;
+  sosa:hasFeatureOfInterest ex:tree_124 ;
+  sosa:observedProperty qk:Height ;
+  sosa:madeBySensor ex:rangefinder_30 ;
+  sosa:hasResult [ 
+    qudt:hasUnit unit:M ; 
+    qudt:value 15.3 ;
+  ] ;
+.
+ex:tree_124 a sosa:FeatureOfInterest ;
+  rdfs:label "tree #124"@en ;
+  sosa:hasProperty qk:Height ;
+.


### PR DESCRIPTION
Adds current SSN/SOSA example instance data under src/current-ssn-sosa/examples/sosa-instance-data/.

No mappings, imports, spreadsheets, release files, or sosa-next files were modified.

Validation:
- make -C src/current-ssn-sosa all
- make -C src all
- ROBOT parse check over added .ttl files