### PR TITLE
Add SSN Systems mapping fixtures

### DIFF
--- a/reports/elk-instance-mapping-entailments.md
+++ b/reports/elk-instance-mapping-entailments.md
@@ -13,7 +13,14 @@ The local materialization layer is used because an earlier version of this test 
 
 This is not full OWL DL reasoning and not HermiT.
 
-It mirrors the example discovery used by `tools/test_instance_data.py`: sorted `*.ttl` files under `src/current-ssn-sosa/examples/sosa-instance-data` by default.
+It preserves the source example discovery used by `tools/test_instance_data.py` and adds clearly labeled synthetic mapping fixtures by default.
+
+Default data directories:
+
+- `src/current-ssn-sosa/examples/sosa-instance-data`
+- `tests/fixtures/ssn-systems-mapping`
+
+Files under `src/current-ssn-sosa/examples/sosa-instance-data` are source examples. Files under `tests/fixtures` are synthetic regression-test fixtures, not source examples or authoritative W3C examples.
 
 For each example, the script builds a temporary no-imports merged graph from:
 
@@ -42,34 +49,37 @@ It does not attempt HermiT or full OWL DL testing.
 ## Summary
 
 - ROBOT executable: `/usr/local/bin/robot`
-- Example files tested: 11
-- ROBOT pass: 11
+- Example files tested: 12
+- Source example files tested: 11
+- Synthetic fixture files tested: 1
+- ROBOT pass: 12
 - ROBOT fail: 0
 - Examples with `owl:Nothing` entities: 0
 - Direct class mappings discovered: 4
 - Direct property mappings discovered: 29
 - Total class expectations checked: 0
-- Total property expectations checked: 95
+- Total property expectations checked: 101
 - Total expectation failures: 0
-- Expected ABox target assertions not observed in ROBOT output: 95
-- Active direct mappings not covered by instance data: 24
+- Expected ABox target assertions not observed in ROBOT output: 101
+- Active direct mappings not covered by instance data: 18
 - Overall status: PASS
 
 ## Per-example ELK Results
 
