### PR TITLE
Document branch workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,22 @@
+# Agent Instructions
+
+Follow the repository branch flow:
+
+```text
+feature/* -> dev -> stage -> main
+```
+
+When creating branches for routine Codex work:
+
+- Start from the latest `dev`.
+- Use a `feature/<short-description>` branch name.
+- Target pull requests to `dev`.
+- Do not create feature branches from `stage` or `main` unless the user explicitly asks for a release or emergency branch.
+- Do not force-push, rewrite history, delete branches, rename branches, or merge unrelated open work unless the user explicitly instructs you to do so.
+
+For promotion work, use pull requests in this order:
+
+- `dev` -> `stage`
+- `stage` -> `main`
+
+Avoid modifying release artifacts under `releases/` or generated build artifacts unless the task explicitly requires those files.

--- a/BRANCHING.md
+++ b/BRANCHING.md
@@ -1,0 +1,33 @@
+# Branching Policy
+
+This repository uses the following branch flow:
+
+```text
+feature/* -> dev -> stage -> main
+```
+
+## Branch Roles
+
+- `feature/*`: short-lived work branches for focused changes.
+- `dev`: integration branch for reviewed feature work.
+- `stage`: stabilization branch for release candidates and final validation.
+- `main`: production and public release branch.
+
+The current GitHub default branch remains `main`. Changing the default branch, renaming branches, deleting branches, force-pushing, or rewriting history is outside this policy and requires explicit maintainer approval.
+
+## Pull Request Targets
+
+- Open feature pull requests from `feature/*` into `dev`.
+- Promote integrated work from `dev` into `stage` with a pull request.
+- Promote validated release candidates from `stage` into `main` with a pull request.
+- Do not target `main` directly from a feature branch unless a maintainer explicitly requests an emergency change.
+
+## Legacy Branches
+
+Branches outside this flow, such as `tests`, are legacy branches. They should not receive new work unless a maintainer explicitly asks for that branch to be used. Do not delete or rename legacy branches as part of routine development.
+
+## Release and Generated Artifacts
+
+Release artifacts under `releases/` are protected project outputs. Do not modify them in routine feature work unless the pull request is specifically scoped to release artifact changes.
+
+Generated reports and build artifacts should remain untracked unless the repository explicitly asks for a generated file to be committed.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,36 @@
+# Contributing
+
+Thank you for contributing to SSN-to-BFO. This repository follows the branch policy described in [BRANCHING.md](BRANCHING.md).
+
+## Branch Flow
+
+Use this flow for all routine work:
+
+```text
+feature/* -> dev -> stage -> main
+```
+
+Create feature branches from the latest `dev` branch:
+
+```bash
+git fetch origin
+git switch dev
+git pull --ff-only origin dev
+git switch -c feature/<short-description>
+```
+
+Open pull requests from `feature/*` into `dev`. After feature work is integrated, maintainers promote `dev` to `stage` and `stage` to `main` with pull requests.
+
+Do not force-push shared branches, rewrite public history, delete branches, rename branches, or merge unrelated open work unless a maintainer explicitly instructs you to do so.
+
+## Validation
+
+Run the repository validation described in the README or in the relevant task instructions before opening a pull request.
+
+Do not add validation commands unless the corresponding files and Make targets are present on the target branch.
+
+## Release Files and Generated Files
+
+The release files under `releases/` are protected project outputs. Do not edit them in routine feature work unless the pull request is specifically about release artifact content.
+
+Generated reports and build artifacts should stay out of Git unless maintainers explicitly request a generated artifact to be committed.


### PR DESCRIPTION
Documents the repository branch flow:

feature/* -> dev -> stage -> main

Adds:
- AGENTS.md for Codex/agent branching instructions
- BRANCHING.md as the policy anchor
- CONTRIBUTING.md for contributor workflow

No branch refs, generated files, release artifacts, or CI workflows are modified in this PR.
