### PR TITLE
Add current SSN/SOSA example validation target

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,3 +83,20 @@ The skipped-target report is written to `src/current-ssn-sosa/build/artifacts/cu
 
 This generated artifact is not a release file. The BFO release placeholder is not populated by this workflow. Complex blank-node expressions, restrictions, intersections, unions, property chains, labels, comments, definitions, natural-language notes, and mapping justifications are skipped. Spreadsheet-to-TTL conversion is not implemented, and no `sosa-next` projection is implemented yet.
 
+## Example validation
+
+Current SSN/SOSA example instance data lives under `src/current-ssn-sosa/examples/sosa-instance-data/`. These files are example data, not ontology imports, and they are not currently imported into the editor ontology.
+
+Run the current-track parse check with:
+
+```bash
+make -C src/current-ssn-sosa validate-examples
+```
+
+Or through the root dispatcher:
+
+```bash
+make -C src validate-examples
+```
+
+This target uses ROBOT `convert` to parse-check every `.ttl` file under `src/current-ssn-sosa/examples/` and writes temporary generated output under `src/current-ssn-sosa/build/artifacts/`. It is not part of `all`.

--- a/src/Makefile
+++ b/src/Makefile
@@ -6,6 +6,7 @@ TRACKS := current-ssn-sosa sosa-next
 .PHONY: reports reports-current-ssn-sosa reports-sosa-next sssom sssom-current-ssn-sosa sssom-sosa-next
 .PHONY: entailed-mappings entailed-current-ssn-sosa entailed-sosa-next unmapped unmapped-current-ssn-sosa unmapped-sosa-next
 .PHONY: artifacts artifacts-current-ssn-sosa artifacts-sosa-next derive-bfo-from-cco derive-bfo-from-cco-current-ssn-sosa
+.PHONY: validate-examples validate-examples-current-ssn-sosa
 
 all: $(TRACKS)
 
@@ -77,6 +78,11 @@ derive-bfo-from-cco: derive-bfo-from-cco-current-ssn-sosa
 
 derive-bfo-from-cco-current-ssn-sosa:
 	$(MAKE) -C current-ssn-sosa derive-bfo-from-cco
+
+validate-examples: validate-examples-current-ssn-sosa
+
+validate-examples-current-ssn-sosa:
+	$(MAKE) -C current-ssn-sosa validate-examples
 
 clean:
 	$(MAKE) -C current-ssn-sosa clean

--- a/src/current-ssn-sosa/Makefile
+++ b/src/current-ssn-sosa/Makefile
@@ -12,6 +12,7 @@ config.EXPORT_QUERIES_DIR := $(config.QUERIES_DIR)/export
 config.REPORT_QUERIES_DIR := $(config.QUERIES_DIR)/report
 config.CONSTRUCT_QUERIES_DIR := $(config.QUERIES_DIR)/construct
 config.LIBRARY_DIR        := ../../build/lib
+config.EXAMPLES_DIR       := examples
 
 config.FAIL_ON_TEST_FAILURES := false
 config.REPORT_FAIL_ON        := none
@@ -33,8 +34,9 @@ UNMAPPED_TERMS_FILE := $(config.REPORTS_DIR)/$(config.ONTOLOGY_PREFIX)-unmapped-
 BFO_ONLY_GENERATED_FILE := $(config.REPORTS_DIR)/$(config.ONTOLOGY_PREFIX)-bfo-only-generated.ttl
 BFO_ONLY_SKIPPED_CCO_TARGETS_FILE := $(config.REPORTS_DIR)/$(config.ONTOLOGY_PREFIX)-bfo-only-skipped-cco-targets.csv
 PROJECTION_CATALOG_FILE := $(config.REPORTS_DIR)/$(config.ONTOLOGY_PREFIX)-projection-catalog.xml
+EXAMPLE_VALIDATION_DIR := $(config.TEMP_DIR)/example-validation
 
-REQUIRED_DIRS      := $(sort $(config.TEMP_DIR) $(config.LIBRARY_DIR) $(config.QUERIES_DIR) $(config.EXPORT_QUERIES_DIR) $(config.REPORT_QUERIES_DIR) $(config.CONSTRUCT_QUERIES_DIR) $(config.REPORTS_DIR))
+REQUIRED_DIRS      := $(sort $(config.TEMP_DIR) $(config.LIBRARY_DIR) $(config.QUERIES_DIR) $(config.EXPORT_QUERIES_DIR) $(config.REPORT_QUERIES_DIR) $(config.CONSTRUCT_QUERIES_DIR) $(config.REPORTS_DIR) $(EXAMPLE_VALIDATION_DIR))
 
 ROBOT_FILE := $(config.LIBRARY_DIR)/robot.jar
 ROBOT := java -jar $(ROBOT_FILE)
@@ -52,7 +54,7 @@ test-edit: verify
 report-edit: report
 explain-edit: explain
 
-.PHONY: sssom-bfo sssom-cco sssom entailed-mappings unmapped artifacts derive-bfo-from-cco
+.PHONY: sssom-bfo sssom-cco sssom entailed-mappings unmapped artifacts derive-bfo-from-cco validate-examples
 sssom: sssom-bfo sssom-cco
 artifacts: report-edit sssom entailed-mappings unmapped
 
@@ -80,6 +82,18 @@ derive-bfo-from-cco: $(config.AUTHORED_CCO_MAPPING_FILE) $(config.CCO_IMPORT_FIL
 	query --query $(config.CONSTRUCT_QUERIES_DIR)/derive-bfo-from-cco.rq $(BFO_ONLY_GENERATED_FILE)
 	$(ROBOT) merge --catalog $(PROJECTION_CATALOG_FILE) --collapse-import-closure false --input $(config.AUTHORED_CCO_MAPPING_FILE) --input $(config.CCO_IMPORT_FILE) \
 	query --query $(config.REPORT_QUERIES_DIR)/unprojectable-cco-targets.rq $(BFO_ONLY_SKIPPED_CCO_TARGETS_FILE) --format csv
+
+validate-examples: | $(EXAMPLE_VALIDATION_DIR) $(ROBOT_FILE)
+	@files="$$(find $(config.EXAMPLES_DIR) -type f -name '*.ttl' | sort)"; \
+	if [ -z "$$files" ]; then \
+		echo "No Turtle example files found under $(config.EXAMPLES_DIR)."; \
+	else \
+		for file in $$files; do \
+			out="$(EXAMPLE_VALIDATION_DIR)/$$(printf '%s' "$$file" | sed 's#[/.]#_#g').ttl"; \
+			echo "Parse-checking $$file"; \
+			$(ROBOT) convert --input "$$file" --format ttl --output "$$out"; \
+		done; \
+	fi
 
 .PHONY: output-release-filepaths
 output-release-filepaths:

--- a/src/current-ssn-sosa/examples/README.md
+++ b/src/current-ssn-sosa/examples/README.md
@@ -1,3 +1,19 @@
 # Current SSN/SOSA examples
 
-Add examples here only after completed current SSN/SOSA mapping content is inserted.
+Current SSN/SOSA example instance data lives under `examples/sosa-instance-data/`.
+
+These files are example/instance data for review and testing. They are not ontology imports, and they are not currently imported into the current SSN/SOSA editor ontology.
+
+To parse-check all Turtle examples without modifying them, run:
+
+```sh
+make validate-examples
+```
+
+From the repository root, the same check can be run with:
+
+```sh
+make -C src validate-examples
+```
+
+The target writes only generated temporary parse outputs under `build/artifacts/`.


### PR DESCRIPTION
Adds repeatable validation for current SSN/SOSA example instance data under src/current-ssn-sosa/examples/.

The new validate-examples target parse-checks all current-track example Turtle files with ROBOT convert. The examples are not imported into the editor ontology and all remains unchanged.

Validation:
- make -C src/current-ssn-sosa validate-examples
- make -C src validate-examples
- make -C src/current-ssn-sosa all
- make -C src all

No mappings, imports, spreadsheets, release files, SSN2BFO.ttl, existing mapping files, or sosa-next files were modified.