-| Example | Status | ROBOT status | `owl:Nothing` count | Class expectations | Property expectations | Expectation failures | ROBOT output missing expected ABox assertions | Notes |
-| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | --- |
-| `src/current-ssn-sosa/examples/sosa-instance-data/Beer-Full-IBS-TH2.ttl` | PASS | 0 | 0 | 0 | 18 | 0 | 18 | OWLAPI parser messages about error#Error entities |
-| `src/current-ssn-sosa/examples/sosa-instance-data/IDEAS.ttl` | PASS | 0 | 0 | 0 | 0 | 0 | 0 | OWLAPI parser messages about error#Error entities |
-| `src/current-ssn-sosa/examples/sosa-instance-data/apartment-134.ttl` | PASS | 0 | 0 | 0 | 15 | 0 | 15 | OWLAPI parser messages about error#Error entities |
-| `src/current-ssn-sosa/examples/sosa-instance-data/dht22-deployment.ttl` | PASS | 0 | 0 | 0 | 0 | 0 | 0 | OWLAPI parser messages about error#Error entities |
-| `src/current-ssn-sosa/examples/sosa-instance-data/dht22.ttl` | PASS | 0 | 0 | 0 | 30 | 0 | 30 | OWLAPI parser messages about error#Error entities |
-| `src/current-ssn-sosa/examples/sosa-instance-data/ip68.ttl` | PASS | 0 | 0 | 0 | 8 | 0 | 8 | OWLAPI parser messages about error#Error entities |
-| `src/current-ssn-sosa/examples/sosa-instance-data/iphone_barometer-sosa.ttl` | PASS | 0 | 0 | 0 | 7 | 0 | 7 | OWLAPI parser messages about error#Error entities |
-| `src/current-ssn-sosa/examples/sosa-instance-data/seismograph.ttl` | PASS | 0 | 0 | 0 | 4 | 0 | 4 | OWLAPI parser messages about error#Error entities |
-| `src/current-ssn-sosa/examples/sosa-instance-data/spinning-cups.ttl` | PASS | 0 | 0 | 0 | 9 | 0 | 9 | OWLAPI parser messages about error#Error entities |
-| `src/current-ssn-sosa/examples/sosa-instance-data/sunspots.ttl` | PASS | 0 | 0 | 0 | 1 | 0 | 1 | OWLAPI parser messages about error#Error entities |
-| `src/current-ssn-sosa/examples/sosa-instance-data/tree-height.ttl` | PASS | 0 | 0 | 0 | 3 | 0 | 3 | OWLAPI parser messages about error#Error entities |
+| Example | Kind | Status | ROBOT status | `owl:Nothing` count | Class expectations | Property expectations | Expectation failures | ROBOT output missing expected ABox assertions | Notes |
+| --- | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | --- |
+| `src/current-ssn-sosa/examples/sosa-instance-data/Beer-Full-IBS-TH2.ttl` | source example | PASS | 0 | 0 | 0 | 18 | 0 | 18 | OWLAPI parser messages about error#Error entities |
+| `src/current-ssn-sosa/examples/sosa-instance-data/IDEAS.ttl` | source example | PASS | 0 | 0 | 0 | 0 | 0 | 0 | OWLAPI parser messages about error#Error entities |
+| `src/current-ssn-sosa/examples/sosa-instance-data/apartment-134.ttl` | source example | PASS | 0 | 0 | 0 | 15 | 0 | 15 | OWLAPI parser messages about error#Error entities |
+| `src/current-ssn-sosa/examples/sosa-instance-data/dht22-deployment.ttl` | source example | PASS | 0 | 0 | 0 | 0 | 0 | 0 | OWLAPI parser messages about error#Error entities |
+| `src/current-ssn-sosa/examples/sosa-instance-data/dht22.ttl` | source example | PASS | 0 | 0 | 0 | 30 | 0 | 30 | OWLAPI parser messages about error#Error entities |
+| `src/current-ssn-sosa/examples/sosa-instance-data/ip68.ttl` | source example | PASS | 0 | 0 | 0 | 8 | 0 | 8 | OWLAPI parser messages about error#Error entities |
+| `src/current-ssn-sosa/examples/sosa-instance-data/iphone_barometer-sosa.ttl` | source example | PASS | 0 | 0 | 0 | 7 | 0 | 7 | OWLAPI parser messages about error#Error entities |
+| `src/current-ssn-sosa/examples/sosa-instance-data/seismograph.ttl` | source example | PASS | 0 | 0 | 0 | 4 | 0 | 4 | OWLAPI parser messages about error#Error entities |
+| `src/current-ssn-sosa/examples/sosa-instance-data/spinning-cups.ttl` | source example | PASS | 0 | 0 | 0 | 9 | 0 | 9 | OWLAPI parser messages about error#Error entities |
+| `src/current-ssn-sosa/examples/sosa-instance-data/sunspots.ttl` | source example | PASS | 0 | 0 | 0 | 1 | 0 | 1 | OWLAPI parser messages about error#Error entities |
+| `src/current-ssn-sosa/examples/sosa-instance-data/tree-height.ttl` | source example | PASS | 0 | 0 | 0 | 3 | 0 | 3 | OWLAPI parser messages about error#Error entities |
+| `tests/fixtures/ssn-systems-mapping/ssn-systems-property-mappings.ttl` | synthetic fixture | PASS | 0 | 0 | 0 | 6 | 0 | 6 | OWLAPI parser messages about error#Error entities |
 
 ## Mapping Expectations Checked
 
@@ -84,6 +94,12 @@ It does not attempt HermiT or full OWL DL testing.
 | property | `sosa:observedProperty` | `cco:ont00001921` | 33 |
 | property | `sosa:observes` | `ssn:forProperty` | 7 |
 | property | `sosa:usedProcedure` | `cco:ont00001920` | 1 |
+| property | `ssn-system:hasOperatingProperty` | `bfo:BFO_0000194` | 1 |
+| property | `ssn-system:hasOperatingRange` | `bfo:BFO_0000196` | 1 |
+| property | `ssn-system:hasSurvivalProperty` | `bfo:BFO_0000194` | 1 |
+| property | `ssn-system:hasSurvivalRange` | `bfo:BFO_0000196` | 1 |
+| property | `ssn-system:hasSystemCapability` | `bfo:BFO_0000196` | 1 |
+| property | `ssn-system:hasSystemProperty` | `bfo:BFO_0000194` | 1 |
 
 ## Failures
 
