### PR TITLE
Treat domain and range rows as coverage

### DIFF
--- a/queries/unmapped-source-terms.rq
+++ b/queries/unmapped-source-terms.rq
@@ -4,6 +4,6 @@ SELECT ?term ?kind ?coverageStatus
 WHERE {
   ?term coms:sourceKind ?kind ;
         coms:coverageStatus ?coverageStatus .
-  FILTER(?coverageStatus != "mapped")
+  FILTER(?coverageStatus NOT IN ("mapped", "covered_by_property_typing"))
 }
 ORDER BY ?kind ?coverageStatus ?term

--- a/reports/coms-automatic-validation-setup.md
+++ b/reports/coms-automatic-validation-setup.md
@@ -58,7 +58,7 @@ sosa:hasFeatureOfInterest | rdfs:range | sosa:FeatureOfInterest
 
 For `rdfs:domain` and `rdfs:range`, the subject must resolve to a declared source object property and the target is parsed by the same Manchester class-expression parser used for class mappings. Named classes, intersections, unions, and existential restrictions are supported. The generated ontology uses the standard RDF/OWL domain or range triple, with an OWL class-expression blank node when the target is complex.
 
-A property may have a relation mapping, one domain row, and one range row. Domain/range rows are local typing axioms and do not by themselves make the property relation-mapped. At most one populated domain row and one populated range row are allowed per property. Multiple OWL domain or range axioms are conjunctive, so alternatives must be combined in one target with Manchester `or`.
+A property may have a relation mapping, one domain row, and one range row. Domain/range rows are local typing axioms and do not by themselves make the property relation-mapped, but they do cover the property for source-term coverage and exclude it from the unmapped object-property set. Such properties remain reported separately as listed only in domain/range property-typing rows. At most one populated domain row and one populated range row are allowed per property. Multiple OWL domain or range axioms are conjunctive, so alternatives must be combined in one target with Manchester `or`.
 
 ## Checks Performed
 

--- a/reports/coms-generation-validation.md
+++ b/reports/coms-generation-validation.md
@@ -9,8 +9,8 @@ Freshness is determined from content hashes, not file timestamps.
 | Item | Value |
 |---|---|
 | workbook SHA-256 | `b1d53596a2cc46f6138f6ad8bbfb01d79defcc253787b65fd974dfa7083d5e3b` |
-| generator SHA-256 | `cec3cfff5345bd543939012b6bf13aafab2cfbe18d70b78c235bdc0c91c4c37b` |
-| generation timestamp (UTC) | `2026-07-14T02:07:03+00:00` |
+| generator SHA-256 | `adb1f1019cb85123e135b32a100ef229693c5e49d41d28062ed2ca7f62a04818` |
+| generation timestamp (UTC) | `2026-07-14T05:15:49+00:00` |
 | generated candidate SHA-256 | `4c29d4ef409931febd089f8a270e772354defd073732eb57b68f95bbd120198a` |
 
 ## Workbook
@@ -206,7 +206,7 @@ This section records mapping and domain/range property-typing rows after parsing
 | mapped classes | 43 |
 | unmapped classes | 1 |
 | mapped object properties | 7 |
-| unmapped object properties | 40 |
+| unmapped object properties | 38 |
 | explicitly listed blank mappings | 3 |
 | listed only in domain/range property-typing rows | 2 |
 | source terms absent from spreadsheet | 36 |
@@ -234,4 +234,4 @@ This section records mapping and domain/range property-typing rows after parsing
 
 ## Runtime
 
-- Runtime seconds: 2.92
+- Runtime seconds: 2.87

--- a/reports/coms-source-term-coverage.md
+++ b/reports/coms-source-term-coverage.md
@@ -10,7 +10,7 @@ Coverage scope is all non-deprecated named OWL classes and object properties def
 - `imports/ssn-systems.ttl`
 
 The source term inventory is produced by `queries/source-classes-and-object-properties.rq`. Unmapped terms are selected from the generated coverage graph by `queries/unmapped-source-terms.rq`.
-A domain or range row lists a property for local typing review but does not count it as relation-mapped; only subproperty, equivalent-property, or property-chain rows do so.
+A domain or range row covers a property for source-term coverage but does not count it as relation-mapped; only subproperty, equivalent-property, or property-chain rows do so.
 
 ## Summary
 
@@ -20,12 +20,12 @@ A domain or range row lists a property for local typing review but does not coun
 | mapped classes | 43 |
 | unmapped classes | 1 |
 | mapped object properties | 7 |
-| unmapped object properties | 40 |
+| unmapped object properties | 38 |
 | explicitly listed blank mappings | 3 |
 | listed only in domain/range property-typing rows | 2 |
 | source terms absent from spreadsheet | 36 |
 | spreadsheet subjects not found in source ontologies | 0 |
