### PR TITLE
Record sensor next CCO deferral

### DIFF
--- a/reports/remaining-audit-disposition.md
+++ b/reports/remaining-audit-disposition.md
@@ -51,8 +51,14 @@ The remaining `sosa:Sensor` issues are known version/alignment issues involving 
 
 Disposition:
 
-- do not mechanically revise the TTL in this cleanup pass;
-- preserve as deferred pending the relevant CCO-version alignment decision.
+- do not mechanically revise the root `SSN2BFO.ttl` in this cleanup pass;
+- do not create separate current-CCO and next-CCO `sosa:Sensor` mapping files yet;
+- defer the versioned mapping split until the next relevant CCO version is released;
+- preserve the audit rows as deferred version/alignment issues.
+
+See:
+
+- `reports/sensor-next-cco-deferral.md`
 
 ## Summary
 

--- a/reports/sensor-next-cco-deferral.md
+++ b/reports/sensor-next-cco-deferral.md
@@ -1,0 +1,30 @@
+# `sosa:Sensor` Next CCO Version Deferral
+
+This note records the disposition of the remaining `sosa:Sensor` audit rows.
+
+No TTL, spreadsheet, tool, generated audit, or versioned mapping files are changed by this note.
+
+## Current issue
+
+The remaining `sosa:Sensor` audit rows reflect a version/alignment split between:
+
+- the current `SSN2BFO.ttl` treatment of `sosa:Sensor`; and
+- the spreadsheet's intended target for a future / next CCO version.
+
+## Decision
+
+Defer the `sosa:Sensor` mapping split until the next relevant CCO version is released.
+
+Do not create separate current-CCO and next-CCO `sosa:Sensor` mapping files yet.
+
+Do not mechanically revise the root `SSN2BFO.ttl` in this cleanup pass.
+
+## Rationale
+
+Creating versioned mapping files before the next CCO release is available would risk encoding a speculative target. The safer approach is to preserve the current mapping, keep the audit issue visible, and revisit the mapping once the next CCO version can be referenced directly.
+
+## Audit treatment
+
+The remaining `sosa:Sensor` audit rows are retained as known deferred version/alignment issues.
+
+They should not be interpreted as accidental omissions from the direct spreadsheet/TTL reconciliation cleanup.


### PR DESCRIPTION
Records that the remaining sosa:Sensor mapping split is deferred until the next relevant CCO version is released. This PR makes no TTL, spreadsheet, tool, generated audit, or versioned mapping file changes.