@@ -91,8 +107,8 @@ No failures were detected.
 
 ## ROBOT Materialization Note
 
-The local RDFS-style expectation check produced `95` expected ABox target assertions.
-Of those, `95` were not observed in ROBOT's reasoned output.
+The local RDFS-style expectation check produced `101` expected ABox target assertions.
+Of those, `101` were not observed in ROBOT's reasoned output.
 
 This is reported as a materialization limitation, not as a mapping failure, because the ELK gate succeeded and the local direct subclass/subproperty closure produced the expected target assertions.
 
@@ -118,12 +134,6 @@ These active direct mappings were discovered in `SSN2BFO.ttl`, but their source 
 | property | `ssn:hasOutput` | `cco:ont00001986` |
 | property | `ssn:hasSubSystem` | `bfo:BFO_0000178` |
 | property | `ssn:inDeployment` | `bfo:BFO_0000056` |
-| property | `ssn-system:hasOperatingProperty` | `bfo:BFO_0000194` |
-| property | `ssn-system:hasOperatingRange` | `bfo:BFO_0000196` |
-| property | `ssn-system:hasSurvivalProperty` | `bfo:BFO_0000194` |
-| property | `ssn-system:hasSurvivalRange` | `bfo:BFO_0000196` |
-| property | `ssn-system:hasSystemCapability` | `bfo:BFO_0000196` |
-| property | `ssn-system:hasSystemProperty` | `bfo:BFO_0000194` |
 | property | `ssn-system:qualityOfObservation` | `cco:ont00001986` |
 | property | `ssn:wasOriginatedBy` | `cco:ont00001962` |
 

--- a/tests/fixtures/ssn-systems-mapping/ssn-systems-property-mappings.ttl
+++ b/tests/fixtures/ssn-systems-mapping/ssn-systems-property-mappings.ttl
@@ -1,0 +1,36 @@
+@prefix ex: <https://example.org/ssn-systems-mapping-fixture/> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix ssn: <http://www.w3.org/ns/ssn/> .
+@prefix ssn-system: <http://www.w3.org/ns/ssn/systems/> .
+
+# Synthetic regression-test fixture for SSN Systems direct property mappings.
+# This is not source example data and is not an authoritative W3C example.
+# It exists only to exercise active SSN Systems mappings in
+# tools/test_elk_instance_mapping_entailments.py.
+
+ex:synthetic-system
+    rdf:type ssn:System ;
+    ssn-system:hasOperatingRange ex:synthetic-operating-range ;
+    ssn-system:hasSurvivalRange ex:synthetic-survival-range ;
+    ssn-system:hasSystemCapability ex:synthetic-system-capability .
+
+ex:synthetic-operating-range
+    rdf:type ssn-system:OperatingRange ;
+    ssn-system:hasOperatingProperty ex:synthetic-operating-property .
+
+ex:synthetic-operating-property
+    rdf:type ssn-system:OperatingProperty .
+
+ex:synthetic-survival-range
+    rdf:type ssn-system:SurvivalRange ;
+    ssn-system:hasSurvivalProperty ex:synthetic-survival-property .
+
+ex:synthetic-survival-property
+    rdf:type ssn-system:SurvivalProperty .
+
+ex:synthetic-system-capability
+    rdf:type ssn-system:SystemCapability ;
+    ssn-system:hasSystemProperty ex:synthetic-system-property .
+
+ex:synthetic-system-property
+    rdf:type ssn-system:SystemProperty .

--- a/tools/test_elk_instance_mapping_entailments.py
+++ b/tools/test_elk_instance_mapping_entailments.py
@@ -37,6 +37,11 @@ SOURCE_NAMESPACES = (
     str(SSN),
 )
 