-| unmapped rows returned by SPARQL coverage query | 41 |
+| unmapped rows returned by SPARQL coverage query | 39 |
 
 ## Mapped Classes
 
@@ -89,11 +89,9 @@ A domain or range row lists a property for local typing review but does not coun
 
 ## Unmapped Object Properties
 
-- `sosa:hasFeatureOfInterest`
 - `sosa:hasSample`
 - `sosa:hosts`
 - `sosa:isActedOnBy`
-- `sosa:isFeatureOfInterestOf`
 - `sosa:isHostedBy`
 - `sosa:isObservedBy`
 - `sosa:isResultOf`

--- a/tests/test_generate_mapping_from_coms.py
+++ b/tests/test_generate_mapping_from_coms.py
@@ -25,6 +25,10 @@ OBSERVATION = URIRef("http://www.w3.org/ns/sosa/Observation")
 ACTUATION = URIRef("http://www.w3.org/ns/sosa/Actuation")
 SAMPLING = URIRef("http://www.w3.org/ns/sosa/Sampling")
 FEATURE_OF_INTEREST = URIRef("http://www.w3.org/ns/sosa/FeatureOfInterest")
+MAPPED_PROPERTY = URIRef("http://www.w3.org/ns/sosa/actsOnProperty")
+DOMAIN_ONLY_PROPERTY = SUBJECT_IRI
+RANGE_ONLY_PROPERTY = URIRef("http://www.w3.org/ns/sosa/hasResult")
+UNCOVERED_PROPERTY = URIRef("http://www.w3.org/ns/sosa/hosts")
 
 
 class ComsDomainRangeTests(unittest.TestCase):
@@ -180,7 +184,7 @@ class ComsDomainRangeTests(unittest.TestCase):
         )
 
     def test_subproperty_domain_and_range_can_coexist(self) -> None:
