### PR TITLE
Add core SSN mapping fixtures

### DIFF
--- a/reports/elk-instance-mapping-entailments.md
+++ b/reports/elk-instance-mapping-entailments.md
@@ -19,6 +19,7 @@ Default data directories:
 
 - `src/current-ssn-sosa/examples/sosa-instance-data`
 - `tests/fixtures/ssn-systems-mapping`
+- `tests/fixtures/ssn-core-mapping`
 
 Files under `src/current-ssn-sosa/examples/sosa-instance-data` are source examples. Files under `tests/fixtures` are synthetic regression-test fixtures, not source examples or authoritative W3C examples.
 
@@ -49,19 +50,19 @@ It does not attempt HermiT or full OWL DL testing.
 ## Summary
 
 - ROBOT executable: `/usr/local/bin/robot`
-- Example files tested: 12
+- Example files tested: 13
 - Source example files tested: 11
-- Synthetic fixture files tested: 1
-- ROBOT pass: 12
+- Synthetic fixture files tested: 2
+- ROBOT pass: 13
 - ROBOT fail: 0
 - Examples with `owl:Nothing` entities: 0
 - Direct class mappings discovered: 4
 - Direct property mappings discovered: 29
-- Total class expectations checked: 0
-- Total property expectations checked: 101
+- Total class expectations checked: 2
+- Total property expectations checked: 106
 - Total expectation failures: 0
-- Expected ABox target assertions not observed in ROBOT output: 101
-- Active direct mappings not covered by instance data: 18
+- Expected ABox target assertions not observed in ROBOT output: 108
+- Active direct mappings not covered by instance data: 11
 - Overall status: PASS
 
 ## Per-example ELK Results
@@ -80,11 +81,14 @@ It does not attempt HermiT or full OWL DL testing.
 | `src/current-ssn-sosa/examples/sosa-instance-data/sunspots.ttl` | source example | PASS | 0 | 0 | 0 | 1 | 0 | 1 | OWLAPI parser messages about error#Error entities |
 | `src/current-ssn-sosa/examples/sosa-instance-data/tree-height.ttl` | source example | PASS | 0 | 0 | 0 | 3 | 0 | 3 | OWLAPI parser messages about error#Error entities |
 | `tests/fixtures/ssn-systems-mapping/ssn-systems-property-mappings.ttl` | synthetic fixture | PASS | 0 | 0 | 0 | 6 | 0 | 6 | OWLAPI parser messages about error#Error entities |
+| `tests/fixtures/ssn-core-mapping/ssn-core-property-class-mappings.ttl` | synthetic fixture | PASS | 0 | 0 | 2 | 5 | 0 | 7 | OWLAPI parser messages about error#Error entities |
 
 ## Mapping Expectations Checked
 
 | Mapping kind | Source | Target | Checked expectation count |
 | --- | --- | --- | ---: |
+| class | `ssn:Input` | `cco:ont00000958` | 1 |
+| class | `ssn:Output` | `cco:ont00000958` | 1 |
 | property | `sosa:actsOnProperty` | `cco:ont00001834` | 1 |
 | property | `sosa:hasResult` | `cco:ont00001986` | 26 |
 | property | `sosa:madeActuation` | `cco:ont00001787` | 1 |
@@ -94,12 +98,17 @@ It does not attempt HermiT or full OWL DL testing.
 | property | `sosa:observedProperty` | `cco:ont00001921` | 33 |
 | property | `sosa:observes` | `ssn:forProperty` | 7 |
 | property | `sosa:usedProcedure` | `cco:ont00001920` | 1 |
+| property | `ssn:detects` | `cco:ont00001886` | 1 |
+| property | `ssn:hasInput` | `cco:ont00001921` | 1 |
+| property | `ssn:hasOutput` | `cco:ont00001986` | 1 |
+| property | `ssn:hasSubSystem` | `bfo:BFO_0000178` | 1 |
 | property | `ssn-system:hasOperatingProperty` | `bfo:BFO_0000194` | 1 |
 | property | `ssn-system:hasOperatingRange` | `bfo:BFO_0000196` | 1 |
 | property | `ssn-system:hasSurvivalProperty` | `bfo:BFO_0000194` | 1 |
 | property | `ssn-system:hasSurvivalRange` | `bfo:BFO_0000196` | 1 |
 | property | `ssn-system:hasSystemCapability` | `bfo:BFO_0000196` | 1 |
 | property | `ssn-system:hasSystemProperty` | `bfo:BFO_0000194` | 1 |
+| property | `ssn:wasOriginatedBy` | `cco:ont00001962` | 1 |
 
 ## Failures
 
@@ -107,8 +116,8 @@ No failures were detected.
 
 ## ROBOT Materialization Note
 
-The local RDFS-style expectation check produced `101` expected ABox target assertions.
-Of those, `101` were not observed in ROBOT's reasoned output.
+The local RDFS-style expectation check produced `108` expected ABox target assertions.
+Of those, `108` were not observed in ROBOT's reasoned output.
 
 This is reported as a materialization limitation, not as a mapping failure, because the ELK gate succeeded and the local direct subclass/subproperty closure produced the expected target assertions.
 