+DEFAULT_DATA_DIRS = (
+    "src/current-ssn-sosa/examples/sosa-instance-data",
+    "tests/fixtures/ssn-systems-mapping",
+)
+
 PREFIXES: tuple[tuple[str, str], ...] = (
     ("rdf", str(RDF)),
     ("rdfs", str(RDFS)),
@@ -82,6 +87,7 @@ class Expectation:
 @dataclass
 class ExampleResult:
     path: Path
+    source_kind: str
     merged_path: Path
     reasoned_path: Path
     robot_status: int | None
@@ -125,7 +131,8 @@ def markdown_escape(text: str) -> str:
 
 
 def slug_for_path(path: Path) -> str:
-    stem = re.sub(r"[^A-Za-z0-9._-]+", "_", path.stem)
+    stem = re.sub(r"[^A-Za-z0-9._-]+", "_", path.as_posix())
+    stem = stem.strip("_").removesuffix("_ttl")
     return stem or "example"
 
 
@@ -144,6 +151,26 @@ def bind_prefixes(graph: Graph) -> None:
 
 def source_term(value: object) -> bool:
     return isinstance(value, URIRef) and str(value).startswith(SOURCE_NAMESPACES)
+
+
+def data_file_kind(path: Path) -> str:
+    text = path.as_posix()
+    if text.startswith("src/current-ssn-sosa/examples/sosa-instance-data/"):
+        return "source example"
+    if text.startswith("tests/fixtures/"):
+        return "synthetic fixture"
+    return "data file"
+
+
+def discover_data_files(data_dirs: list[Path]) -> list[Path]:
+    files: list[Path] = []
+    seen: set[Path] = set()
+    for data_dir in data_dirs:
+        for path in sorted(data_dir.glob("*.ttl")):
+            if path not in seen:
+                files.append(path)
+                seen.add(path)
+    return files
 
 
 def extract_direct_mappings(ttl_path: Path) -> tuple[list[DirectMapping], list[DirectMapping]]:
@@ -354,8 +381,10 @@ def write_report(
     uncovered: list[DirectMapping],
     robot_path: str | None,
     tmp_dir: Path,
+    data_dirs: list[Path],
 ) -> None:
     status_counts = Counter(result.status for result in example_results)
+    kind_counts = Counter(result.source_kind for result in example_results)
     robot_pass = sum(1 for result in example_results if result.robot_status == 0)
     robot_fail = len(example_results) - robot_pass
     class_checked = sum(1 for expectation in expectations if expectation.kind == "class")
@@ -382,7 +411,13 @@ def write_report(
         "",
         "This is not full OWL DL reasoning and not HermiT.",
         "",
-        "It mirrors the example discovery used by `tools/test_instance_data.py`: sorted `*.ttl` files under `src/current-ssn-sosa/examples/sosa-instance-data` by default.",
+        "It preserves the source example discovery used by `tools/test_instance_data.py` and adds clearly labeled synthetic mapping fixtures by default.",
+        "",
+        "Default data directories:",
+        "",
+        *[f"- `{path}`" for path in data_dirs],
+        "",
+        "Files under `src/current-ssn-sosa/examples/sosa-instance-data` are source examples. Files under `tests/fixtures` are synthetic regression-test fixtures, not source examples or authoritative W3C examples.",
         "",
         "For each example, the script builds a temporary no-imports merged graph from:",
         "",
@@ -412,6 +447,8 @@ def write_report(
         "",
         f"- ROBOT executable: `{robot_path or 'not found'}`",
         f"- Example files tested: {len(example_results)}",
+        f"- Source example files tested: {kind_counts.get('source example', 0)}",
+        f"- Synthetic fixture files tested: {kind_counts.get('synthetic fixture', 0)}",
         f"- ROBOT pass: {robot_pass}",
         f"- ROBOT fail: {robot_fail}",
         f"- Examples with `owl:Nothing` entities: {len(nothing_failures)}",
@@ -426,8 +463,8 @@ def write_report(
         "",
         "## Per-example ELK Results",
         "",
-        "| Example | Status | ROBOT status | `owl:Nothing` count | Class expectations | Property expectations | Expectation failures | ROBOT output missing expected ABox assertions | Notes |",
-        "| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | --- |",
+        "| Example | Kind | Status | ROBOT status | `owl:Nothing` count | Class expectations | Property expectations | Expectation failures | ROBOT output missing expected ABox assertions | Notes |",
+        "| --- | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | --- |",
     ]
 
     for result in example_results:
@@ -436,7 +473,7 @@ def write_report(
             notes = "; ".join(part for part in [notes, f"Parse error: {result.parse_error}"] if part)
         lines.append(
             "| "
-            f"`{result.path}` | {result.status} | "
+            f"`{result.path}` | {result.source_kind} | {result.status} | "
             f"{'' if result.robot_status is None else result.robot_status} | "
             f"{'' if result.nothing_count is None else result.nothing_count} | "
             f"{result.class_expectations_checked} | "
@@ -579,8 +616,12 @@ def main() -> int:
     )
     parser.add_argument(
         "--data-dir",
-        default="src/current-ssn-sosa/examples/sosa-instance-data",
-        help="Directory containing example .ttl files.",
+        action="append",
+        default=None,
+        help=(
+            "Directory containing .ttl data files. Can be passed multiple times. "
+            f"Defaults to: {', '.join(DEFAULT_DATA_DIRS)}."
+        ),
     )
     parser.add_argument(
         "--output",
@@ -601,14 +642,14 @@ def main() -> int:
 
     mapping_paths = [Path(p) for p in args.mapping]
     ttl_path = Path(args.ttl)
-    data_dir = Path(args.data_dir)
+    data_dirs = [Path(p) for p in (args.data_dir or DEFAULT_DATA_DIRS)]
     output_path = Path(args.output)
     tmp_dir = Path(args.tmp_dir)
     tmp_dir.mkdir(parents=True, exist_ok=True)
 
     robot_path = args.robot or shutil.which("robot")
     class_mappings, property_mappings = extract_direct_mappings(ttl_path)
-    data_files = sorted(data_dir.glob("*.ttl"))
+    data_files = discover_data_files(data_dirs)
 
     all_expectations: list[Expectation] = []
     example_results: list[ExampleResult] = []
@@ -624,6 +665,7 @@ def main() -> int:
             class_mappings + property_mappings,
             None,
             tmp_dir,
+            data_dirs,
         )
         print(f"Wrote {output_path}")
         print(f"Example files tested: {len(data_files)}")
@@ -660,6 +702,7 @@ def main() -> int:
         example_results.append(
             ExampleResult(
                 path=example_path,
+                source_kind=data_file_kind(example_path),
                 merged_path=merged_path,
                 reasoned_path=reasoned_path,
                 robot_status=robot_status,
@@ -686,6 +729,7 @@ def main() -> int:
         uncovered,
         robot_path,
         tmp_dir,
+        data_dirs,
     )
 
     robot_pass = sum(1 for result in example_results if result.robot_status == 0)


### PR DESCRIPTION
## Summary
- Adds synthetic regression-test fixture data for six SSN Systems property mappings.
- Updates the ELK instance mapping entailment test to include both source examples and synthetic mapping fixtures by default.
- Regenerates the ELK instance entailment report.

## Coverage added
The following mappings are now covered by the ELK instance entailment test:
- ssn-system:hasOperatingProperty -> bfo:BFO_0000194
- ssn-system:hasOperatingRange -> bfo:BFO_0000196
- ssn-system:hasSurvivalProperty -> bfo:BFO_0000194
- ssn-system:hasSurvivalRange -> bfo:BFO_0000196
- ssn-system:hasSystemCapability -> bfo:BFO_0000196
- ssn-system:hasSystemProperty -> bfo:BFO_0000194

## Validation
- ELK instance entailment test: PASS
- Files tested: 12 total, including 11 source examples and 1 synthetic fixture
- ROBOT/ELK passed for 12/12 files
- owl:Nothing count was 0 for all files
- Property expectations checked: 101
- Expectation failures: 0
- Existing instance-data smoke test: PASS
- TTL parse OK for SSN2BFO.ttl and the new fixture
- Mapping audit remains at the expected two deferred sosa:Sensor version-alignment issues
- python -m py_compile passed
- git diff --check passed

## Scope
Test fixture, test harness, and generated report only. No ontology mappings, spreadsheet files, imports, source examples, release/generated artifacts, or source mapping files changed.