-        graph, _, stats = self.generate(
+        graph, processed, stats = self.generate(
             [
                 (SUBJECT, "rdfs:subPropertyOf", "sosa:isFeatureOfInterestOf"),
                 (SUBJECT, "rdfs:domain", "sosa:Observation or sosa:Actuation"),
@@ -197,22 +201,52 @@ class ComsDomainRangeTests(unittest.TestCase):
         self.assertEqual(len(list(graph.objects(SUBJECT_IRI, RDFS.subPropertyOf))), 1)
         self.assertEqual(len(list(graph.objects(SUBJECT_IRI, RDFS.domain))), 1)
         self.assertEqual(len(list(graph.objects(SUBJECT_IRI, RDFS.range))), 1)
+        coverage = coms.build_coverage(processed, [], self.root / "coexistence-coverage.md")
+        self.assertIn(SUBJECT_IRI, coverage.mapped_object_properties)
+        self.assertNotIn(SUBJECT_IRI, coverage.property_typing_only_terms)
+        self.assertNotIn(SUBJECT_IRI, coverage.unmapped_object_properties)
 
-    def test_domain_range_only_property_remains_unmapped_in_coverage(self) -> None:
+    def coverage_classification_fixture(self):
         processed, _ = self.process(
             [
+                ("sosa:actsOnProperty", "rdfs:subPropertyOf", "sosa:isActedOnBy"),
                 (SUBJECT, "rdfs:domain", "sosa:Observation"),
-                (SUBJECT, "rdfs:range", "sosa:FeatureOfInterest"),
+                ("sosa:hasResult", "rdfs:range", "sosa:Result"),
             ]
         )
-        coverage = coms.build_coverage(processed, [], self.root / "coverage.md")
+        return coms.build_coverage(processed, [], self.root / "coverage.md")
 
-        self.assertNotIn(SUBJECT_IRI, coverage.mapped_terms)
-        self.assertNotIn(SUBJECT_IRI, coverage.mapped_object_properties)
-        self.assertIn(SUBJECT_IRI, coverage.unmapped_object_properties)
-        self.assertIn(SUBJECT_IRI, coverage.listed_terms)
-        self.assertIn(SUBJECT_IRI, coverage.listed_unmapped_terms)
-        self.assertNotIn(SUBJECT_IRI, coverage.absent_terms)
+    def test_relation_mapped_property_is_mapped_and_covered(self) -> None:
+        coverage = self.coverage_classification_fixture()
+
+        self.assertIn(MAPPED_PROPERTY, coverage.mapped_object_properties)
+        self.assertNotIn(MAPPED_PROPERTY, coverage.property_typing_only_terms)
+        self.assertNotIn(MAPPED_PROPERTY, coverage.unmapped_object_properties)
+
+    def test_domain_only_property_is_covered_but_not_mapped(self) -> None:
+        coverage = self.coverage_classification_fixture()
+
+        self.assertNotIn(DOMAIN_ONLY_PROPERTY, coverage.mapped_object_properties)
+        self.assertIn(DOMAIN_ONLY_PROPERTY, coverage.property_typing_only_terms)
+        self.assertNotIn(DOMAIN_ONLY_PROPERTY, coverage.unmapped_object_properties)
+
+    def test_range_only_property_is_covered_but_not_mapped(self) -> None:
+        coverage = self.coverage_classification_fixture()
+
+        self.assertNotIn(RANGE_ONLY_PROPERTY, coverage.mapped_object_properties)
+        self.assertIn(RANGE_ONLY_PROPERTY, coverage.property_typing_only_terms)
+        self.assertNotIn(RANGE_ONLY_PROPERTY, coverage.unmapped_object_properties)
+
+    def test_genuinely_uncovered_property_remains_unmapped(self) -> None:
+        coverage = self.coverage_classification_fixture()
+
+        self.assertNotIn(UNCOVERED_PROPERTY, coverage.mapped_object_properties)
+        self.assertNotIn(UNCOVERED_PROPERTY, coverage.property_typing_only_terms)
+        self.assertIn(UNCOVERED_PROPERTY, coverage.unmapped_object_properties)
+        self.assertEqual(
+            coverage.query_unmapped_count,
+            len(coverage.unmapped_classes) + len(coverage.unmapped_object_properties),
+        )
 
 
 if __name__ == "__main__":

--- a/tools/generate_mapping_from_coms.py
+++ b/tools/generate_mapping_from_coms.py
@@ -244,6 +244,7 @@ class HermitResult:
 class CoverageResult:
     source_terms: dict[URIRef, str]
     mapped_terms: set[URIRef]
+    property_typing_terms: set[URIRef]
     listed_terms: set[URIRef]
     explicit_blank_terms: set[URIRef]
     spreadsheet_missing_subjects: set[str]
@@ -271,7 +272,9 @@ class CoverageResult:
         return {
             term
             for term, kind in self.source_terms.items()
-            if kind == "object_property" and term not in self.mapped_terms
+            if kind == "object_property"
+            and term not in self.mapped_terms
+            and term not in self.property_typing_terms
         }
 
     @property
@@ -279,8 +282,8 @@ class CoverageResult:
         return set(self.source_terms) - self.listed_terms
 
     @property
-    def listed_unmapped_terms(self) -> set[URIRef]:
-        return self.listed_terms - self.mapped_terms - self.explicit_blank_terms
+    def property_typing_only_terms(self) -> set[URIRef]:
+        return self.property_typing_terms - self.mapped_terms
 
 
 @dataclass
@@ -972,6 +975,11 @@ def build_coverage(
     }
 
     mapped_terms = {row.subject for row in processed_rows if row.predicate in MAPPING_PREDICATES}
+    property_typing_terms = {
+        row.subject
+        for row in processed_rows
+        if row.predicate in DOMAIN_RANGE_PREDICATES
+    }
     listed_terms = {row.subject for row in processed_rows}
     explicit_blank_terms = {row.subject for row in processed_rows if not row.predicate}
     missing_subjects = set(source_subject_errors)
@@ -983,10 +991,10 @@ def build_coverage(
         coverage_graph.add((term, COMS_COVERAGE.sourceKind, Literal(kind)))
         if term in mapped_terms:
             status = "mapped"
+        elif term in property_typing_terms:
+            status = "covered_by_property_typing"
         elif term in explicit_blank_terms:
             status = "explicitly_unmapped"
-        elif term in listed_terms:
-            status = "listed_unmapped"
         else:
             status = "absent_from_spreadsheet"
         coverage_graph.add((term, COMS_COVERAGE.coverageStatus, Literal(status)))
@@ -995,6 +1003,7 @@ def build_coverage(
     result = CoverageResult(
         source_terms=source_terms,
         mapped_terms=mapped_terms,
+        property_typing_terms=property_typing_terms,
         listed_terms=listed_terms,
         explicit_blank_terms=explicit_blank_terms,
         spreadsheet_missing_subjects=missing_subjects,
@@ -1022,7 +1031,7 @@ def write_coverage_report(path: Path, coverage: CoverageResult) -> None:
         "",
         "The source term inventory is produced by `queries/source-classes-and-object-properties.rq`. "
         "Unmapped terms are selected from the generated coverage graph by `queries/unmapped-source-terms.rq`.",
-        "A domain or range row lists a property for local typing review but does not count it as relation-mapped; only subproperty, equivalent-property, or property-chain rows do so.",
+        "A domain or range row covers a property for source-term coverage but does not count it as relation-mapped; only subproperty, equivalent-property, or property-chain rows do so.",
         "",
         "## Summary",
         "",
@@ -1034,7 +1043,7 @@ def write_coverage_report(path: Path, coverage: CoverageResult) -> None:
         f"| mapped object properties | {len(coverage.mapped_object_properties)} |",
         f"| unmapped object properties | {len(coverage.unmapped_object_properties)} |",
         f"| explicitly listed blank mappings | {len(coverage.explicit_blank_terms)} |",
-        f"| listed only in domain/range property-typing rows | {len(coverage.listed_unmapped_terms)} |",
+        f"| listed only in domain/range property-typing rows | {len(coverage.property_typing_only_terms)} |",
         f"| source terms absent from spreadsheet | {len(coverage.absent_terms)} |",
         f"| spreadsheet subjects not found in source ontologies | {len(coverage.spreadsheet_missing_subjects)} |",
         f"| unmapped rows returned by SPARQL coverage query | {coverage.query_unmapped_count} |",
@@ -1061,7 +1070,7 @@ def write_coverage_report(path: Path, coverage: CoverageResult) -> None:
         "",
         "## Listed Only In Domain/Range Property-Typing Rows",
         "",
-        *format_term_list(coverage.listed_unmapped_terms),
+        *format_term_list(coverage.property_typing_only_terms),
         "",
         "## Source Terms Absent From Spreadsheet",
         "",
@@ -1546,7 +1555,7 @@ def write_generation_report(
                 f"| mapped object properties | {len(coverage.mapped_object_properties)} |",
                 f"| unmapped object properties | {len(coverage.unmapped_object_properties)} |",
                 f"| explicitly listed blank mappings | {len(coverage.explicit_blank_terms)} |",
-                f"| listed only in domain/range property-typing rows | {len(coverage.listed_unmapped_terms)} |",
+                f"| listed only in domain/range property-typing rows | {len(coverage.property_typing_only_terms)} |",
                 f"| source terms absent from spreadsheet | {len(coverage.absent_terms)} |",
                 f"| spreadsheet subjects not found in source ontologies | {len(coverage.spreadsheet_missing_subjects)} |",
             ]
@@ -1652,7 +1661,7 @@ def write_summary_json(
             "mapped_object_properties": len(coverage.mapped_object_properties),
             "unmapped_object_properties": len(coverage.unmapped_object_properties),
             "explicitly_listed_blank_mappings": len(coverage.explicit_blank_terms),
-            "listed_only_in_domain_range_rows": len(coverage.listed_unmapped_terms),
+            "listed_only_in_domain_range_rows": len(coverage.property_typing_only_terms),
             "source_terms_absent_from_spreadsheet": len(coverage.absent_terms),
             "spreadsheet_subjects_not_found": len(coverage.spreadsheet_missing_subjects),
         },

--- a/tools/watch_coms_mapping.py
+++ b/tools/watch_coms_mapping.py
@@ -56,6 +56,26 @@ def last_good_status(workbook_hash: str | None, check_passed: bool) -> str:
     return f"preserved (workbook SHA-256 {payload.get('workbook_sha256', 'unknown')})"
 
 
+def last_success_coverage_status() -> str | None:
+    try:
+        payload = json.loads(LAST_SUCCESS.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    counts = payload.get("source_term_counts")
+    if not isinstance(counts, dict):
+        return None
+    mapped = counts.get("mapped_object_properties")
+    typing_only = counts.get("listed_only_in_domain_range_rows")
+    unmapped = counts.get("unmapped_object_properties")
+    if any(value is None for value in (mapped, typing_only, unmapped)):
+        return None
+    return (
+        f"Coverage counts: mapped object properties {mapped}; "
+        f"listed only in domain/range property-typing rows {typing_only}; "
+        f"unmapped object properties {unmapped}"
+    )
+
+
 def run_check(trigger: str, workbook_hash: str | None) -> bool:
     started = time.perf_counter()
     print(f"Detection time: {now_text()}", flush=True)
@@ -67,6 +87,10 @@ def run_check(trigger: str, workbook_hash: str | None) -> bool:
     print(f"Check result: {'PASS' if passed else f'FAIL ({proc.returncode})'}", flush=True)
     print(f"Duration: {elapsed:.2f} seconds", flush=True)
     print(f"Last-good output status: {last_good_status(workbook_hash, passed)}", flush=True)
+    if passed:
+        coverage_status = last_success_coverage_status()
+        if coverage_status is not None:
+            print(coverage_status, flush=True)
     return passed
 
 


### PR DESCRIPTION
# Treat domain and range rows as coverage

## Changed files

- queries/unmapped-source-terms.rq
- reports/coms-automatic-validation-setup.md
- reports/coms-generation-validation.md
- reports/coms-source-term-coverage.md
- tests/test_generate_mapping_from_coms.py
- tools/generate_mapping_from_coms.py
- tools/watch_coms_mapping.py

## Validation

- Human gate required: confirm validation output before merge.