@@ -120,22 +129,15 @@ These active direct mappings were discovered in `SSN2BFO.ttl`, but their source 
 | --- | --- | --- |
 | class | `sosa-rel:RelationshipNature` | `cco:ont00000958` |
 | class | `sosa-rel:SampleRelationship` | `cco:ont00000958` |
-| class | `ssn:Input` | `cco:ont00000958` |
-| class | `ssn:Output` | `cco:ont00000958` |
 | property | `sosa:isActedOnBy` | `cco:ont00001886` |
 | property | `sosa:isResultOf` | `cco:ont00001816` |
 | property | `sosa:madeBySampler` | `cco:ont00001833` |
 | property | `sosa:madeSampling` | `cco:ont00001787` |
 | property | `ssn:deployedOnPlatform` | `bfo:BFO_0000057` |
 | property | `ssn:deployedSystem` | `bfo:BFO_0000057` |
-| property | `ssn:detects` | `cco:ont00001886` |
 | property | `ssn:hasDeployment` | `bfo:BFO_0000056` |
-| property | `ssn:hasInput` | `cco:ont00001921` |
-| property | `ssn:hasOutput` | `cco:ont00001986` |
-| property | `ssn:hasSubSystem` | `bfo:BFO_0000178` |
 | property | `ssn:inDeployment` | `bfo:BFO_0000056` |
 | property | `ssn-system:qualityOfObservation` | `cco:ont00001986` |
-| property | `ssn:wasOriginatedBy` | `cco:ont00001962` |
 
 ## Deferred/out-of-scope Mappings
 

--- a/tests/fixtures/ssn-core-mapping/ssn-core-property-class-mappings.ttl
+++ b/tests/fixtures/ssn-core-mapping/ssn-core-property-class-mappings.ttl
@@ -1,0 +1,37 @@
+@prefix ex: <https://example.org/ssn-core-mapping-fixture/> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix sosa: <http://www.w3.org/ns/sosa/> .
+@prefix ssn: <http://www.w3.org/ns/ssn/> .
+
+# Synthetic regression-test fixture for core SSN direct mappings.
+# This is not source example data and is not an authoritative W3C example.
+# It exists only to exercise active core SSN mappings in
+# tools/test_elk_instance_mapping_entailments.py.
+
+ex:synthetic-procedure
+    ssn:hasInput ex:synthetic-input ;
+    ssn:hasOutput ex:synthetic-output .
+
+ex:synthetic-input
+    rdf:type ssn:Input .
+
+ex:synthetic-output
+    rdf:type ssn:Output .
+
+ex:synthetic-sensor
+    rdf:type sosa:Sensor ;
+    ssn:detects ex:synthetic-stimulus .
+
+ex:synthetic-observation
+    rdf:type sosa:Observation ;
+    ssn:wasOriginatedBy ex:synthetic-stimulus .
+
+ex:synthetic-stimulus
+    rdf:type ssn:Stimulus .
+
+ex:synthetic-system
+    rdf:type ssn:System ;
+    ssn:hasSubSystem ex:synthetic-subsystem .
+
+ex:synthetic-subsystem
+    rdf:type ssn:System .

--- a/tools/test_elk_instance_mapping_entailments.py
+++ b/tools/test_elk_instance_mapping_entailments.py
@@ -40,6 +40,7 @@ SOURCE_NAMESPACES = (
 DEFAULT_DATA_DIRS = (
     "src/current-ssn-sosa/examples/sosa-instance-data",
     "tests/fixtures/ssn-systems-mapping",
+    "tests/fixtures/ssn-core-mapping",
 )
 
 PREFIXES: tuple[tuple[str, str], ...] = (


### PR DESCRIPTION
## Summary
- Adds synthetic regression-test fixture data for core SSN direct mappings.
- Updates the ELK instance mapping entailment test to include the new fixture directory by default.
- Regenerates the ELK instance entailment report.

## Coverage added
The following mappings are now covered by the ELK instance entailment test:
- ssn:Input -> cco:ont00000958
- ssn:Output -> cco:ont00000958
- ssn:hasInput -> cco:ont00001921
- ssn:hasOutput -> cco:ont00001986
- ssn:detects -> cco:ont00001886
- ssn:hasSubSystem -> bfo:BFO_0000178
- ssn:wasOriginatedBy -> cco:ont00001962

## Validation
- ELK instance entailment test: PASS
- Files tested: 13 total, including 11 source examples and 2 synthetic fixtures
- ROBOT/ELK passed for 13/13 files
- owl:Nothing count was 0 for all files
- Class expectations checked: 2
- Property expectations checked: 106
- Expectation failures: 0
- Existing instance-data smoke test: PASS
- TTL parse OK for SSN2BFO.ttl and the new fixture
- Mapping audit remains at the expected two deferred sosa:Sensor version-alignment issues
- python -m py_compile passed
- git diff --check passed

## Scope
Test fixture, test harness default-directory update, and generated report only. No ontology mappings, spreadsheet files, imports, source examples, release/generated artifacts, or source mapping files changed.