### PR TITLE
Confirm Prescriptive ICE replacement

### DIFF
--- a/reports/mapping-consistency-resolution-plan.md
+++ b/reports/mapping-consistency-resolution-plan.md
@@ -35,14 +35,15 @@ Notes:
 
 | Status | Issue ID | Source term | Sheet / row | Problem | Proposed resolution type | Fix belongs in |
 | --- | --- | --- | --- | --- | --- | --- |
-| [ ] | `ISSUE-0044` | `sosa:Procedure` | `Common Classes` / 12 | Spreadsheet target includes unresolved label alias `cco:PrescriptiveInformationContentEntity`; the audit could not resolve it to a unique CCO IRI or CURIE. The local CCO import does not contain that label/token. | Review `cco:ont00000965` as a candidate spreadsheet replacement token, pending human confirmation. Replace or supplement the label-style target with a resolvable CCO IRI or CURIE before mechanical comparison only after confirmation. | Spreadsheet / manual review |
+| [ ] | `ISSUE-0044` | `sosa:Procedure` | `Common Classes` / 12 | Spreadsheet target includes unresolved label alias `cco:PrescriptiveInformationContentEntity`; the audit could not resolve it to a unique CCO IRI or CURIE. The local CCO import does not contain that label/token. | Human review confirmed `cco:ont00000965` is the correct spreadsheet replacement for `cco:PrescriptiveInformationContentEntity`. Update the spreadsheet separately with the resolvable CCO IRI or CURIE. | Spreadsheet |
 
 Notes:
 
 - This is the only remaining `prefix_or_iri_issue` in the current audit.
 - The local CCO import contains `cco:ont00000965` with label `"Directive Information Content Entity"`, alt label `"Directive ICE"`, and definition `"An Information Content Entity that consists of a set of propositions or images (as in the case of a blueprint) that prescribe some Entity."`
-- `cco:ont00000965` is a candidate replacement for the spreadsheet token, pending human confirmation; it is not automatically correct.
-- Do not edit TTL mechanically from this issue.
+- Human review confirmed `cco:ont00000965` is the correct replacement for the spreadsheet token `cco:PrescriptiveInformationContentEntity`.
+- The spreadsheet should be updated separately for this issue.
+- Do not edit `SSN2BFO.ttl` for this issue.
 
 ## 3. Target Mismatch Review
 


### PR DESCRIPTION
Records the human review decision for the remaining prefix_or_iri_issue.

Decision:
- cco:ont00000965 is the correct replacement for cco:PrescriptiveInformationContentEntity.
- The spreadsheet should be updated separately.
- SSN2BFO.ttl should not be edited for this issue.

No TTL mappings, spreadsheets, imports, release files, src mapping files, or sosa-next files were modified.

Validation:
- git diff --check