### PR TITLE
Add COMS product disposition accounting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: validate validate-write audit-write legacy-audit-write compile check check-coms check-coms-row-identities check-publication-metadata watch-coms coms-status post-merge-check status diffstat
+.PHONY: validate validate-write audit-write legacy-audit-write compile check check-coms check-coms-row-identities check-coms-product-dispositions check-publication-metadata watch-coms coms-status post-merge-check status diffstat
 
 validate:
 	python tools/run_validation_suite.py
@@ -23,6 +23,7 @@ compile:
 		tools/test_instance_data.py \
 		tools/compare_mappings.py \
 		tools/coms_row_identity.py \
+		tools/product_dispositions.py \
 		tools/generate_mapping_from_coms.py \
 		tools/check_coms_mapping.py \
 		tools/watch_coms_mapping.py \
@@ -30,6 +31,7 @@ compile:
 		tools/check_publication_metadata.py \
 		tests/test_generate_mapping_from_coms.py \
 		tests/test_coms_row_identity.py \
+		tests/test_product_dispositions.py \
 		tests/test_publication_metadata.py \
 		tools/workflow_check.py
 
@@ -43,6 +45,10 @@ check-coms:
 check-coms-row-identities:
 	python -m unittest discover -s tests -p 'test_coms_row_identity.py'
 	python -m unittest discover -s tests -p 'test_generate_mapping_from_coms.py'
+	python tools/check_coms_mapping.py --check-only
+
+check-coms-product-dispositions:
+	python -m unittest discover -s tests -p 'test_product_dispositions.py'
 	python tools/check_coms_mapping.py --check-only
 
 watch-coms:

--- a/README.md
+++ b/README.md
@@ -33,6 +33,12 @@ Every governed row in `mappings/SSN2BFO-COMS.xlsx` has a persistent `coms:RowID`
 
 RowIDs must never be reused. Deletion, retirement, replacement, splitting, and merging of governed rows remain prohibited until a governed lineage and retirement registry exists. Two active rows may not resolve to the same canonical authoritative axiom, even when their RowIDs, locations, or rationales differ. Run the focused identity and normal COMS checks with `make check-coms-row-identities`.
 
+### COMS product dispositions
+
+`reports/coms-product-dispositions.json` is generated evidence accounting for every governed row and canonical authoritative axiom across the integrated, alignment-core, strict-BFO-mapping, BFO-projection, and CCO-extension products. It is derived from COMS RowIDs, canonical expressions, and `config/publication-metadata.toml`; it is not an editable mapping authority.
+
+The artifact classifies axioms as target-neutral, BFO-bearing, CCO-bearing, or mixed BFO/CCO and records the approved per-product status. CCO-bearing and mixed axioms remain explicitly deferred for strict BFO transformation and BFO projection because no transformation rule or weakened projection is approved. Modular ontology generation and transformations remain unimplemented. Run the focused nonmutating gate with `make check-coms-product-dispositions`.
+
 ## Validation environment
 
 `make check` is the canonical authoritative validation gate used both locally and by hosted CI. It validates the COMS workbook and authoritative root mapping, including freshness, source coverage, focused generator tests, example checks, HermiT consistency, Python compilation, whitespace, and repository cleanliness as currently implemented.

--- a/reports/coms-automatic-validation-setup.md
+++ b/reports/coms-automatic-validation-setup.md
@@ -37,7 +37,7 @@ The default mode is `--update`. For a non-mutating freshness and quality gate, u
 python tools/check_coms_mapping.py --check-only
 ```
 
-`--check-only` fails when the workbook hash, generator hash, authoritative ontology hash, maintained reports, or regenerated semantic products do not match. It does not rewrite tracked artifacts. The ordinary validation suite invokes this mode.
+`--check-only` fails when the workbook hash, generator or identity/disposition module hashes, publication-metadata hash, authoritative ontology hash, maintained reports, or regenerated semantic products do not match. It does not rewrite tracked artifacts. The ordinary validation suite invokes this mode.
 
 Current local status is available with:
 
@@ -74,7 +74,8 @@ Each complete check:
 8. Applies the established import and SOSA functional/inverse-functional cleanup.
 9. Runs HermiT and requires zero `owl:Nothing` and zero unexpected named unsatisfiable classes.
 10. Requires all generated reports and validates hash-based source metadata.
-11. Runs `git diff --check`.
+11. Derives and reconciles all per-product row and canonical-axiom dispositions, including target-vocabulary categories and canonical JSON serialization.
+12. Runs `git diff --check`.
 
 The generated validation report records the workbook SHA-256, generator-file SHA-256, UTC generation timestamp, maintained ontology path, and generated ontology SHA-256. Freshness never relies on timestamps alone.
 
@@ -86,8 +87,11 @@ Generation and validation happen under `.cache/coms/`. The maintained files are 
 - `reports/coms-generation-validation.md`
 - `reports/coms-source-term-coverage.md`
 - `reports/coms-vs-pre-coms-legacy-diff.md`
+- `reports/coms-product-dispositions.json`
 
 Each replacement is atomic. If any check fails, the maintained last-known-good files remain unchanged. A post-replacement whitespace failure also triggers rollback from temporary backups.
+
+The product-disposition JSON is generated evidence rather than an editable mapping source. It is published in the same transaction as the ontology and other reports, so no maintained output can become newer or older than the disposition accounting.
 
 `SSN2BFO.ttl` is the authoritative generated publication artifact. `mappings/SSN2BFO-COMS.xlsx` is its sole editable mapping source, and `legacy/SSN2BFO-pre-COMS.ttl` is used only as the frozen informational comparison baseline.
 

--- a/reports/coms-generation-validation.md
+++ b/reports/coms-generation-validation.md
@@ -9,11 +9,15 @@ Freshness is determined from content hashes, not file timestamps.
 | Item | Value |
 |---|---|
 | workbook SHA-256 | `febb8b58b4a701cead90697412a9721112c4e6dfd3af47d3c3a77c93754690e0` |
-| generator SHA-256 | `810e1ea5ccbf0efe94d8783af618552407ba096f0f658e543987c964e0f59a51` |
+| generator SHA-256 | `8a74fd84c79314fc43f7f1fd85af54c8717588bd40c1d1ce8fbfc2bb3d65eb78` |
 | row-identity module SHA-256 | `9af9f9ed5b9321040428960e1293cffe27ebb48cc7a68a71f53f84cf18a60425` |
-| generation timestamp (UTC) | `2026-07-15T15:02:03+00:00` |
+| product-disposition module SHA-256 | `987fa4809e5780831f9e50e0b5cacc52888284fc7eae82a0928056c45c14a7d8` |
+| publication metadata SHA-256 | `a25196f873bc849a0a5b33012c22312d3ea9e70504219c9e781e77e595993564` |
+| generation timestamp (UTC) | `2026-07-15T16:33:02+00:00` |
 | maintained ontology path | `SSN2BFO.ttl` |
 | generated ontology SHA-256 | `fd6eadf1bcbd4bfc6dc06df58915116d8f909bc8c3238592b1f13509cec47d16` |
+| maintained product-disposition path | `reports/coms-product-dispositions.json` |
+| product-disposition JSON SHA-256 | `d2a97c288d107dd0242d59836b751a1a864c5a69d9865c340d50bd59fe629393` |
 
 ## Workbook
 
@@ -260,6 +264,21 @@ The RowID is persistent identity; the source-expression SHA-256 excludes locatio
 | `urn:uuid:b7873da3-fc78-4a2a-92e1-ef83efb6d600` | `Sheet2` | 61 | `range` | `7867920787556af6ea7cdcfd036b466545cf68a1724655dad17b1288b19f62d8` | `ObjectPropertyRange(<http://www.w3.org/ns/ssn/isProxyFor> <http://www.w3.org/ns/ssn/Property>)` | _(blank)_ |
 | `urn:uuid:51c8556f-9b82-4113-a9d7-c733e70cf8cd` | `Sheet2` | 62 | `object_property_mapping` | `fe8a979e62b1dfe2f2f00c6a65df77262575c4c615fa293e1c5f5095ef61b44c` | `SubObjectPropertyOf(<http://www.w3.org/ns/ssn/wasOriginatedBy> <https://www.commoncoreontologies.org/ont00001962>)` | _(blank)_ |
 
+## Product Dispositions
+
+- Path: `reports/coms-product-dispositions.json`
+- Schema version: `1`
+- Product order: `integrated`, `alignment_core`, `strict_bfo_mapping`, `bfo_projection`, `cco_extension`
+- Governed rows: 105
+- Canonical authoritative axioms: 105
+- Zero-axiom rows: 0
+- Target-neutral axioms: 29
+- BFO-bearing axioms: 19
+- CCO-bearing axioms: 25
+- Mixed BFO/CCO axioms: 32
+- Disposition reconciliation and canonical serialization: PASS
+- No lossless transformation or weakened projection is approved by this artifact.
+
 ## Generated Ontology
 
 - Path: `SSN2BFO.ttl`
@@ -429,4 +448,4 @@ This section records mapping and domain/range property-typing rows after parsing
 
 ## Runtime
 
-- Runtime seconds: 3.12
+- Runtime seconds: 3.19

--- a/reports/coms-product-dispositions.json
+++ b/reports/coms-product-dispositions.json
@@ -1,0 +1,6432 @@
+{
+  "schema_version": 1,
+  "canonicalization_version": "coms-row-expression-v1",
+  "workbook_sha256": "febb8b58b4a701cead90697412a9721112c4e6dfd3af47d3c3a77c93754690e0",
+  "generator_sha256": "8a74fd84c79314fc43f7f1fd85af54c8717588bd40c1d1ce8fbfc2bb3d65eb78",
+  "row_identity_module_sha256": "9af9f9ed5b9321040428960e1293cffe27ebb48cc7a68a71f53f84cf18a60425",
+  "disposition_module_sha256": "987fa4809e5780831f9e50e0b5cacc52888284fc7eae82a0928056c45c14a7d8",
+  "publication_metadata_sha256": "a25196f873bc849a0a5b33012c22312d3ea9e70504219c9e781e77e595993564",
+  "product_order": [
+    "integrated",
+    "alignment_core",
+    "strict_bfo_mapping",
+    "bfo_projection",
+    "cco_extension"
+  ],
+  "summary": {
+    "governed_row_count": 105,
+    "unique_row_id_count": 105,
+    "authoritative_axiom_count": 105,
+    "unique_authoritative_axiom_count": 105,
+    "zero_axiom_row_count": 0,
+    "target_neutral_axiom_count": 29,
+    "bfo_bearing_axiom_count": 19,
+    "cco_bearing_axiom_count": 25,
+    "mixed_bfo_cco_axiom_count": 32,
+    "class_mapping_row_count": 44,
+    "relation_mapping_row_count": 25,
+    "property_chain_row_count": 5,
+    "property_typing_row_count": 31,
+    "explicitly_unmapped_row_count": 0
+  },
+  "rows": [
+    {
+      "row_id": "urn:uuid:01085646-1b07-4c69-a39a-0c5c8ab53d33",
+      "location": {
+        "worksheet": "Sheet2",
+        "row": 26
+      },
+      "subject": {
+        "lexical": "sosa:madeActuation",
+        "iri": "http://www.w3.org/ns/sosa/madeActuation"
+      },
+      "predicate": {
+        "lexical": "rdfs:domain",
+        "iri": "http://www.w3.org/2000/01/rdf-schema#domain"
+      },
+      "authoritative_target_lexical": "sosa:Actuator",
+      "canonical_row_expression": {
+        "canonicalization": "coms-row-expression-v1",
+        "mapping_type": "domain",
+        "predicate_iri": "http://www.w3.org/2000/01/rdf-schema#domain",
+        "subject_iri": "http://www.w3.org/ns/sosa/madeActuation",
+        "target": "<http://www.w3.org/ns/sosa/Actuator>"
+      },
+      "source_expression_sha256": "83aead1b2757da7978dc77d9a7e2dfb0704c5df30337ee02d7d954dbedefac27",
+      "mapping_type": "domain",
+      "coverage_classification": "property_typing",
+      "reasoning": "",
+      "authoritative_axioms": [
+        {
+          "axiom_id": "sha256:d26c043966cd9ac909de23299f25178e558bdf2b31d0c4cdceef63feca9f1367",
+          "canonical_expression": "ObjectPropertyDomain(<http://www.w3.org/ns/sosa/madeActuation> <http://www.w3.org/ns/sosa/Actuator>)",
+          "referenced_iris": [
+            "http://www.w3.org/2000/01/rdf-schema#domain",
+            "http://www.w3.org/ns/sosa/Actuator",
+            "http://www.w3.org/ns/sosa/madeActuation"
+          ],
+          "target_category": "target_neutral",
+          "product_dispositions": {
+            "integrated": {
+              "status": "emitted_unchanged"
+            },
+            "alignment_core": {
+              "status": "emitted_unchanged"
+            },
+            "strict_bfo_mapping": {
+              "status": "provided_through_import"
+            },
+            "bfo_projection": {
+              "status": "provided_transitively"
+            },
+            "cco_extension": {
+              "status": "provided_transitively"
+            }
+          }
+        }
+      ],
+      "row_product_dispositions": null
+    },
+    {
+      "row_id": "urn:uuid:01b1aff2-a12b-430b-9775-b43241c3a7cf",
+      "location": {
+        "worksheet": "Sheet2",
+        "row": 7
+      },
+      "subject": {
+        "lexical": "sosa:hasFeatureOfInterest",
+        "iri": "http://www.w3.org/ns/sosa/hasFeatureOfInterest"
+      },
+      "predicate": {
+        "lexical": "rdfs:range",
+        "iri": "http://www.w3.org/2000/01/rdf-schema#range"
+      },
+      "authoritative_target_lexical": "sosa:FeatureOfInterest",
+      "canonical_row_expression": {
+        "canonicalization": "coms-row-expression-v1",
+        "mapping_type": "range",
+        "predicate_iri": "http://www.w3.org/2000/01/rdf-schema#range",
+        "subject_iri": "http://www.w3.org/ns/sosa/hasFeatureOfInterest",
+        "target": "<http://www.w3.org/ns/sosa/FeatureOfInterest>"
+      },
+      "source_expression_sha256": "6408065f23d5e5840f14b6e0929330e9b7be02c7100203216a37d2ad7c9f5c0c",
+      "mapping_type": "range",
+      "coverage_classification": "property_typing",
+      "reasoning": "",
+      "authoritative_axioms": [
+        {
+          "axiom_id": "sha256:9922788e81b846ae627e86d59ed8a00a0ea0c82441995dff3268e55339cbeaba",
+          "canonical_expression": "ObjectPropertyRange(<http://www.w3.org/ns/sosa/hasFeatureOfInterest> <http://www.w3.org/ns/sosa/FeatureOfInterest>)",
+          "referenced_iris": [
+            "http://www.w3.org/2000/01/rdf-schema#range",
+            "http://www.w3.org/ns/sosa/FeatureOfInterest",
+            "http://www.w3.org/ns/sosa/hasFeatureOfInterest"
+          ],
+          "target_category": "target_neutral",
+          "product_dispositions": {
+            "integrated": {
+              "status": "emitted_unchanged"
+            },
+            "alignment_core": {
+              "status": "emitted_unchanged"
+            },
+            "strict_bfo_mapping": {
+              "status": "provided_through_import"
+            },
+            "bfo_projection": {
+              "status": "provided_transitively"
+            },
+            "cco_extension": {
+              "status": "provided_transitively"
+            }
+          }
+        }
+      ],
+      "row_product_dispositions": null
+    },
+    {
+      "row_id": "urn:uuid:02294d3c-f88d-4d3d-921e-8d6c00457476",
+      "location": {
+        "worksheet": "Sheet2",
+        "row": 15
+      },
+      "subject": {
+        "lexical": "ssn:isPropertyOf",
+        "iri": "http://www.w3.org/ns/ssn/isPropertyOf"
+      },
+      "predicate": {
+        "lexical": "rdfs:domain",
+        "iri": "http://www.w3.org/2000/01/rdf-schema#domain"
+      },
+      "authoritative_target_lexical": "(bfo:SpecificallyDependentContinuant or bfo:ProcessProfile)",
+      "canonical_row_expression": {
+        "canonicalization": "coms-row-expression-v1",
+        "mapping_type": "domain",
+        "predicate_iri": "http://www.w3.org/2000/01/rdf-schema#domain",
+        "subject_iri": "http://www.w3.org/ns/ssn/isPropertyOf",
+        "target": "ObjectUnionOf(<http://purl.obolibrary.org/obo/BFO_0000020> <http://purl.obolibrary.org/obo/BFO_0000144>)"
+      },
+      "source_expression_sha256": "2f4f4b8a49cd6309baf0b3b420cca9f68d899f4d6847a47f1045f97fd4eb90ec",
+      "mapping_type": "domain",
+      "coverage_classification": "property_typing",
+      "reasoning": "",
+      "authoritative_axioms": [
+        {
+          "axiom_id": "sha256:0caeec31770247fe2efeb443e85fefe9b4e1648a7d9569adc35d2972b77682b1",
+          "canonical_expression": "ObjectPropertyDomain(<http://www.w3.org/ns/ssn/isPropertyOf> ObjectUnionOf(<http://purl.obolibrary.org/obo/BFO_0000020> <http://purl.obolibrary.org/obo/BFO_0000144>))",
+          "referenced_iris": [
+            "http://purl.obolibrary.org/obo/BFO_0000020",
+            "http://purl.obolibrary.org/obo/BFO_0000144",
+            "http://www.w3.org/2000/01/rdf-schema#domain",
+            "http://www.w3.org/ns/ssn/isPropertyOf"
+          ],
+          "target_category": "bfo_bearing",
+          "product_dispositions": {
+            "integrated": {
+              "status": "emitted_unchanged"
+            },
+            "alignment_core": {
+              "status": "not_applicable",
+              "reason_code": "TARGET_SPECIFIC"
+            },
+            "strict_bfo_mapping": {
+              "status": "emitted_unchanged"
+            },
+            "bfo_projection": {
+              "status": "provided_through_import"
+            },
+            "cco_extension": {
+              "status": "provided_through_import"
+            }
+          }
+        }
+      ],
+      "row_product_dispositions": null
+    },
+    {
+      "row_id": "urn:uuid:06782965-88c5-4345-ab99-ea027513ec86",
+      "location": {
+        "worksheet": "Sheet1",
+        "row": 6
+      },
+      "subject": {
+        "lexical": "sosa:FeatureOfInterest",
+        "iri": "http://www.w3.org/ns/sosa/FeatureOfInterest"
+      },
+      "predicate": {
+        "lexical": "rdfs:subClassOf",
+        "iri": "http://www.w3.org/2000/01/rdf-schema#subClassOf"
+      },
+      "authoritative_target_lexical": "(bfo:SpecificallyDependentContinuant or bfo:ProcessProfile or bfo:MaterialEntity or bfo:Process)",
+      "canonical_row_expression": {
+        "canonicalization": "coms-row-expression-v1",
+        "mapping_type": "class_mapping",
+        "predicate_iri": "http://www.w3.org/2000/01/rdf-schema#subClassOf",
+        "subject_iri": "http://www.w3.org/ns/sosa/FeatureOfInterest",
+        "target": "ObjectUnionOf(<http://purl.obolibrary.org/obo/BFO_0000015> <http://purl.obolibrary.org/obo/BFO_0000020> <http://purl.obolibrary.org/obo/BFO_0000040> <http://purl.obolibrary.org/obo/BFO_0000144>)"
+      },
+      "source_expression_sha256": "c8da57437716d5da9ab48656f3c97b921c4501b95ba843edb14345f62ecd041d",
+      "mapping_type": "class_mapping",
+      "coverage_classification": "class_mapping",
+      "reasoning": "Direct alignment deferred because SOSA permits a FeatureOfInterest to be property-like. Restricting every FeatureOfInterest to a material entity or process makes the SSN survival-range pattern unsatisfiable.",
+      "authoritative_axioms": [
+        {
+          "axiom_id": "sha256:ebc5a554a5a02d96a177a4905b1f58369c2a1b3cb0c5e952b40208fd3d70f720",
+          "canonical_expression": "SubClassOf(<http://www.w3.org/ns/sosa/FeatureOfInterest> ObjectUnionOf(<http://purl.obolibrary.org/obo/BFO_0000015> <http://purl.obolibrary.org/obo/BFO_0000020> <http://purl.obolibrary.org/obo/BFO_0000040> <http://purl.obolibrary.org/obo/BFO_0000144>))",
+          "referenced_iris": [
+            "http://purl.obolibrary.org/obo/BFO_0000015",
+            "http://purl.obolibrary.org/obo/BFO_0000020",
+            "http://purl.obolibrary.org/obo/BFO_0000040",
+            "http://purl.obolibrary.org/obo/BFO_0000144",
+            "http://www.w3.org/2000/01/rdf-schema#subClassOf",
+            "http://www.w3.org/ns/sosa/FeatureOfInterest"
+          ],
+          "target_category": "bfo_bearing",
+          "product_dispositions": {
+            "integrated": {
+              "status": "emitted_unchanged"
+            },
+            "alignment_core": {
+              "status": "not_applicable",
+              "reason_code": "TARGET_SPECIFIC"
+            },
+            "strict_bfo_mapping": {
+              "status": "emitted_unchanged"
+            },
+            "bfo_projection": {
+              "status": "provided_through_import"
+            },
+            "cco_extension": {
+              "status": "provided_through_import"
+            }
+          }
+        }
+      ],
+      "row_product_dispositions": null
+    },
+    {
+      "row_id": "urn:uuid:0f9d6fa9-00b9-4602-b31d-9e205f53e67d",
+      "location": {
+        "worksheet": "Sheet2",
+        "row": 27
+      },
+      "subject": {
+        "lexical": "sosa:madeActuation",
+        "iri": "http://www.w3.org/ns/sosa/madeActuation"
+      },
+      "predicate": {
+        "lexical": "rdfs:range",
+        "iri": "http://www.w3.org/2000/01/rdf-schema#range"
+      },
+      "authoritative_target_lexical": "sosa:Actuation",
+      "canonical_row_expression": {
+        "canonicalization": "coms-row-expression-v1",
+        "mapping_type": "range",
+        "predicate_iri": "http://www.w3.org/2000/01/rdf-schema#range",
+        "subject_iri": "http://www.w3.org/ns/sosa/madeActuation",
+        "target": "<http://www.w3.org/ns/sosa/Actuation>"
+      },
+      "source_expression_sha256": "38b45e7132f890f685473157123fd00617403ef84b475be0696941be9ce100d3",
+      "mapping_type": "range",
+      "coverage_classification": "property_typing",
+      "reasoning": "",
+      "authoritative_axioms": [
+        {
+          "axiom_id": "sha256:41080a7afb8263845cbd910a2a4c6d5bfec9b2b21126a5acd1c037b7e404b797",
+          "canonical_expression": "ObjectPropertyRange(<http://www.w3.org/ns/sosa/madeActuation> <http://www.w3.org/ns/sosa/Actuation>)",
+          "referenced_iris": [
+            "http://www.w3.org/2000/01/rdf-schema#range",
+            "http://www.w3.org/ns/sosa/Actuation",
+            "http://www.w3.org/ns/sosa/madeActuation"
+          ],
+          "target_category": "target_neutral",
+          "product_dispositions": {
+            "integrated": {
+              "status": "emitted_unchanged"
+            },
+            "alignment_core": {
+              "status": "emitted_unchanged"
+            },
+            "strict_bfo_mapping": {
+              "status": "provided_through_import"
+            },
+            "bfo_projection": {
+              "status": "provided_transitively"
+            },
+            "cco_extension": {
+              "status": "provided_transitively"
+            }
+          }
+        }
+      ],
+      "row_product_dispositions": null
+    },
+    {
+      "row_id": "urn:uuid:124e6b06-906a-47be-a459-92babef3992e",
+      "location": {
+        "worksheet": "Sheet1",
+        "row": 17
+      },
+      "subject": {
+        "lexical": "ssn-system:Frequency",
+        "iri": "http://www.w3.org/ns/ssn/systems/Frequency"
+      },
+      "predicate": {
+        "lexical": "rdfs:subClassOf",
+        "iri": "http://www.w3.org/2000/01/rdf-schema#subClassOf"
+      },
+      "authoritative_target_lexical": "bfo:Function and bfo:has_realization some (cco:PlannedAct and bfo:has_occurrent_part some (cco:Frequency and cco:prescribed_by some cco:ArtifactFunctionSpecification))",
+      "canonical_row_expression": {
+        "canonicalization": "coms-row-expression-v1",
+        "mapping_type": "class_mapping",
+        "predicate_iri": "http://www.w3.org/2000/01/rdf-schema#subClassOf",
+        "subject_iri": "http://www.w3.org/ns/ssn/systems/Frequency",
+        "target": "ObjectIntersectionOf(<http://purl.obolibrary.org/obo/BFO_0000034> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000054> ObjectIntersectionOf(<https://www.commoncoreontologies.org/ont00000228> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000117> ObjectIntersectionOf(<https://www.commoncoreontologies.org/ont00001047> ObjectSomeValuesFrom(<https://www.commoncoreontologies.org/ont00001920> <https://www.commoncoreontologies.org/ont00000118>))))))"
+      },
+      "source_expression_sha256": "478f26ce5b36bc0249f3631e2a1cb1374a9782ad20d6491b57ce2af4a88ac16a",
+      "mapping_type": "class_mapping",
+      "coverage_classification": "class_mapping",
+      "reasoning": "",
+      "authoritative_axioms": [
+        {
+          "axiom_id": "sha256:d0be6196d522ed9650cdfebad33b965d523868a68682405423324b28c54f1e82",
+          "canonical_expression": "SubClassOf(<http://www.w3.org/ns/ssn/systems/Frequency> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/BFO_0000034> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000054> ObjectIntersectionOf(<https://www.commoncoreontologies.org/ont00000228> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000117> ObjectIntersectionOf(<https://www.commoncoreontologies.org/ont00001047> ObjectSomeValuesFrom(<https://www.commoncoreontologies.org/ont00001920> <https://www.commoncoreontologies.org/ont00000118>)))))))",
+          "referenced_iris": [
+            "http://purl.obolibrary.org/obo/BFO_0000034",
+            "http://purl.obolibrary.org/obo/BFO_0000054",
+            "http://purl.obolibrary.org/obo/BFO_0000117",
+            "http://www.w3.org/2000/01/rdf-schema#subClassOf",
+            "http://www.w3.org/ns/ssn/systems/Frequency",
+            "https://www.commoncoreontologies.org/ont00000118",
+            "https://www.commoncoreontologies.org/ont00000228",
+            "https://www.commoncoreontologies.org/ont00001047",
+            "https://www.commoncoreontologies.org/ont00001920"
+          ],
+          "target_category": "mixed_bfo_cco",
+          "product_dispositions": {
+            "integrated": {
+              "status": "emitted_unchanged"
+            },
+            "alignment_core": {
+              "status": "not_applicable",
+              "reason_code": "TARGET_SPECIFIC"
+            },
+            "strict_bfo_mapping": {
+              "status": "deferred",
+              "reason_code": "NO_APPROVED_TRANSFORMATION_RULE"
+            },
+            "bfo_projection": {
+              "status": "deferred",
+              "reason_code": "NO_APPROVED_TRANSFORMATION_RULE"
+            },
+            "cco_extension": {
+              "status": "emitted_unchanged"
+            }
+          }
+        }
+      ],
+      "row_product_dispositions": null
+    },
+    {
+      "row_id": "urn:uuid:158c0cce-2c1d-4baf-90b5-243d7cdce34d",
+      "location": {
+        "worksheet": "Sheet2",
+        "row": 56
+      },
+      "subject": {
+        "lexical": "ssn:hasSubSystem",
+        "iri": "http://www.w3.org/ns/ssn/hasSubSystem"
+      },
+      "predicate": {
+        "lexical": "rdfs:subPropertyOf",
+        "iri": "http://www.w3.org/2000/01/rdf-schema#subPropertyOf"
+      },
+      "authoritative_target_lexical": "bfo:has_continuant_part",
+      "canonical_row_expression": {
+        "canonicalization": "coms-row-expression-v1",
+        "mapping_type": "object_property_mapping",
+        "predicate_iri": "http://www.w3.org/2000/01/rdf-schema#subPropertyOf",
+        "subject_iri": "http://www.w3.org/ns/ssn/hasSubSystem",
+        "target": "<http://purl.obolibrary.org/obo/BFO_0000178>"
+      },
+      "source_expression_sha256": "71441321015321658bd32ac0185d96d0af0887865756974b4a1839835f39fabc",
+      "mapping_type": "object_property_mapping",
+      "coverage_classification": "relation_mapping",
+      "reasoning": "",
+      "authoritative_axioms": [
+        {
+          "axiom_id": "sha256:a967fdeccb6b435f0f84de94b976dec27307580651a7d16a08b900be0daa4dd1",
+          "canonical_expression": "SubObjectPropertyOf(<http://www.w3.org/ns/ssn/hasSubSystem> <http://purl.obolibrary.org/obo/BFO_0000178>)",
+          "referenced_iris": [
+            "http://purl.obolibrary.org/obo/BFO_0000178",
+            "http://www.w3.org/2000/01/rdf-schema#subPropertyOf",
+            "http://www.w3.org/ns/ssn/hasSubSystem"
+          ],
+          "target_category": "bfo_bearing",
+          "product_dispositions": {
+            "integrated": {
+              "status": "emitted_unchanged"
+            },
+            "alignment_core": {
+              "status": "not_applicable",
+              "reason_code": "TARGET_SPECIFIC"
+            },
+            "strict_bfo_mapping": {
+              "status": "emitted_unchanged"
+            },
+            "bfo_projection": {
+              "status": "provided_through_import"
+            },
+            "cco_extension": {
+              "status": "provided_through_import"
+            }
+          }
+        }
+      ],
+      "row_product_dispositions": null
+    },
+    {
+      "row_id": "urn:uuid:17528e16-1f22-4c6e-9e29-e3b3c6699804",
+      "location": {
+        "worksheet": "Sheet2",
+        "row": 59
+      },
+      "subject": {
+        "lexical": "ssn:inDeployment",
+        "iri": "http://www.w3.org/ns/ssn/inDeployment"
+      },
+      "predicate": {
+        "lexical": "rdfs:subPropertyOf",
+        "iri": "http://www.w3.org/2000/01/rdf-schema#subPropertyOf"
+      },
+      "authoritative_target_lexical": "bfo:participates_in",
+      "canonical_row_expression": {
+        "canonicalization": "coms-row-expression-v1",
+        "mapping_type": "object_property_mapping",
+        "predicate_iri": "http://www.w3.org/2000/01/rdf-schema#subPropertyOf",
+        "subject_iri": "http://www.w3.org/ns/ssn/inDeployment",
+        "target": "<http://purl.obolibrary.org/obo/BFO_0000056>"
+      },
+      "source_expression_sha256": "8af39ca015db241800bcf10d34c6ef428870ad6cb2ec489011d20a7085ee5c38",
+      "mapping_type": "object_property_mapping",
+      "coverage_classification": "relation_mapping",
+      "reasoning": "",
+      "authoritative_axioms": [
+        {
+          "axiom_id": "sha256:cb03fd4e0013c6cb36cdae6f435a71662e5ace11c4b60fd6121e30a58cfddbaf",
+          "canonical_expression": "SubObjectPropertyOf(<http://www.w3.org/ns/ssn/inDeployment> <http://purl.obolibrary.org/obo/BFO_0000056>)",
+          "referenced_iris": [
+            "http://purl.obolibrary.org/obo/BFO_0000056",
+            "http://www.w3.org/2000/01/rdf-schema#subPropertyOf",
+            "http://www.w3.org/ns/ssn/inDeployment"
+          ],
+          "target_category": "bfo_bearing",
+          "product_dispositions": {
+            "integrated": {
+              "status": "emitted_unchanged"
+            },
+            "alignment_core": {
+              "status": "not_applicable",
+              "reason_code": "TARGET_SPECIFIC"
+            },
+            "strict_bfo_mapping": {
+              "status": "emitted_unchanged"
+            },
+            "bfo_projection": {
+              "status": "provided_through_import"
+            },
+            "cco_extension": {
+              "status": "provided_through_import"
+            }
+          }
+        }
+      ],
+      "row_product_dispositions": null
+    },
+    {
+      "row_id": "urn:uuid:1a25c5c5-795c-444c-ba3b-e0578f9e715b",
+      "location": {
+        "worksheet": "Sheet1",
+        "row": 18
+      },
+      "subject": {
+        "lexical": "ssn-system:Latency",
+        "iri": "http://www.w3.org/ns/ssn/systems/Latency"
+      },
+      "predicate": {
+        "lexical": "rdfs:subClassOf",
+        "iri": "http://www.w3.org/2000/01/rdf-schema#subClassOf"
+      },
+      "authoritative_target_lexical": "bfo:Function and bfo:has_realization some (cco:PlannedAct and (cco:has_process_part some cco:Cause) and (cco:has_process_part some cco:Effect) and (bfo:occupies_temporal_region some (bfo:TemporalRegion and cco:prescribed_by some cco:ArtifactFunctionSpecification)))",
+      "canonical_row_expression": {
+        "canonicalization": "coms-row-expression-v1",
+        "mapping_type": "class_mapping",
+        "predicate_iri": "http://www.w3.org/2000/01/rdf-schema#subClassOf",
+        "subject_iri": "http://www.w3.org/ns/ssn/systems/Latency",
+        "target": "ObjectIntersectionOf(<http://purl.obolibrary.org/obo/BFO_0000034> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000054> ObjectIntersectionOf(<https://www.commoncoreontologies.org/ont00000228> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000199> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/BFO_0000008> ObjectSomeValuesFrom(<https://www.commoncoreontologies.org/ont00001920> <https://www.commoncoreontologies.org/ont00000118>))) ObjectSomeValuesFrom(<https://www.commoncoreontologies.org/ont00001777> <https://www.commoncoreontologies.org/ont00000660>) ObjectSomeValuesFrom(<https://www.commoncoreontologies.org/ont00001777> <https://www.commoncoreontologies.org/ont00000978>))))"
+      },
+      "source_expression_sha256": "2fa8fda06a35546b7cd86061a3740e383918c087de982faceb34ad1ace104823",
+      "mapping_type": "class_mapping",
+      "coverage_classification": "class_mapping",
+      "reasoning": "",
+      "authoritative_axioms": [
+        {
+          "axiom_id": "sha256:3457b3a3df2aa6fa0356c77e1cfd6ff95dbb450c7e9965c5bf1beb987488a3a1",
+          "canonical_expression": "SubClassOf(<http://www.w3.org/ns/ssn/systems/Latency> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/BFO_0000034> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000054> ObjectIntersectionOf(<https://www.commoncoreontologies.org/ont00000228> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000199> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/BFO_0000008> ObjectSomeValuesFrom(<https://www.commoncoreontologies.org/ont00001920> <https://www.commoncoreontologies.org/ont00000118>))) ObjectSomeValuesFrom(<https://www.commoncoreontologies.org/ont00001777> <https://www.commoncoreontologies.org/ont00000660>) ObjectSomeValuesFrom(<https://www.commoncoreontologies.org/ont00001777> <https://www.commoncoreontologies.org/ont00000978>)))))",
+          "referenced_iris": [
+            "http://purl.obolibrary.org/obo/BFO_0000008",
+            "http://purl.obolibrary.org/obo/BFO_0000034",
+            "http://purl.obolibrary.org/obo/BFO_0000054",
+            "http://purl.obolibrary.org/obo/BFO_0000199",
+            "http://www.w3.org/2000/01/rdf-schema#subClassOf",
+            "http://www.w3.org/ns/ssn/systems/Latency",
+            "https://www.commoncoreontologies.org/ont00000118",
+            "https://www.commoncoreontologies.org/ont00000228",
+            "https://www.commoncoreontologies.org/ont00000660",
+            "https://www.commoncoreontologies.org/ont00000978",
+            "https://www.commoncoreontologies.org/ont00001777",
+            "https://www.commoncoreontologies.org/ont00001920"
+          ],
+          "target_category": "mixed_bfo_cco",
+          "product_dispositions": {
+            "integrated": {
+              "status": "emitted_unchanged"
+            },
+            "alignment_core": {
+              "status": "not_applicable",
+              "reason_code": "TARGET_SPECIFIC"
+            },
+            "strict_bfo_mapping": {
+              "status": "deferred",
+              "reason_code": "NO_APPROVED_TRANSFORMATION_RULE"
+            },
+            "bfo_projection": {
+              "status": "deferred",
+              "reason_code": "NO_APPROVED_TRANSFORMATION_RULE"
+            },
+            "cco_extension": {
+              "status": "emitted_unchanged"
+            }
+          }
+        }
+      ],
+      "row_product_dispositions": null
+    },
+    {
+      "row_id": "urn:uuid:1b7c27d4-1b0e-461f-8a77-7a81631ab342",
+      "location": {
+        "worksheet": "Sheet1",
+        "row": 4
+      },
+      "subject": {
+        "lexical": "sosa:ActuatableProperty",
+        "iri": "http://www.w3.org/ns/sosa/ActuatableProperty"
+      },
+      "predicate": {
+        "lexical": "rdfs:subClassOf",
+        "iri": "http://www.w3.org/2000/01/rdf-schema#subClassOf"
+      },
+      "authoritative_target_lexical": "(bfo:SpecificallyDependentContinuant and bfo:inheres_in some sosa:FeatureOfInterest) or (bfo:ProcessProfile and bfo:occurrent_part_of some sosa:FeatureOfInterest)",
+      "canonical_row_expression": {
+        "canonicalization": "coms-row-expression-v1",
+        "mapping_type": "class_mapping",
+        "predicate_iri": "http://www.w3.org/2000/01/rdf-schema#subClassOf",
+        "subject_iri": "http://www.w3.org/ns/sosa/ActuatableProperty",
+        "target": "ObjectUnionOf(ObjectIntersectionOf(<http://purl.obolibrary.org/obo/BFO_0000020> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000197> <http://www.w3.org/ns/sosa/FeatureOfInterest>)) ObjectIntersectionOf(<http://purl.obolibrary.org/obo/BFO_0000144> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000132> <http://www.w3.org/ns/sosa/FeatureOfInterest>)))"
+      },
+      "source_expression_sha256": "fb1601493fb203b063d1b1e562ea5451a1ece8905d7f93e8ca4649dac9810d3a",
+      "mapping_type": "class_mapping",
+      "coverage_classification": "class_mapping",
+      "reasoning": "",
+      "authoritative_axioms": [
+        {
+          "axiom_id": "sha256:f0ed25535d9f911882545913dac2c83339346e2ca16a5e939b2a2e27cd5f1c4e",
+          "canonical_expression": "SubClassOf(<http://www.w3.org/ns/sosa/ActuatableProperty> ObjectUnionOf(ObjectIntersectionOf(<http://purl.obolibrary.org/obo/BFO_0000020> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000197> <http://www.w3.org/ns/sosa/FeatureOfInterest>)) ObjectIntersectionOf(<http://purl.obolibrary.org/obo/BFO_0000144> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000132> <http://www.w3.org/ns/sosa/FeatureOfInterest>))))",
+          "referenced_iris": [
+            "http://purl.obolibrary.org/obo/BFO_0000020",
+            "http://purl.obolibrary.org/obo/BFO_0000132",
+            "http://purl.obolibrary.org/obo/BFO_0000144",
+            "http://purl.obolibrary.org/obo/BFO_0000197",
+            "http://www.w3.org/2000/01/rdf-schema#subClassOf",
+            "http://www.w3.org/ns/sosa/ActuatableProperty",
+            "http://www.w3.org/ns/sosa/FeatureOfInterest"
+          ],
+          "target_category": "bfo_bearing",
+          "product_dispositions": {
+            "integrated": {
+              "status": "emitted_unchanged"
+            },
+            "alignment_core": {
+              "status": "not_applicable",
+              "reason_code": "TARGET_SPECIFIC"
+            },
+            "strict_bfo_mapping": {
+              "status": "emitted_unchanged"
+            },
+            "bfo_projection": {
+              "status": "provided_through_import"
+            },
+            "cco_extension": {
+              "status": "provided_through_import"
+            }
+          }
+        }
+      ],
+      "row_product_dispositions": null
+    },
+    {
+      "row_id": "urn:uuid:1c52d7ee-ee3d-4eb7-ae42-4df1912ee8eb",
+      "location": {
+        "worksheet": "Sheet1",
+        "row": 31
+      },
+      "subject": {
+        "lexical": "ssn:Deployment",
+        "iri": "http://www.w3.org/ns/ssn/Deployment"
+      },
+      "predicate": {
+        "lexical": "owl:equivalentClass",
+        "iri": "http://www.w3.org/2002/07/owl#equivalentClass"
+      },
+      "authoritative_target_lexical": "cco:PlannedAct and (ssn:deployedSystem some ssn:System) and (ssn:deployedOnPlatform some bfo:MaterialEntity)",
+      "canonical_row_expression": {
+        "canonicalization": "coms-row-expression-v1",
+        "mapping_type": "class_mapping",
+        "predicate_iri": "http://www.w3.org/2002/07/owl#equivalentClass",
+        "subject_iri": "http://www.w3.org/ns/ssn/Deployment",
+        "target": "ObjectIntersectionOf(<https://www.commoncoreontologies.org/ont00000228> ObjectSomeValuesFrom(<http://www.w3.org/ns/ssn/deployedOnPlatform> <http://purl.obolibrary.org/obo/BFO_0000040>) ObjectSomeValuesFrom(<http://www.w3.org/ns/ssn/deployedSystem> <http://www.w3.org/ns/ssn/System>))"
+      },
+      "source_expression_sha256": "f05c613dbda3a8cda59297e2e0ccac44bdfbfe2cd5890088971e09ef0e83f677",
+      "mapping_type": "class_mapping",
+      "coverage_classification": "class_mapping",
+      "reasoning": "",
+      "authoritative_axioms": [
+        {
+          "axiom_id": "sha256:7b6dc290ded8df4f46f20ce28efdc86479348dd0c0746fd31c883e97724b0361",
+          "canonical_expression": "EquivalentClasses(<http://www.w3.org/ns/ssn/Deployment> ObjectIntersectionOf(<https://www.commoncoreontologies.org/ont00000228> ObjectSomeValuesFrom(<http://www.w3.org/ns/ssn/deployedOnPlatform> <http://purl.obolibrary.org/obo/BFO_0000040>) ObjectSomeValuesFrom(<http://www.w3.org/ns/ssn/deployedSystem> <http://www.w3.org/ns/ssn/System>)))",
+          "referenced_iris": [
+            "http://purl.obolibrary.org/obo/BFO_0000040",
+            "http://www.w3.org/2002/07/owl#equivalentClass",
+            "http://www.w3.org/ns/ssn/Deployment",
+            "http://www.w3.org/ns/ssn/System",
+            "http://www.w3.org/ns/ssn/deployedOnPlatform",
+            "http://www.w3.org/ns/ssn/deployedSystem",
+            "https://www.commoncoreontologies.org/ont00000228"
+          ],
+          "target_category": "mixed_bfo_cco",
+          "product_dispositions": {
+            "integrated": {
+              "status": "emitted_unchanged"
+            },
+            "alignment_core": {
+              "status": "not_applicable",
+              "reason_code": "TARGET_SPECIFIC"
+            },
+            "strict_bfo_mapping": {
+              "status": "deferred",
+              "reason_code": "NO_APPROVED_TRANSFORMATION_RULE"
+            },
+            "bfo_projection": {
+              "status": "deferred",
+              "reason_code": "NO_APPROVED_TRANSFORMATION_RULE"
+            },
+            "cco_extension": {
+              "status": "emitted_unchanged"
+            }
+          }
+        }
+      ],
+      "row_product_dispositions": null
+    },
+    {
+      "row_id": "urn:uuid:1e9432ec-0bfb-4c05-8a16-c4295d545f81",
+      "location": {
+        "worksheet": "Sheet2",
+        "row": 44
+      },
+      "subject": {
+        "lexical": "ssn-system:hasSystemCapability",
+        "iri": "http://www.w3.org/ns/ssn/systems/hasSystemCapability"
+      },
+      "predicate": {
+        "lexical": "rdfs:range",
+        "iri": "http://www.w3.org/2000/01/rdf-schema#range"
+      },
+      "authoritative_target_lexical": "ssn-system:SystemCapability",
+      "canonical_row_expression": {
+        "canonicalization": "coms-row-expression-v1",
+        "mapping_type": "range",
+        "predicate_iri": "http://www.w3.org/2000/01/rdf-schema#range",
+        "subject_iri": "http://www.w3.org/ns/ssn/systems/hasSystemCapability",
+        "target": "<http://www.w3.org/ns/ssn/systems/SystemCapability>"
+      },
+      "source_expression_sha256": "3e02bc508bc6d80d73bf7ace564a18916b058d60a62d778a14a9c02740df9122",
+      "mapping_type": "range",
+      "coverage_classification": "property_typing",
+      "reasoning": "",
+      "authoritative_axioms": [
+        {
+          "axiom_id": "sha256:a1b8c592a4cf6791fb11952b7c19ff54de44725f94537d874e93b3ea320232ab",
+          "canonical_expression": "ObjectPropertyRange(<http://www.w3.org/ns/ssn/systems/hasSystemCapability> <http://www.w3.org/ns/ssn/systems/SystemCapability>)",
+          "referenced_iris": [
+            "http://www.w3.org/2000/01/rdf-schema#range",
+            "http://www.w3.org/ns/ssn/systems/SystemCapability",
+            "http://www.w3.org/ns/ssn/systems/hasSystemCapability"
+          ],
+          "target_category": "target_neutral",
+          "product_dispositions": {
+            "integrated": {
+              "status": "emitted_unchanged"
+            },
+            "alignment_core": {
+              "status": "emitted_unchanged"
+            },
+            "strict_bfo_mapping": {
+              "status": "provided_through_import"
+            },
+            "bfo_projection": {
+              "status": "provided_transitively"
+            },
+            "cco_extension": {
+              "status": "provided_transitively"
+            }
+          }
+        }
+      ],
+      "row_product_dispositions": null
+    },
+    {
+      "row_id": "urn:uuid:2018c5db-cb41-4a54-aa97-df5df82f0286",
+      "location": {
+        "worksheet": "Sheet2",
+        "row": 14
+      },
+      "subject": {
+        "lexical": "ssn-system:qualityOfObservation",
+        "iri": "http://www.w3.org/ns/ssn/systems/qualityOfObservation"
+      },
+      "predicate": {
+        "lexical": "rdfs:subPropertyOf",
+        "iri": "http://www.w3.org/2000/01/rdf-schema#subPropertyOf"
+      },
+      "authoritative_target_lexical": "cco:has_output",
+      "canonical_row_expression": {
+        "canonicalization": "coms-row-expression-v1",
+        "mapping_type": "object_property_mapping",
+        "predicate_iri": "http://www.w3.org/2000/01/rdf-schema#subPropertyOf",
+        "subject_iri": "http://www.w3.org/ns/ssn/systems/qualityOfObservation",
+        "target": "<https://www.commoncoreontologies.org/ont00001986>"
+      },
+      "source_expression_sha256": "19f9b7df8bb9c81f7b2ec9d2244b3f9864e53c21d1e54ceeb59f8e7d2704f613",
+      "mapping_type": "object_property_mapping",
+      "coverage_classification": "relation_mapping",
+      "reasoning": "",
+      "authoritative_axioms": [
+        {
+          "axiom_id": "sha256:8d7dc6c8f9ecc7fc94c23b7a9c5e8603e3013f8dcef2453f4c45f3d4ee8f0f93",
+          "canonical_expression": "SubObjectPropertyOf(<http://www.w3.org/ns/ssn/systems/qualityOfObservation> <https://www.commoncoreontologies.org/ont00001986>)",
+          "referenced_iris": [
+            "http://www.w3.org/2000/01/rdf-schema#subPropertyOf",
+            "http://www.w3.org/ns/ssn/systems/qualityOfObservation",
+            "https://www.commoncoreontologies.org/ont00001986"
+          ],
+          "target_category": "cco_bearing",
+          "product_dispositions": {
+            "integrated": {
+              "status": "emitted_unchanged"
+            },
+            "alignment_core": {
+              "status": "not_applicable",
+              "reason_code": "TARGET_SPECIFIC"
+            },
+            "strict_bfo_mapping": {
+              "status": "deferred",
+              "reason_code": "NO_APPROVED_TRANSFORMATION_RULE"
+            },
+            "bfo_projection": {
+              "status": "deferred",
+              "reason_code": "NO_APPROVED_TRANSFORMATION_RULE"
+            },
+            "cco_extension": {
+              "status": "emitted_unchanged"
+            }
+          }
+        }
+      ],
+      "row_product_dispositions": null
+    },
+    {
+      "row_id": "urn:uuid:206e2eaa-765b-491b-ad9c-73f144f048a1",
+      "location": {
+        "worksheet": "Sheet1",
+        "row": 21
+      },
+      "subject": {
+        "lexical": "ssn-system:OperatingProperty",
+        "iri": "http://www.w3.org/ns/ssn/systems/OperatingProperty"
+      },
+      "predicate": {
+        "lexical": "rdfs:subClassOf",
+        "iri": "http://www.w3.org/2000/01/rdf-schema#subClassOf"
+      },
+      "authoritative_target_lexical": "(bfo:SpecificallyDependentContinuant or bfo:ProcessProfile) and cco:prescribed_by some cco:ArtifactDesign",
+      "canonical_row_expression": {
+        "canonicalization": "coms-row-expression-v1",
+        "mapping_type": "class_mapping",
+        "predicate_iri": "http://www.w3.org/2000/01/rdf-schema#subClassOf",
+        "subject_iri": "http://www.w3.org/ns/ssn/systems/OperatingProperty",
+        "target": "ObjectIntersectionOf(ObjectSomeValuesFrom(<https://www.commoncoreontologies.org/ont00001920> <https://www.commoncoreontologies.org/ont00000319>) ObjectUnionOf(<http://purl.obolibrary.org/obo/BFO_0000020> <http://purl.obolibrary.org/obo/BFO_0000144>))"
+      },
+      "source_expression_sha256": "10f70cc32598bc0a01b685df5387a83792a97b8853079af8f2e72b450cd2312b",
+      "mapping_type": "class_mapping",
+      "coverage_classification": "class_mapping",
+      "reasoning": "",
+      "authoritative_axioms": [
+        {
+          "axiom_id": "sha256:3f12e123ab52f767626a55a1d07c7d5d85a955e538890927ea02090db15411ab",
+          "canonical_expression": "SubClassOf(<http://www.w3.org/ns/ssn/systems/OperatingProperty> ObjectIntersectionOf(ObjectSomeValuesFrom(<https://www.commoncoreontologies.org/ont00001920> <https://www.commoncoreontologies.org/ont00000319>) ObjectUnionOf(<http://purl.obolibrary.org/obo/BFO_0000020> <http://purl.obolibrary.org/obo/BFO_0000144>)))",
+          "referenced_iris": [
+            "http://purl.obolibrary.org/obo/BFO_0000020",
+            "http://purl.obolibrary.org/obo/BFO_0000144",
+            "http://www.w3.org/2000/01/rdf-schema#subClassOf",
+            "http://www.w3.org/ns/ssn/systems/OperatingProperty",
+            "https://www.commoncoreontologies.org/ont00000319",
+            "https://www.commoncoreontologies.org/ont00001920"
+          ],
+          "target_category": "mixed_bfo_cco",
+          "product_dispositions": {
+            "integrated": {
+              "status": "emitted_unchanged"
+            },
+            "alignment_core": {
+              "status": "not_applicable",
+              "reason_code": "TARGET_SPECIFIC"
+            },
+            "strict_bfo_mapping": {
+              "status": "deferred",
+              "reason_code": "NO_APPROVED_TRANSFORMATION_RULE"
+            },
+            "bfo_projection": {
+              "status": "deferred",
+              "reason_code": "NO_APPROVED_TRANSFORMATION_RULE"
+            },
+            "cco_extension": {
+              "status": "emitted_unchanged"
+            }
+          }
+        }
+      ],
+      "row_product_dispositions": null
+    },
+    {
+      "row_id": "urn:uuid:23915904-0174-4f2f-b6cf-6a8671b92d7e",
+      "location": {
+        "worksheet": "Sheet1",
+        "row": 35
+      },
+      "subject": {
+        "lexical": "ssn:Stimulus",
+        "iri": "http://www.w3.org/ns/ssn/Stimulus"
+      },
+      "predicate": {
+        "lexical": "owl:equivalentClass",
+        "iri": "http://www.w3.org/2002/07/owl#equivalentClass"
+      },
+      "authoritative_target_lexical": "cco:Cause and (cco:is_cause_of some sosa:Observation)",
+      "canonical_row_expression": {
+        "canonicalization": "coms-row-expression-v1",
+        "mapping_type": "class_mapping",
+        "predicate_iri": "http://www.w3.org/2002/07/owl#equivalentClass",
+        "subject_iri": "http://www.w3.org/ns/ssn/Stimulus",
+        "target": "ObjectIntersectionOf(<https://www.commoncoreontologies.org/ont00000978> ObjectSomeValuesFrom(<https://www.commoncoreontologies.org/ont00001803> <http://www.w3.org/ns/sosa/Observation>))"
+      },
+      "source_expression_sha256": "bcc4aa63f9e3d86b30f0900127e61cc1e56b946b4a30f3a11e2c6302f2a2f75c",
+      "mapping_type": "class_mapping",
+      "coverage_classification": "class_mapping",
+      "reasoning": "",
+      "authoritative_axioms": [
+        {
+          "axiom_id": "sha256:3c8142551309a66a37dc13ff25eb6fd6b31e7089a776f7391316bacb3705cf1e",
+          "canonical_expression": "EquivalentClasses(<http://www.w3.org/ns/ssn/Stimulus> ObjectIntersectionOf(<https://www.commoncoreontologies.org/ont00000978> ObjectSomeValuesFrom(<https://www.commoncoreontologies.org/ont00001803> <http://www.w3.org/ns/sosa/Observation>)))",
+          "referenced_iris": [
+            "http://www.w3.org/2002/07/owl#equivalentClass",
+            "http://www.w3.org/ns/sosa/Observation",
+            "http://www.w3.org/ns/ssn/Stimulus",
+            "https://www.commoncoreontologies.org/ont00000978",
+            "https://www.commoncoreontologies.org/ont00001803"
+          ],
+          "target_category": "cco_bearing",
+          "product_dispositions": {
+            "integrated": {
+              "status": "emitted_unchanged"
+            },
+            "alignment_core": {
+              "status": "not_applicable",
+              "reason_code": "TARGET_SPECIFIC"
+            },
+            "strict_bfo_mapping": {
+              "status": "deferred",
+              "reason_code": "NO_APPROVED_TRANSFORMATION_RULE"
+            },
+            "bfo_projection": {
+              "status": "deferred",
+              "reason_code": "NO_APPROVED_TRANSFORMATION_RULE"
+            },
+            "cco_extension": {
+              "status": "emitted_unchanged"
+            }
+          }
+        }
+      ],
+      "row_product_dispositions": null
+    },
+    {
+      "row_id": "urn:uuid:265137eb-a279-4f9a-b1b9-e85d7ecb02a7",
+      "location": {
+        "worksheet": "Sheet2",
+        "row": 38
+      },
+      "subject": {
+        "lexical": "ssn-system:hasOperatingRange",
+        "iri": "http://www.w3.org/ns/ssn/systems/hasOperatingRange"
+      },
+      "predicate": {
+        "lexical": "rdfs:domain",
+        "iri": "http://www.w3.org/2000/01/rdf-schema#domain"
+      },
+      "authoritative_target_lexical": "ssn:System",
+      "canonical_row_expression": {
+        "canonicalization": "coms-row-expression-v1",
+        "mapping_type": "domain",
+        "predicate_iri": "http://www.w3.org/2000/01/rdf-schema#domain",
+        "subject_iri": "http://www.w3.org/ns/ssn/systems/hasOperatingRange",
+        "target": "<http://www.w3.org/ns/ssn/System>"
+      },
+      "source_expression_sha256": "be38dc3ef3f5e76e250d1cb245360749bd7336ed0785cdab09a20730ea6ef540",
+      "mapping_type": "domain",
+      "coverage_classification": "property_typing",
+      "reasoning": "",
+      "authoritative_axioms": [
+        {
+          "axiom_id": "sha256:c039b2a88fe82d34a443e1753f23414ba037f6b6b5d20093323ed6efdce90540",
+          "canonical_expression": "ObjectPropertyDomain(<http://www.w3.org/ns/ssn/systems/hasOperatingRange> <http://www.w3.org/ns/ssn/System>)",
+          "referenced_iris": [
+            "http://www.w3.org/2000/01/rdf-schema#domain",
+            "http://www.w3.org/ns/ssn/System",
+            "http://www.w3.org/ns/ssn/systems/hasOperatingRange"
+          ],
+          "target_category": "target_neutral",
+          "product_dispositions": {
+            "integrated": {
+              "status": "emitted_unchanged"
+            },
+            "alignment_core": {
+              "status": "emitted_unchanged"
+            },
+            "strict_bfo_mapping": {
+              "status": "provided_through_import"
+            },
+            "bfo_projection": {
+              "status": "provided_transitively"
+            },
+            "cco_extension": {
+              "status": "provided_transitively"
+            }
+          }
+        }
+      ],
+      "row_product_dispositions": null
+    },
+    {
+      "row_id": "urn:uuid:27ab2a4a-15a3-4585-885a-bbac1fe0a5bb",
+      "location": {
+        "worksheet": "Sheet2",
+        "row": 53
+      },
+      "subject": {
+        "lexical": "ssn:hasOutput",
+        "iri": "http://www.w3.org/ns/ssn/hasOutput"
+      },
+      "predicate": {
+        "lexical": "rdfs:domain",
+        "iri": "http://www.w3.org/2000/01/rdf-schema#domain"
+      },
+      "authoritative_target_lexical": "sosa:Procedure",
+      "canonical_row_expression": {
+        "canonicalization": "coms-row-expression-v1",
+        "mapping_type": "domain",
+        "predicate_iri": "http://www.w3.org/2000/01/rdf-schema#domain",
+        "subject_iri": "http://www.w3.org/ns/ssn/hasOutput",
+        "target": "<http://www.w3.org/ns/sosa/Procedure>"
+      },
+      "source_expression_sha256": "60b56bf1da2a86512e40747f2a2037968b757e2c9be7abf50ea4910098d03a67",
+      "mapping_type": "domain",
+      "coverage_classification": "property_typing",
+      "reasoning": "",
+      "authoritative_axioms": [
+        {
+          "axiom_id": "sha256:f9e3e9bae942c365fd53f52ede02164deff53aa65f5d20a1efa91cd54df7724f",
+          "canonical_expression": "ObjectPropertyDomain(<http://www.w3.org/ns/ssn/hasOutput> <http://www.w3.org/ns/sosa/Procedure>)",
+          "referenced_iris": [
+            "http://www.w3.org/2000/01/rdf-schema#domain",
+            "http://www.w3.org/ns/sosa/Procedure",
+            "http://www.w3.org/ns/ssn/hasOutput"
+          ],
+          "target_category": "target_neutral",
+          "product_dispositions": {
+            "integrated": {
+              "status": "emitted_unchanged"
+            },
+            "alignment_core": {
+              "status": "emitted_unchanged"
+            },
+            "strict_bfo_mapping": {
+              "status": "provided_through_import"
+            },
+            "bfo_projection": {
+              "status": "provided_transitively"
+            },
+            "cco_extension": {
+              "status": "provided_transitively"
+            }
+          }
+        }
+      ],
+      "row_product_dispositions": null
+    },
+    {
+      "row_id": "urn:uuid:282b2a18-f710-4eac-a5c8-43894a242f23",
+      "location": {
+        "worksheet": "Sheet1",
+        "row": 32
+      },
+      "subject": {
+        "lexical": "ssn:Input",
+        "iri": "http://www.w3.org/ns/ssn/Input"
+      },
+      "predicate": {
+        "lexical": "rdfs:subClassOf",
+        "iri": "http://www.w3.org/2000/01/rdf-schema#subClassOf"
+      },
+      "authoritative_target_lexical": "cco:InformationContentEntity",
+      "canonical_row_expression": {
+        "canonicalization": "coms-row-expression-v1",
+        "mapping_type": "class_mapping",
+        "predicate_iri": "http://www.w3.org/2000/01/rdf-schema#subClassOf",
+        "subject_iri": "http://www.w3.org/ns/ssn/Input",
+        "target": "<https://www.commoncoreontologies.org/ont00000958>"
+      },
+      "source_expression_sha256": "3db4c188033abac7841a40ef88585754cd5d50b3acca2a7876b36e71c8635b23",
+      "mapping_type": "class_mapping",
+      "coverage_classification": "class_mapping",
+      "reasoning": "",
+      "authoritative_axioms": [
+        {
+          "axiom_id": "sha256:3904c25cf0f62fae33bad65d4d752ae170f94b3678274b151bd6fdd007c4d120",
+          "canonical_expression": "SubClassOf(<http://www.w3.org/ns/ssn/Input> <https://www.commoncoreontologies.org/ont00000958>)",
+          "referenced_iris": [
+            "http://www.w3.org/2000/01/rdf-schema#subClassOf",
+            "http://www.w3.org/ns/ssn/Input",
+            "https://www.commoncoreontologies.org/ont00000958"
+          ],
+          "target_category": "cco_bearing",
+          "product_dispositions": {
+            "integrated": {
+              "status": "emitted_unchanged"
+            },
+            "alignment_core": {
+              "status": "not_applicable",
+              "reason_code": "TARGET_SPECIFIC"
+            },
+            "strict_bfo_mapping": {
+              "status": "deferred",
+              "reason_code": "NO_APPROVED_TRANSFORMATION_RULE"
+            },
+            "bfo_projection": {
+              "status": "deferred",
+              "reason_code": "NO_APPROVED_TRANSFORMATION_RULE"
+            },
+            "cco_extension": {
+              "status": "emitted_unchanged"
+            }
+          }
+        }
+      ],
+      "row_product_dispositions": null
+    },
+    {
+      "row_id": "urn:uuid:287f1392-ca8f-4dc2-9d42-b60b3962adfc",
+      "location": {
+        "worksheet": "Sheet2",
+        "row": 49
+      },
+      "subject": {
+        "lexical": "ssn:forProperty",
+        "iri": "http://www.w3.org/ns/ssn/forProperty"
+      },
+      "predicate": {
+        "lexical": "owl:propertyChainAxiom",
+        "iri": "http://www.w3.org/2002/07/owl#propertyChainAxiom"
+      },
+      "authoritative_target_lexical": "cco:described_by o cco:is_about",
+      "canonical_row_expression": {
+        "canonicalization": "coms-row-expression-v1",
+        "mapping_type": "property_chain",
+        "predicate_iri": "http://www.w3.org/2002/07/owl#propertyChainAxiom",
+        "subject_iri": "http://www.w3.org/ns/ssn/forProperty",
+        "target": "ObjectPropertyChain(<https://www.commoncoreontologies.org/ont00001917> <https://www.commoncoreontologies.org/ont00001808>)"
+      },
+      "source_expression_sha256": "ff05717a8a1580d8eaad24c06c1234e062508961eef5a0ec0a0952a9c46cf660",
+      "mapping_type": "property_chain",
+      "coverage_classification": "property_chain",
+      "reasoning": "",
+      "authoritative_axioms": [
+        {
+          "axiom_id": "sha256:ac90bbff84f27289fdc5c5fb492323384ea75b344016bb5eb7a4d34a540a8f91",
+          "canonical_expression": "SubObjectPropertyOf(ObjectPropertyChain(<https://www.commoncoreontologies.org/ont00001917> <https://www.commoncoreontologies.org/ont00001808>) <http://www.w3.org/ns/ssn/forProperty>)",
+          "referenced_iris": [
+            "http://www.w3.org/2002/07/owl#propertyChainAxiom",
+            "http://www.w3.org/ns/ssn/forProperty",
+            "https://www.commoncoreontologies.org/ont00001808",
+            "https://www.commoncoreontologies.org/ont00001917"
+          ],
+          "target_category": "cco_bearing",
+          "product_dispositions": {
+            "integrated": {
+              "status": "emitted_unchanged"
+            },
+            "alignment_core": {
+              "status": "not_applicable",
+              "reason_code": "TARGET_SPECIFIC"
+            },
+            "strict_bfo_mapping": {
+              "status": "deferred",
+              "reason_code": "NO_APPROVED_TRANSFORMATION_RULE"
+            },
+            "bfo_projection": {
+              "status": "deferred",
+              "reason_code": "NO_APPROVED_TRANSFORMATION_RULE"
+            },
+            "cco_extension": {
+              "status": "emitted_unchanged"
+            }
+          }
+        }
+      ],
+      "row_product_dispositions": null
+    },
+    {
+      "row_id": "urn:uuid:2902e2b3-44f8-4f81-8ca9-2def4b68befd",
+      "location": {
+        "worksheet": "Sheet1",
+        "row": 38
+      },
+      "subject": {
+        "lexical": "sosa:Sensor",
+        "iri": "http://www.w3.org/ns/sosa/Sensor"
+      },
+      "predicate": {
+        "lexical": "rdfs:subClassOf",
+        "iri": "http://www.w3.org/2000/01/rdf-schema#subClassOf"
+      },
+      "authoritative_target_lexical": "bfo:MaterialEntity and (bfo:bearer_of some (bfo:RealizableEntity and (bfo:has_realization some sosa:Observation))) and (cco:agent_in some sosa:Observation)",
+      "canonical_row_expression": {
+        "canonicalization": "coms-row-expression-v1",
+        "mapping_type": "class_mapping",
+        "predicate_iri": "http://www.w3.org/2000/01/rdf-schema#subClassOf",
+        "subject_iri": "http://www.w3.org/ns/sosa/Sensor",
+        "target": "ObjectIntersectionOf(<http://purl.obolibrary.org/obo/BFO_0000040> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000196> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/BFO_0000017> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000054> <http://www.w3.org/ns/sosa/Observation>))) ObjectSomeValuesFrom(<https://www.commoncoreontologies.org/ont00001787> <http://www.w3.org/ns/sosa/Observation>))"
+      },
+      "source_expression_sha256": "63a0643266c14870cd600ce103710df959e9b7f7dd4220c985337951e6f55252",
+      "mapping_type": "class_mapping",
+      "coverage_classification": "class_mapping",
+      "reasoning": "",
+      "authoritative_axioms": [
+        {
+          "axiom_id": "sha256:f1380a66f7734f9b3e29c3e53388eabffa1e5fb296f1e0a192ada48d796a6c2b",
+          "canonical_expression": "SubClassOf(<http://www.w3.org/ns/sosa/Sensor> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/BFO_0000040> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000196> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/BFO_0000017> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000054> <http://www.w3.org/ns/sosa/Observation>))) ObjectSomeValuesFrom(<https://www.commoncoreontologies.org/ont00001787> <http://www.w3.org/ns/sosa/Observation>)))",
+          "referenced_iris": [
+            "http://purl.obolibrary.org/obo/BFO_0000017",
+            "http://purl.obolibrary.org/obo/BFO_0000040",
+            "http://purl.obolibrary.org/obo/BFO_0000054",
+            "http://purl.obolibrary.org/obo/BFO_0000196",
+            "http://www.w3.org/2000/01/rdf-schema#subClassOf",
+            "http://www.w3.org/ns/sosa/Observation",
+            "http://www.w3.org/ns/sosa/Sensor",
+            "https://www.commoncoreontologies.org/ont00001787"
+          ],
+          "target_category": "mixed_bfo_cco",
+          "product_dispositions": {
+            "integrated": {
+              "status": "emitted_unchanged"
+            },
+            "alignment_core": {
+              "status": "not_applicable",
+              "reason_code": "TARGET_SPECIFIC"
+            },
+            "strict_bfo_mapping": {
+              "status": "deferred",
+              "reason_code": "NO_APPROVED_TRANSFORMATION_RULE"
+            },
+            "bfo_projection": {
+              "status": "deferred",
+              "reason_code": "NO_APPROVED_TRANSFORMATION_RULE"
+            },
+            "cco_extension": {
+              "status": "emitted_unchanged"
+            }
+          }
+        }
+      ],
+      "row_product_dispositions": null
+    },
+    {
+      "row_id": "urn:uuid:2a4f78b4-92cb-4095-9a6b-2ae03e00be4a",
+      "location": {
+        "worksheet": "Sheet1",
+        "row": 5
+      },
+      "subject": {
+        "lexical": "sosa:Actuation",
+        "iri": "http://www.w3.org/ns/sosa/Actuation"
+      },
+      "predicate": {
+        "lexical": "owl:equivalentClass",
+        "iri": "http://www.w3.org/2002/07/owl#equivalentClass"
+      },
+      "authoritative_target_lexical": "cco:PlannedAct and (sosa:actsOnProperty some sosa:ActuatableProperty)",
+      "canonical_row_expression": {
+        "canonicalization": "coms-row-expression-v1",
+        "mapping_type": "class_mapping",
+        "predicate_iri": "http://www.w3.org/2002/07/owl#equivalentClass",
+        "subject_iri": "http://www.w3.org/ns/sosa/Actuation",
+        "target": "ObjectIntersectionOf(<https://www.commoncoreontologies.org/ont00000228> ObjectSomeValuesFrom(<http://www.w3.org/ns/sosa/actsOnProperty> <http://www.w3.org/ns/sosa/ActuatableProperty>))"
+      },
+      "source_expression_sha256": "8db69af6d7175d894153961af20069ada1ff015b288dccbebef4ebb60849421d",
+      "mapping_type": "class_mapping",
+      "coverage_classification": "class_mapping",
+      "reasoning": "",
+      "authoritative_axioms": [
+        {
+          "axiom_id": "sha256:c65595bd49e621675a797ec88f0bed32696c176393221adaae8b1a9192cdd842",
+          "canonical_expression": "EquivalentClasses(<http://www.w3.org/ns/sosa/Actuation> ObjectIntersectionOf(<https://www.commoncoreontologies.org/ont00000228> ObjectSomeValuesFrom(<http://www.w3.org/ns/sosa/actsOnProperty> <http://www.w3.org/ns/sosa/ActuatableProperty>)))",
+          "referenced_iris": [
+            "http://www.w3.org/2002/07/owl#equivalentClass",
+            "http://www.w3.org/ns/sosa/ActuatableProperty",
+            "http://www.w3.org/ns/sosa/Actuation",
+            "http://www.w3.org/ns/sosa/actsOnProperty",
+            "https://www.commoncoreontologies.org/ont00000228"
+          ],
+          "target_category": "cco_bearing",
+          "product_dispositions": {
+            "integrated": {
+              "status": "emitted_unchanged"
+            },
+            "alignment_core": {
+              "status": "not_applicable",
+              "reason_code": "TARGET_SPECIFIC"
+            },
+            "strict_bfo_mapping": {
+              "status": "deferred",
+              "reason_code": "NO_APPROVED_TRANSFORMATION_RULE"
+            },
+            "bfo_projection": {
+              "status": "deferred",
+              "reason_code": "NO_APPROVED_TRANSFORMATION_RULE"
+            },
+            "cco_extension": {
+              "status": "emitted_unchanged"
+            }
+          }
+        }
+      ],
+      "row_product_dispositions": null
+    },
+    {
+      "row_id": "urn:uuid:2abe4468-736d-4db8-99d7-1670730a6710",
+      "location": {
+        "worksheet": "Sheet2",
+        "row": 11
+      },
+      "subject": {
+        "lexical": "sosa:phenomenonTime",
+        "iri": "http://www.w3.org/ns/sosa/phenomenonTime"
+      },
+      "predicate": {
+        "lexical": "rdfs:subPropertyOf",
+        "iri": "http://www.w3.org/2000/01/rdf-schema#subPropertyOf"
+      },
+      "authoritative_target_lexical": "bfo:occupies_temporal_region",
+      "canonical_row_expression": {
+        "canonicalization": "coms-row-expression-v1",
+        "mapping_type": "object_property_mapping",
+        "predicate_iri": "http://www.w3.org/2000/01/rdf-schema#subPropertyOf",
+        "subject_iri": "http://www.w3.org/ns/sosa/phenomenonTime",
+        "target": "<http://purl.obolibrary.org/obo/BFO_0000199>"
+      },
+      "source_expression_sha256": "40553a3ab5b52532d5d74c4fe23ffb3c52321ac8799ab61c33abba7ba2d59bbd",
+      "mapping_type": "object_property_mapping",
+      "coverage_classification": "relation_mapping",
+      "reasoning": "",
+      "authoritative_axioms": [
+        {
+          "axiom_id": "sha256:39946148848f627dc9bd67601c5d0d1184960c34054c876541a77fa9d42e3d6b",
+          "canonical_expression": "SubObjectPropertyOf(<http://www.w3.org/ns/sosa/phenomenonTime> <http://purl.obolibrary.org/obo/BFO_0000199>)",
+          "referenced_iris": [
+            "http://purl.obolibrary.org/obo/BFO_0000199",
+            "http://www.w3.org/2000/01/rdf-schema#subPropertyOf",
+            "http://www.w3.org/ns/sosa/phenomenonTime"
+          ],
+          "target_category": "bfo_bearing",
+          "product_dispositions": {
+            "integrated": {
+              "status": "emitted_unchanged"
+            },
+            "alignment_core": {
+              "status": "not_applicable",
+              "reason_code": "TARGET_SPECIFIC"
+            },
+            "strict_bfo_mapping": {
+              "status": "emitted_unchanged"
+            },
+            "bfo_projection": {
+              "status": "provided_through_import"
+            },
+            "cco_extension": {
+              "status": "provided_through_import"
+            }
+          }
+        }
+      ],
+      "row_product_dispositions": null
+    },
+    {
+      "row_id": "urn:uuid:2ae25d88-9551-45e7-a2b9-7735575e4d8f",
+      "location": {
+        "worksheet": "Sheet2",
+        "row": 16
+      },
+      "subject": {
+        "lexical": "sosa:hasSample",
+        "iri": "http://www.w3.org/ns/sosa/hasSample"
+      },
+      "predicate": {
+        "lexical": "owl:propertyChainAxiom",
+        "iri": "http://www.w3.org/2002/07/owl#propertyChainAxiom"
+      },
+      "authoritative_target_lexical": "cco:represented_by o bfo:generically_depends_on",
+      "canonical_row_expression": {
+        "canonicalization": "coms-row-expression-v1",
+        "mapping_type": "property_chain",
+        "predicate_iri": "http://www.w3.org/2002/07/owl#propertyChainAxiom",
+        "subject_iri": "http://www.w3.org/ns/sosa/hasSample",
+        "target": "ObjectPropertyChain(<https://www.commoncoreontologies.org/ont00001873> <http://purl.obolibrary.org/obo/BFO_0000084>)"
+      },
+      "source_expression_sha256": "bfd39659b1869355d5164e90202c5d221a3d6363266d39483da4b91b727a63eb",
+      "mapping_type": "property_chain",
+      "coverage_classification": "property_chain",
+      "reasoning": "",
+      "authoritative_axioms": [
+        {
+          "axiom_id": "sha256:c0432102a5bd62d16ad94c26ec3e08d19540ba218dfb1a28a6bd87cd1e4be9ac",
+          "canonical_expression": "SubObjectPropertyOf(ObjectPropertyChain(<https://www.commoncoreontologies.org/ont00001873> <http://purl.obolibrary.org/obo/BFO_0000084>) <http://www.w3.org/ns/sosa/hasSample>)",
+          "referenced_iris": [
+            "http://purl.obolibrary.org/obo/BFO_0000084",
+            "http://www.w3.org/2002/07/owl#propertyChainAxiom",
+            "http://www.w3.org/ns/sosa/hasSample",
+            "https://www.commoncoreontologies.org/ont00001873"
+          ],
+          "target_category": "mixed_bfo_cco",
+          "product_dispositions": {
+            "integrated": {
+              "status": "emitted_unchanged"
+            },
+            "alignment_core": {
+              "status": "not_applicable",
+              "reason_code": "TARGET_SPECIFIC"
+            },
+            "strict_bfo_mapping": {
+              "status": "deferred",
+              "reason_code": "NO_APPROVED_TRANSFORMATION_RULE"
+            },
+            "bfo_projection": {
+              "status": "deferred",
+              "reason_code": "NO_APPROVED_TRANSFORMATION_RULE"
+            },
+            "cco_extension": {
+              "status": "emitted_unchanged"
+            }
+          }
+        }
+      ],
+      "row_product_dispositions": null
+    },
+    {
+      "row_id": "urn:uuid:2befdb79-d016-45f8-8c35-69ee93fa731f",
+      "location": {
+        "worksheet": "Sheet1",
+        "row": 23
+      },
+      "subject": {
+        "lexical": "ssn-system:Precision",
+        "iri": "http://www.w3.org/ns/ssn/systems/Precision"
+      },
+      "predicate": {
+        "lexical": "rdfs:subClassOf",
+        "iri": "http://www.w3.org/2000/01/rdf-schema#subClassOf"
+      },
+      "authoritative_target_lexical": "bfo:Function and bfo:has_realization some (bfo:Process and cco:is_subject_of some (cco:DescriptiveInformationContentEntity and cco:is_measured_by some (cco:ReliabilityMeasurementInformationContentEntity and cco:prescribed_by some cco:ArtifactFunctionSpecification)))",
+      "canonical_row_expression": {
+        "canonicalization": "coms-row-expression-v1",
+        "mapping_type": "class_mapping",
+        "predicate_iri": "http://www.w3.org/2000/01/rdf-schema#subClassOf",
+        "subject_iri": "http://www.w3.org/ns/ssn/systems/Precision",
+        "target": "ObjectIntersectionOf(<http://purl.obolibrary.org/obo/BFO_0000034> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000054> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/BFO_0000015> ObjectSomeValuesFrom(<https://www.commoncoreontologies.org/ont00001801> ObjectIntersectionOf(<https://www.commoncoreontologies.org/ont00000853> ObjectSomeValuesFrom(<https://www.commoncoreontologies.org/ont00001904> ObjectIntersectionOf(<https://www.commoncoreontologies.org/ont00001256> ObjectSomeValuesFrom(<https://www.commoncoreontologies.org/ont00001920> <https://www.commoncoreontologies.org/ont00000118>))))))))"
+      },
+      "source_expression_sha256": "0d074b5355e0d3561dc181a9fa4a987ac87799804de4b6d49828ced614ff7359",
+      "mapping_type": "class_mapping",
+      "coverage_classification": "class_mapping",
+      "reasoning": "",
+      "authoritative_axioms": [
+        {
+          "axiom_id": "sha256:7bcd034eadbf0577e59b123707dd31bbd105681183ea0b8e5cf98914676d3a59",
+          "canonical_expression": "SubClassOf(<http://www.w3.org/ns/ssn/systems/Precision> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/BFO_0000034> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000054> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/BFO_0000015> ObjectSomeValuesFrom(<https://www.commoncoreontologies.org/ont00001801> ObjectIntersectionOf(<https://www.commoncoreontologies.org/ont00000853> ObjectSomeValuesFrom(<https://www.commoncoreontologies.org/ont00001904> ObjectIntersectionOf(<https://www.commoncoreontologies.org/ont00001256> ObjectSomeValuesFrom(<https://www.commoncoreontologies.org/ont00001920> <https://www.commoncoreontologies.org/ont00000118>)))))))))",
+          "referenced_iris": [
+            "http://purl.obolibrary.org/obo/BFO_0000015",
+            "http://purl.obolibrary.org/obo/BFO_0000034",
+            "http://purl.obolibrary.org/obo/BFO_0000054",
+            "http://www.w3.org/2000/01/rdf-schema#subClassOf",
+            "http://www.w3.org/ns/ssn/systems/Precision",
+            "https://www.commoncoreontologies.org/ont00000118",
+            "https://www.commoncoreontologies.org/ont00000853",
+            "https://www.commoncoreontologies.org/ont00001256",
+            "https://www.commoncoreontologies.org/ont00001801",
+            "https://www.commoncoreontologies.org/ont00001904",
+            "https://www.commoncoreontologies.org/ont00001920"
+          ],
+          "target_category": "mixed_bfo_cco",
+          "product_dispositions": {
+            "integrated": {
+              "status": "emitted_unchanged"
+            },
+            "alignment_core": {
+              "status": "not_applicable",
+              "reason_code": "TARGET_SPECIFIC"
+            },
+            "strict_bfo_mapping": {
+              "status": "deferred",
+              "reason_code": "NO_APPROVED_TRANSFORMATION_RULE"
+            },
+            "bfo_projection": {
+              "status": "deferred",
+              "reason_code": "NO_APPROVED_TRANSFORMATION_RULE"
+            },
+            "cco_extension": {
+              "status": "emitted_unchanged"
+            }
+          }
+        }
+      ],
+      "row_product_dispositions": null
+    },
+    {
+      "row_id": "urn:uuid:304f62a7-9160-4857-9c39-04a7215b1bb0",
+      "location": {
+        "worksheet": "Sheet1",
+        "row": 28
+      },
+      "subject": {
+        "lexical": "ssn-system:SurvivalProperty",
+        "iri": "http://www.w3.org/ns/ssn/systems/SurvivalProperty"
+      },
+      "predicate": {
+        "lexical": "rdfs:subClassOf",
+        "iri": "http://www.w3.org/2000/01/rdf-schema#subClassOf"
+      },
+      "authoritative_target_lexical": "bfo:Function and bfo:has_realization some (bfo:Process and cco:caused_by some (bfo:Process and bfo:realizes some (cco:Affordance and cco:prescribed_by some cco:ArtifactDesign)))",
+      "canonical_row_expression": {
+        "canonicalization": "coms-row-expression-v1",
+        "mapping_type": "class_mapping",
+        "predicate_iri": "http://www.w3.org/2000/01/rdf-schema#subClassOf",
+        "subject_iri": "http://www.w3.org/ns/ssn/systems/SurvivalProperty",
+        "target": "ObjectIntersectionOf(<http://purl.obolibrary.org/obo/BFO_0000034> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000054> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/BFO_0000015> ObjectSomeValuesFrom(<https://www.commoncoreontologies.org/ont00001819> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/BFO_0000015> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000055> ObjectIntersectionOf(<https://www.commoncoreontologies.org/ont00000177> ObjectSomeValuesFrom(<https://www.commoncoreontologies.org/ont00001920> <https://www.commoncoreontologies.org/ont00000319>))))))))"
+      },
+      "source_expression_sha256": "ea72f4dbda8f016f87ab205d4be69a51e6866ea076fb45c211661b2b68e73a15",
+      "mapping_type": "class_mapping",
+      "coverage_classification": "class_mapping",
+      "reasoning": "",
+      "authoritative_axioms": [
+        {
+          "axiom_id": "sha256:6c917d0118060a0a5c8175a486c2880f4948c998bfc384d1494925e0e9e26390",
+          "canonical_expression": "SubClassOf(<http://www.w3.org/ns/ssn/systems/SurvivalProperty> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/BFO_0000034> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000054> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/BFO_0000015> ObjectSomeValuesFrom(<https://www.commoncoreontologies.org/ont00001819> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/BFO_0000015> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000055> ObjectIntersectionOf(<https://www.commoncoreontologies.org/ont00000177> ObjectSomeValuesFrom(<https://www.commoncoreontologies.org/ont00001920> <https://www.commoncoreontologies.org/ont00000319>)))))))))",
+          "referenced_iris": [
+            "http://purl.obolibrary.org/obo/BFO_0000015",
+            "http://purl.obolibrary.org/obo/BFO_0000034",
+            "http://purl.obolibrary.org/obo/BFO_0000054",
+            "http://purl.obolibrary.org/obo/BFO_0000055",
+            "http://www.w3.org/2000/01/rdf-schema#subClassOf",
+            "http://www.w3.org/ns/ssn/systems/SurvivalProperty",
+            "https://www.commoncoreontologies.org/ont00000177",
+            "https://www.commoncoreontologies.org/ont00000319",
+            "https://www.commoncoreontologies.org/ont00001819",
+            "https://www.commoncoreontologies.org/ont00001920"
+          ],
+          "target_category": "mixed_bfo_cco",
+          "product_dispositions": {
+            "integrated": {
+              "status": "emitted_unchanged"
+            },
+            "alignment_core": {
+              "status": "not_applicable",
+              "reason_code": "TARGET_SPECIFIC"
+            },
+            "strict_bfo_mapping": {
+              "status": "deferred",
+              "reason_code": "NO_APPROVED_TRANSFORMATION_RULE"
+            },
+            "bfo_projection": {
+              "status": "deferred",
+              "reason_code": "NO_APPROVED_TRANSFORMATION_RULE"
+            },
+            "cco_extension": {
+              "status": "emitted_unchanged"
+            }
+          }
+        }
+      ],
+      "row_product_dispositions": null
+    },
+    {
+      "row_id": "urn:uuid:326ad20d-f954-44e0-b94f-dccf0fd76ebb",
+      "location": {
+        "worksheet": "Sheet1",
+        "row": 11
+      },
+      "subject": {
+        "lexical": "sosa:Sample",
+        "iri": "http://www.w3.org/ns/sosa/Sample"
+      },
+      "predicate": {
+        "lexical": "owl:equivalentClass",
+        "iri": "http://www.w3.org/2002/07/owl#equivalentClass"
+      },
+      "authoritative_target_lexical": "bfo:MaterialEntity and (cco:is_object_of some sosa:Sampling)",
+      "canonical_row_expression": {
+        "canonicalization": "coms-row-expression-v1",
+        "mapping_type": "class_mapping",
+        "predicate_iri": "http://www.w3.org/2002/07/owl#equivalentClass",
+        "subject_iri": "http://www.w3.org/ns/sosa/Sample",
+        "target": "ObjectIntersectionOf(<http://purl.obolibrary.org/obo/BFO_0000040> ObjectSomeValuesFrom(<https://www.commoncoreontologies.org/ont00001936> <http://www.w3.org/ns/sosa/Sampling>))"
+      },
+      "source_expression_sha256": "487e82d6ba9c2529f91b500b06e2681ee82343693847544dd8428fb02758469d",
+      "mapping_type": "class_mapping",
+      "coverage_classification": "class_mapping",
+      "reasoning": "",
+      "authoritative_axioms": [
+        {
+          "axiom_id": "sha256:787e892cd89062b21176fd6a4732cccaba3bd65cddaae2d9c8580e3072b140b9",
+          "canonical_expression": "EquivalentClasses(<http://www.w3.org/ns/sosa/Sample> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/BFO_0000040> ObjectSomeValuesFrom(<https://www.commoncoreontologies.org/ont00001936> <http://www.w3.org/ns/sosa/Sampling>)))",
+          "referenced_iris": [
+            "http://purl.obolibrary.org/obo/BFO_0000040",
+            "http://www.w3.org/2002/07/owl#equivalentClass",
+            "http://www.w3.org/ns/sosa/Sample",
+            "http://www.w3.org/ns/sosa/Sampling",
+            "https://www.commoncoreontologies.org/ont00001936"
+          ],
+          "target_category": "mixed_bfo_cco",
+          "product_dispositions": {
+            "integrated": {
+              "status": "emitted_unchanged"
+            },
+            "alignment_core": {
+              "status": "not_applicable",
+              "reason_code": "TARGET_SPECIFIC"
+            },
+            "strict_bfo_mapping": {
+              "status": "deferred",
+              "reason_code": "NO_APPROVED_TRANSFORMATION_RULE"
+            },
+            "bfo_projection": {
+              "status": "deferred",
+              "reason_code": "NO_APPROVED_TRANSFORMATION_RULE"
+            },
+            "cco_extension": {
+              "status": "emitted_unchanged"
+            }
+          }
+        }
+      ],
+      "row_product_dispositions": null
+    },
+    {
+      "row_id": "urn:uuid:335606ce-18b3-43d9-b13e-7301015c9d26",
+      "location": {
+        "worksheet": "Sheet1",
+        "row": 20
+      },
+      "subject": {
+        "lexical": "ssn-system:OperatingPowerRange",
+        "iri": "http://www.w3.org/ns/ssn/systems/OperatingPowerRange"
+      },
+      "predicate": {
+        "lexical": "rdfs:subClassOf",
+        "iri": "http://www.w3.org/2000/01/rdf-schema#subClassOf"
+      },
+      "authoritative_target_lexical": "bfo:Function and bfo:has_realization some (bfo:Process and bfo:has_occurrent_part some (cco:Power and cco:prescribed_by some cco:ArtifactDesign))",
+      "canonical_row_expression": {
+        "canonicalization": "coms-row-expression-v1",
+        "mapping_type": "class_mapping",
+        "predicate_iri": "http://www.w3.org/2000/01/rdf-schema#subClassOf",
+        "subject_iri": "http://www.w3.org/ns/ssn/systems/OperatingPowerRange",
+        "target": "ObjectIntersectionOf(<http://purl.obolibrary.org/obo/BFO_0000034> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000054> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/BFO_0000015> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000117> ObjectIntersectionOf(<https://www.commoncoreontologies.org/ont00000503> ObjectSomeValuesFrom(<https://www.commoncoreontologies.org/ont00001920> <https://www.commoncoreontologies.org/ont00000319>))))))"
+      },
+      "source_expression_sha256": "ca6148da0e1204ef82128833520bde3ed981f4676c8e3866ebf758b01a421e5b",
+      "mapping_type": "class_mapping",
+      "coverage_classification": "class_mapping",
+      "reasoning": "",
+      "authoritative_axioms": [
+        {
+          "axiom_id": "sha256:2d3f18260f6d804a9e949bda85aca7dcfe2d170b01199991ee8797423dd99a61",
+          "canonical_expression": "SubClassOf(<http://www.w3.org/ns/ssn/systems/OperatingPowerRange> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/BFO_0000034> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000054> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/BFO_0000015> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000117> ObjectIntersectionOf(<https://www.commoncoreontologies.org/ont00000503> ObjectSomeValuesFrom(<https://www.commoncoreontologies.org/ont00001920> <https://www.commoncoreontologies.org/ont00000319>)))))))",
+          "referenced_iris": [
+            "http://purl.obolibrary.org/obo/BFO_0000015",
+            "http://purl.obolibrary.org/obo/BFO_0000034",
+            "http://purl.obolibrary.org/obo/BFO_0000054",
+            "http://purl.obolibrary.org/obo/BFO_0000117",
+            "http://www.w3.org/2000/01/rdf-schema#subClassOf",
+            "http://www.w3.org/ns/ssn/systems/OperatingPowerRange",
+            "https://www.commoncoreontologies.org/ont00000319",
+            "https://www.commoncoreontologies.org/ont00000503",
+            "https://www.commoncoreontologies.org/ont00001920"
+          ],
+          "target_category": "mixed_bfo_cco",
+          "product_dispositions": {
+            "integrated": {
+              "status": "emitted_unchanged"
+            },
+            "alignment_core": {
+              "status": "not_applicable",
+              "reason_code": "TARGET_SPECIFIC"
+            },
+            "strict_bfo_mapping": {
+              "status": "deferred",
+              "reason_code": "NO_APPROVED_TRANSFORMATION_RULE"
+            },
+            "bfo_projection": {
+              "status": "deferred",
+              "reason_code": "NO_APPROVED_TRANSFORMATION_RULE"
+            },
+            "cco_extension": {
+              "status": "emitted_unchanged"
+            }
+          }
+        }
+      ],
+      "row_product_dispositions": null
+    },
+    {
+      "row_id": "urn:uuid:3734c3b6-e62e-4ae5-be42-8fef0b10d2f4",
+      "location": {
+        "worksheet": "Sheet2",
+        "row": 4
+      },
+      "subject": {
+        "lexical": "sampling:relatedSample",
+        "iri": "http://www.w3.org/ns/sosa/sampling/relatedSample"
+      },
+      "predicate": {
+        "lexical": "rdfs:subPropertyOf",
+        "iri": "http://www.w3.org/2000/01/rdf-schema#subPropertyOf"
+      },
+      "authoritative_target_lexical": "cco:is_about",
+      "canonical_row_expression": {
+        "canonicalization": "coms-row-expression-v1",
+        "mapping_type": "object_property_mapping",
+        "predicate_iri": "http://www.w3.org/2000/01/rdf-schema#subPropertyOf",
+        "subject_iri": "http://www.w3.org/ns/sosa/sampling/relatedSample",
+        "target": "<https://www.commoncoreontologies.org/ont00001808>"
+      },
+      "source_expression_sha256": "1569e27d068c2096846026f7f259c735d3d2d494edb6de138cb0b14dd63af95e",
+      "mapping_type": "object_property_mapping",
+      "coverage_classification": "relation_mapping",
+      "reasoning": "",
+      "authoritative_axioms": [
+        {
+          "axiom_id": "sha256:72d1a5d3f112c4b7c8d7eb32b1196babbd912b1213beba3c5d2967fbf7221ba0",
+          "canonical_expression": "SubObjectPropertyOf(<http://www.w3.org/ns/sosa/sampling/relatedSample> <https://www.commoncoreontologies.org/ont00001808>)",
+          "referenced_iris": [
+            "http://www.w3.org/2000/01/rdf-schema#subPropertyOf",
+            "http://www.w3.org/ns/sosa/sampling/relatedSample",
+            "https://www.commoncoreontologies.org/ont00001808"
+          ],
+          "target_category": "cco_bearing",
+          "product_dispositions": {
+            "integrated": {
+              "status": "emitted_unchanged"
+            },
+            "alignment_core": {
+              "status": "not_applicable",
+              "reason_code": "TARGET_SPECIFIC"
+            },
+            "strict_bfo_mapping": {
+              "status": "deferred",
+              "reason_code": "NO_APPROVED_TRANSFORMATION_RULE"
+            },
+            "bfo_projection": {
+              "status": "deferred",
+              "reason_code": "NO_APPROVED_TRANSFORMATION_RULE"
+            },
+            "cco_extension": {
+              "status": "emitted_unchanged"
+            }
+          }
+        }
+      ],
+      "row_product_dispositions": null
+    },
+    {
+      "row_id": "urn:uuid:37576663-68e9-4298-8652-a3c614c34ae3",
+      "location": {
+        "worksheet": "Sheet2",
+        "row": 37
+      },
+      "subject": {
+        "lexical": "ssn-system:hasOperatingProperty",
+        "iri": "http://www.w3.org/ns/ssn/systems/hasOperatingProperty"
+      },
+      "predicate": {
+        "lexical": "rdfs:subPropertyOf",
+        "iri": "http://www.w3.org/2000/01/rdf-schema#subPropertyOf"
+      },
+      "authoritative_target_lexical": "bfo:specifically_depended_on_by",
+      "canonical_row_expression": {
+        "canonicalization": "coms-row-expression-v1",
+        "mapping_type": "object_property_mapping",
+        "predicate_iri": "http://www.w3.org/2000/01/rdf-schema#subPropertyOf",
+        "subject_iri": "http://www.w3.org/ns/ssn/systems/hasOperatingProperty",
+        "target": "<http://purl.obolibrary.org/obo/BFO_0000194>"
+      },
+      "source_expression_sha256": "d0957c4a3b9e144232abb48c196d943ff1118b429eb4cc27532d4247d4c2c5b6",
+      "mapping_type": "object_property_mapping",
+      "coverage_classification": "relation_mapping",
+      "reasoning": "",
+      "authoritative_axioms": [
+        {
+          "axiom_id": "sha256:4ee0a31d0d7abc626e19715ee1f31b610823136f2ea133155491a644f72db22a",
+          "canonical_expression": "SubObjectPropertyOf(<http://www.w3.org/ns/ssn/systems/hasOperatingProperty> <http://purl.obolibrary.org/obo/BFO_0000194>)",
+          "referenced_iris": [
+            "http://purl.obolibrary.org/obo/BFO_0000194",
+            "http://www.w3.org/2000/01/rdf-schema#subPropertyOf",
+            "http://www.w3.org/ns/ssn/systems/hasOperatingProperty"
+          ],
+          "target_category": "bfo_bearing",
+          "product_dispositions": {
+            "integrated": {
+              "status": "emitted_unchanged"
+            },
+            "alignment_core": {
+              "status": "not_applicable",
+              "reason_code": "TARGET_SPECIFIC"
+            },
+            "strict_bfo_mapping": {
+              "status": "emitted_unchanged"
+            },
+            "bfo_projection": {
+              "status": "provided_through_import"
+            },
+            "cco_extension": {
+              "status": "provided_through_import"
+            }
+          }
+        }
+      ],
+      "row_product_dispositions": null
+    },
+    {
+      "row_id": "urn:uuid:377fa547-ff5c-4ffa-af6f-40d291ab2ab9",
+      "location": {
+        "worksheet": "Sheet2",
+        "row": 12
+      },
+      "subject": {
+        "lexical": "sosa:usedProcedure",
+        "iri": "http://www.w3.org/ns/sosa/usedProcedure"
+      },
+      "predicate": {
+        "lexical": "rdfs:subPropertyOf",
+        "iri": "http://www.w3.org/2000/01/rdf-schema#subPropertyOf"
+      },
+      "authoritative_target_lexical": "cco:prescribed_by",
+      "canonical_row_expression": {
+        "canonicalization": "coms-row-expression-v1",
+        "mapping_type": "object_property_mapping",
+        "predicate_iri": "http://www.w3.org/2000/01/rdf-schema#subPropertyOf",
+        "subject_iri": "http://www.w3.org/ns/sosa/usedProcedure",
+        "target": "<https://www.commoncoreontologies.org/ont00001920>"
+      },
+      "source_expression_sha256": "9f73be21f435e6ac7a96c45014d248ffa694c90e0c1ae716885675ac74d2d918",
+      "mapping_type": "object_property_mapping",
+      "coverage_classification": "relation_mapping",
+      "reasoning": "",
+      "authoritative_axioms": [
+        {
+          "axiom_id": "sha256:87e268563c3100731545a500259535d0784a692b94e3d42d25ef938a1b5019af",
+          "canonical_expression": "SubObjectPropertyOf(<http://www.w3.org/ns/sosa/usedProcedure> <https://www.commoncoreontologies.org/ont00001920>)",
+          "referenced_iris": [
+            "http://www.w3.org/2000/01/rdf-schema#subPropertyOf",
+            "http://www.w3.org/ns/sosa/usedProcedure",
+            "https://www.commoncoreontologies.org/ont00001920"
+          ],
+          "target_category": "cco_bearing",
+          "product_dispositions": {
+            "integrated": {
+              "status": "emitted_unchanged"
+            },
+            "alignment_core": {
+              "status": "not_applicable",
+              "reason_code": "TARGET_SPECIFIC"
+            },
+            "strict_bfo_mapping": {
+              "status": "deferred",
+              "reason_code": "NO_APPROVED_TRANSFORMATION_RULE"
+            },
+            "bfo_projection": {
+              "status": "deferred",
+              "reason_code": "NO_APPROVED_TRANSFORMATION_RULE"
+            },
+            "cco_extension": {
+              "status": "emitted_unchanged"
+            }
+          }
+        }
+      ],
+      "row_product_dispositions": null
+    },
+    {
+      "row_id": "urn:uuid:37fac05e-0d70-420d-a0c0-78bc1d87cd63",
+      "location": {
+        "worksheet": "Sheet2",
+        "row": 22
+      },
+      "subject": {
+        "lexical": "sosa:isObservedBy",
+        "iri": "http://www.w3.org/ns/sosa/isObservedBy"
+      },
+      "predicate": {
+        "lexical": "rdfs:range",
+        "iri": "http://www.w3.org/2000/01/rdf-schema#range"
+      },
+      "authoritative_target_lexical": "sosa:Sensor",
+      "canonical_row_expression": {
+        "canonicalization": "coms-row-expression-v1",
+        "mapping_type": "range",
+        "predicate_iri": "http://www.w3.org/2000/01/rdf-schema#range",
+        "subject_iri": "http://www.w3.org/ns/sosa/isObservedBy",
+        "target": "<http://www.w3.org/ns/sosa/Sensor>"
+      },
+      "source_expression_sha256": "7096425af18d2a7f3be2531b2f91886a07801fc4e247087fa8418f28fd041ab6",
+      "mapping_type": "range",
+      "coverage_classification": "property_typing",
+      "reasoning": "",
+      "authoritative_axioms": [
+        {
+          "axiom_id": "sha256:1f37a84e9d8ba4775e3ff0dd1f730f21cd573dba406d80512ce84a4edb70c456",
+          "canonical_expression": "ObjectPropertyRange(<http://www.w3.org/ns/sosa/isObservedBy> <http://www.w3.org/ns/sosa/Sensor>)",
+          "referenced_iris": [
+            "http://www.w3.org/2000/01/rdf-schema#range",
+            "http://www.w3.org/ns/sosa/Sensor",
+            "http://www.w3.org/ns/sosa/isObservedBy"
+          ],
+          "target_category": "target_neutral",
+          "product_dispositions": {
+            "integrated": {
+              "status": "emitted_unchanged"
+            },
+            "alignment_core": {
+              "status": "emitted_unchanged"
+            },
+            "strict_bfo_mapping": {
+              "status": "provided_through_import"
+            },
+            "bfo_projection": {
+              "status": "provided_transitively"
+            },
+            "cco_extension": {
+              "status": "provided_transitively"
+            }
+          }
+        }
+      ],
+      "row_product_dispositions": null
+    },
+    {
+      "row_id": "urn:uuid:3ac135c9-bfd7-49cf-9c51-4d6e9ed56d87",
+      "location": {
+        "worksheet": "Sheet1",
+        "row": 24
+      },
+      "subject": {
+        "lexical": "ssn-system:Resolution",
+        "iri": "http://www.w3.org/ns/ssn/systems/Resolution"
+      },
+      "predicate": {
+        "lexical": "rdfs:subClassOf",
+        "iri": "http://www.w3.org/2000/01/rdf-schema#subClassOf"
+      },
+      "authoritative_target_lexical": "bfo:Function and bfo:has_realization some (bfo:Process and cco:is_subject_of some (cco:DescriptiveInformationContentEntity and cco:is_measured_by some (cco:DeviationMeasurementInformationContentEntity and cco:prescribed_by some cco:ArtifactFunctionSpecification)))",
+      "canonical_row_expression": {
+        "canonicalization": "coms-row-expression-v1",
+        "mapping_type": "class_mapping",
+        "predicate_iri": "http://www.w3.org/2000/01/rdf-schema#subClassOf",
+        "subject_iri": "http://www.w3.org/ns/ssn/systems/Resolution",
+        "target": "ObjectIntersectionOf(<http://purl.obolibrary.org/obo/BFO_0000034> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000054> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/BFO_0000015> ObjectSomeValuesFrom(<https://www.commoncoreontologies.org/ont00001801> ObjectIntersectionOf(<https://www.commoncoreontologies.org/ont00000853> ObjectSomeValuesFrom(<https://www.commoncoreontologies.org/ont00001904> ObjectIntersectionOf(<https://www.commoncoreontologies.org/ont00000731> ObjectSomeValuesFrom(<https://www.commoncoreontologies.org/ont00001920> <https://www.commoncoreontologies.org/ont00000118>))))))))"
+      },
+      "source_expression_sha256": "a1b40bd9317136e38532eb86ffbd5249bced8edad40313d5ec3fc31357f918a4",
+      "mapping_type": "class_mapping",
+      "coverage_classification": "class_mapping",
+      "reasoning": "",
+      "authoritative_axioms": [
+        {
+          "axiom_id": "sha256:851caee27c77385ceed70a2deb1a071a3e708361318649f6f62e6b37813791a9",
+          "canonical_expression": "SubClassOf(<http://www.w3.org/ns/ssn/systems/Resolution> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/BFO_0000034> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000054> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/BFO_0000015> ObjectSomeValuesFrom(<https://www.commoncoreontologies.org/ont00001801> ObjectIntersectionOf(<https://www.commoncoreontologies.org/ont00000853> ObjectSomeValuesFrom(<https://www.commoncoreontologies.org/ont00001904> ObjectIntersectionOf(<https://www.commoncoreontologies.org/ont00000731> ObjectSomeValuesFrom(<https://www.commoncoreontologies.org/ont00001920> <https://www.commoncoreontologies.org/ont00000118>)))))))))",
+          "referenced_iris": [
+            "http://purl.obolibrary.org/obo/BFO_0000015",
+            "http://purl.obolibrary.org/obo/BFO_0000034",
+            "http://purl.obolibrary.org/obo/BFO_0000054",
+            "http://www.w3.org/2000/01/rdf-schema#subClassOf",
+            "http://www.w3.org/ns/ssn/systems/Resolution",
+            "https://www.commoncoreontologies.org/ont00000118",
+            "https://www.commoncoreontologies.org/ont00000731",
+            "https://www.commoncoreontologies.org/ont00000853",
+            "https://www.commoncoreontologies.org/ont00001801",
+            "https://www.commoncoreontologies.org/ont00001904",
+            "https://www.commoncoreontologies.org/ont00001920"
+          ],
+          "target_category": "mixed_bfo_cco",
+          "product_dispositions": {
+            "integrated": {
+              "status": "emitted_unchanged"
+            },
+            "alignment_core": {
+              "status": "not_applicable",
+              "reason_code": "TARGET_SPECIFIC"
+            },
+            "strict_bfo_mapping": {
+              "status": "deferred",
+              "reason_code": "NO_APPROVED_TRANSFORMATION_RULE"
+            },
+            "bfo_projection": {
+              "status": "deferred",
+              "reason_code": "NO_APPROVED_TRANSFORMATION_RULE"
+            },
+            "cco_extension": {
+              "status": "emitted_unchanged"
+            }
+          }
+        }
+      ],
+      "row_product_dispositions": null
+    },
+    {
+      "row_id": "urn:uuid:3af8734c-ac86-46b0-8c0c-27a19525bc1e",
+      "location": {
+        "worksheet": "Sheet2",
+        "row": 18
+      },
+      "subject": {
+        "lexical": "sosa:hosts",
+        "iri": "http://www.w3.org/ns/sosa/hosts"
+      },
+      "predicate": {
+        "lexical": "owl:propertyChainAxiom",
+        "iri": "http://www.w3.org/2002/07/owl#propertyChainAxiom"
+      },
+      "authoritative_target_lexical": "bfo:bearer_of o bfo:has_realization o bfo:has_participant",
+      "canonical_row_expression": {
+        "canonicalization": "coms-row-expression-v1",
+        "mapping_type": "property_chain",
+        "predicate_iri": "http://www.w3.org/2002/07/owl#propertyChainAxiom",
+        "subject_iri": "http://www.w3.org/ns/sosa/hosts",
+        "target": "ObjectPropertyChain(<http://purl.obolibrary.org/obo/BFO_0000196> <http://purl.obolibrary.org/obo/BFO_0000054> <http://purl.obolibrary.org/obo/BFO_0000057>)"
+      },
+      "source_expression_sha256": "9486b4a342f938c087be79e441c7f8767e177df1020995c8ce0c49c1e2fde60e",
+      "mapping_type": "property_chain",
+      "coverage_classification": "property_chain",
+      "reasoning": "",
+      "authoritative_axioms": [
+        {
+          "axiom_id": "sha256:90d2b3a965084a150dcd254003bbdd2e5d706d8dd1b7a941c44e44ee2ea1737e",
+          "canonical_expression": "SubObjectPropertyOf(ObjectPropertyChain(<http://purl.obolibrary.org/obo/BFO_0000196> <http://purl.obolibrary.org/obo/BFO_0000054> <http://purl.obolibrary.org/obo/BFO_0000057>) <http://www.w3.org/ns/sosa/hosts>)",
+          "referenced_iris": [
+            "http://purl.obolibrary.org/obo/BFO_0000054",
+            "http://purl.obolibrary.org/obo/BFO_0000057",
+            "http://purl.obolibrary.org/obo/BFO_0000196",
+            "http://www.w3.org/2002/07/owl#propertyChainAxiom",
+            "http://www.w3.org/ns/sosa/hosts"
+          ],
+          "target_category": "bfo_bearing",
+          "product_dispositions": {
+            "integrated": {
+              "status": "emitted_unchanged"
+            },
+            "alignment_core": {
+              "status": "not_applicable",
+              "reason_code": "TARGET_SPECIFIC"
+            },
+            "strict_bfo_mapping": {
+              "status": "emitted_unchanged"
+            },
+            "bfo_projection": {
+              "status": "provided_through_import"
+            },
+            "cco_extension": {
+              "status": "provided_through_import"
+            }
+          }
+        }
+      ],
+      "row_product_dispositions": null
+    },
+    {
+      "row_id": "urn:uuid:3ddcc935-040b-450b-8ffa-8b0972e33c3b",
+      "location": {
+        "worksheet": "Sheet1",
+        "row": 26
+      },
+      "subject": {
+        "lexical": "ssn-system:Selectivity",
+        "iri": "http://www.w3.org/ns/ssn/systems/Selectivity"
+      },
+      "predicate": {
+        "lexical": "rdfs:subClassOf",
+        "iri": "http://www.w3.org/2000/01/rdf-schema#subClassOf"
+      },
+      "authoritative_target_lexical": "bfo:Function and bfo:has_realization some (cco:PlannedAct and bfo:has_participant some (bfo:Continuant and cco:prescribed_by some cco:ArtifactFunctionSpecification))",
+      "canonical_row_expression": {
+        "canonicalization": "coms-row-expression-v1",
+        "mapping_type": "class_mapping",
+        "predicate_iri": "http://www.w3.org/2000/01/rdf-schema#subClassOf",
+        "subject_iri": "http://www.w3.org/ns/ssn/systems/Selectivity",
+        "target": "ObjectIntersectionOf(<http://purl.obolibrary.org/obo/BFO_0000034> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000054> ObjectIntersectionOf(<https://www.commoncoreontologies.org/ont00000228> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000057> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/BFO_0000002> ObjectSomeValuesFrom(<https://www.commoncoreontologies.org/ont00001920> <https://www.commoncoreontologies.org/ont00000118>))))))"
+      },
+      "source_expression_sha256": "aabf5aee802973379ba4c8cb711e194580526dde4b9a9c4669e4a2cd28d3a5da",
+      "mapping_type": "class_mapping",
+      "coverage_classification": "class_mapping",
+      "reasoning": "",
+      "authoritative_axioms": [
+        {
+          "axiom_id": "sha256:3638f72bc407bf83119efc46ddbf7364798b8e5afa31a906bc1d736b62d980b1",
+          "canonical_expression": "SubClassOf(<http://www.w3.org/ns/ssn/systems/Selectivity> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/BFO_0000034> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000054> ObjectIntersectionOf(<https://www.commoncoreontologies.org/ont00000228> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000057> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/BFO_0000002> ObjectSomeValuesFrom(<https://www.commoncoreontologies.org/ont00001920> <https://www.commoncoreontologies.org/ont00000118>)))))))",
+          "referenced_iris": [
+            "http://purl.obolibrary.org/obo/BFO_0000002",
+            "http://purl.obolibrary.org/obo/BFO_0000034",
+            "http://purl.obolibrary.org/obo/BFO_0000054",
+            "http://purl.obolibrary.org/obo/BFO_0000057",
+            "http://www.w3.org/2000/01/rdf-schema#subClassOf",
+            "http://www.w3.org/ns/ssn/systems/Selectivity",
+            "https://www.commoncoreontologies.org/ont00000118",
+            "https://www.commoncoreontologies.org/ont00000228",
+            "https://www.commoncoreontologies.org/ont00001920"
+          ],
+          "target_category": "mixed_bfo_cco",
+          "product_dispositions": {
+            "integrated": {
+              "status": "emitted_unchanged"
+            },
+            "alignment_core": {
+              "status": "not_applicable",
+              "reason_code": "TARGET_SPECIFIC"
+            },
+            "strict_bfo_mapping": {
+              "status": "deferred",
+              "reason_code": "NO_APPROVED_TRANSFORMATION_RULE"
+            },
+            "bfo_projection": {
+              "status": "deferred",
+              "reason_code": "NO_APPROVED_TRANSFORMATION_RULE"
+            },
+            "cco_extension": {
+              "status": "emitted_unchanged"
+            }
+          }
+        }
+      ],
+      "row_product_dispositions": null
+    },
+    {
+      "row_id": "urn:uuid:434602eb-cfc3-4bca-9fb3-92154e87c6bc",
+      "location": {
+        "worksheet": "Sheet2",
+        "row": 32
+      },
+      "subject": {
+        "lexical": "sosa:madeBySensor",
+        "iri": "http://www.w3.org/ns/sosa/madeBySensor"
+      },
+      "predicate": {
+        "lexical": "rdfs:domain",
+        "iri": "http://www.w3.org/2000/01/rdf-schema#domain"
+      },
+      "authoritative_target_lexical": "sosa:Observation",
+      "canonical_row_expression": {
+        "canonicalization": "coms-row-expression-v1",
+        "mapping_type": "domain",
+        "predicate_iri": "http://www.w3.org/2000/01/rdf-schema#domain",
+        "subject_iri": "http://www.w3.org/ns/sosa/madeBySensor",
+        "target": "<http://www.w3.org/ns/sosa/Observation>"
+      },
+      "source_expression_sha256": "7e3f2b33b64788358236504d3e06e12bd7e0231949e52f31e801908d7e55f1db",
+      "mapping_type": "domain",
+      "coverage_classification": "property_typing",
+      "reasoning": "",
+      "authoritative_axioms": [
+        {
+          "axiom_id": "sha256:c8842712d9b51ad420a00450debb0f4fa62a2487b085a0ee6e722b1787bb676b",
+          "canonical_expression": "ObjectPropertyDomain(<http://www.w3.org/ns/sosa/madeBySensor> <http://www.w3.org/ns/sosa/Observation>)",
+          "referenced_iris": [
+            "http://www.w3.org/2000/01/rdf-schema#domain",
+            "http://www.w3.org/ns/sosa/Observation",
+            "http://www.w3.org/ns/sosa/madeBySensor"
+          ],
+          "target_category": "target_neutral",
+          "product_dispositions": {
+            "integrated": {
+              "status": "emitted_unchanged"
+            },
+            "alignment_core": {
+              "status": "emitted_unchanged"
+            },
+            "strict_bfo_mapping": {
+              "status": "provided_through_import"
+            },
+            "bfo_projection": {
+              "status": "provided_transitively"
+            },
+            "cco_extension": {
+              "status": "provided_transitively"
+            }
+          }
+        }
+      ],
+      "row_product_dispositions": null
+    },
+    {
+      "row_id": "urn:uuid:43ad1a14-e8a4-48d5-ae2b-3b5a5b28f8d3",
+      "location": {
+        "worksheet": "Sheet2",
+        "row": 55
+      },
+      "subject": {
+        "lexical": "ssn:hasProperty",
+        "iri": "http://www.w3.org/ns/ssn/hasProperty"
+      },
+      "predicate": {
+        "lexical": "rdfs:range",
+        "iri": "http://www.w3.org/2000/01/rdf-schema#range"
+      },
+      "authoritative_target_lexical": "(bfo:SpecificallyDependentContinuant or bfo:ProcessProfile)",
+      "canonical_row_expression": {
+        "canonicalization": "coms-row-expression-v1",
+        "mapping_type": "range",
+        "predicate_iri": "http://www.w3.org/2000/01/rdf-schema#range",
+        "subject_iri": "http://www.w3.org/ns/ssn/hasProperty",
+        "target": "ObjectUnionOf(<http://purl.obolibrary.org/obo/BFO_0000020> <http://purl.obolibrary.org/obo/BFO_0000144>)"
+      },
+      "source_expression_sha256": "1b842013b19abf9df9c994d68128178132fda149bb001b02c29ebfd93a043804",
+      "mapping_type": "range",
+      "coverage_classification": "property_typing",
+      "reasoning": "",
+      "authoritative_axioms": [
+        {
+          "axiom_id": "sha256:6dfa77b04dfaea343d0a8767e6467c603eafddf10395ff40ac7416f52c7fd4d4",
+          "canonical_expression": "ObjectPropertyRange(<http://www.w3.org/ns/ssn/hasProperty> ObjectUnionOf(<http://purl.obolibrary.org/obo/BFO_0000020> <http://purl.obolibrary.org/obo/BFO_0000144>))",
+          "referenced_iris": [
+            "http://purl.obolibrary.org/obo/BFO_0000020",
+            "http://purl.obolibrary.org/obo/BFO_0000144",
+            "http://www.w3.org/2000/01/rdf-schema#range",
+            "http://www.w3.org/ns/ssn/hasProperty"
+          ],
+          "target_category": "bfo_bearing",
+          "product_dispositions": {
+            "integrated": {
+              "status": "emitted_unchanged"
+            },
+            "alignment_core": {
+              "status": "not_applicable",
+              "reason_code": "TARGET_SPECIFIC"
+            },
+            "strict_bfo_mapping": {
+              "status": "emitted_unchanged"
+            },
+            "bfo_projection": {
+              "status": "provided_through_import"
+            },
+            "cco_extension": {
+              "status": "provided_through_import"
+            }
+          }
+        }
+      ],
+      "row_product_dispositions": null
+    },
+    {
+      "row_id": "urn:uuid:4afaf231-5478-4a50-9a12-0cbf59d78d7e",
+      "location": {
+        "worksheet": "Sheet2",
+        "row": 57
+      },
+      "subject": {
+        "lexical": "ssn:implementedBy",
+        "iri": "http://www.w3.org/ns/ssn/implementedBy"
+      },
+      "predicate": {
+        "lexical": "rdfs:subPropertyOf",
+        "iri": "http://www.w3.org/2000/01/rdf-schema#subPropertyOf"
+      },
+      "authoritative_target_lexical": "cco:prescribes",
+      "canonical_row_expression": {
+        "canonicalization": "coms-row-expression-v1",
+        "mapping_type": "object_property_mapping",
+        "predicate_iri": "http://www.w3.org/2000/01/rdf-schema#subPropertyOf",
+        "subject_iri": "http://www.w3.org/ns/ssn/implementedBy",
+        "target": "<https://www.commoncoreontologies.org/ont00001942>"
+      },
+      "source_expression_sha256": "ef681068fcc4afa870acf612bb26197c4711ac04eab19500f0e96a75a004d10b",
+      "mapping_type": "object_property_mapping",
+      "coverage_classification": "relation_mapping",
+      "reasoning": "",
+      "authoritative_axioms": [
+        {
+          "axiom_id": "sha256:14fa695165c7036e41a38bca759038d8c35e8b0b6362c6940d3359cf0143fac1",
+          "canonical_expression": "SubObjectPropertyOf(<http://www.w3.org/ns/ssn/implementedBy> <https://www.commoncoreontologies.org/ont00001942>)",
+          "referenced_iris": [
+            "http://www.w3.org/2000/01/rdf-schema#subPropertyOf",
+            "http://www.w3.org/ns/ssn/implementedBy",
+            "https://www.commoncoreontologies.org/ont00001942"
+          ],
+          "target_category": "cco_bearing",
+          "product_dispositions": {
+            "integrated": {
+              "status": "emitted_unchanged"
+            },
+            "alignment_core": {
+              "status": "not_applicable",
+              "reason_code": "TARGET_SPECIFIC"
+            },
+            "strict_bfo_mapping": {
+              "status": "deferred",
+              "reason_code": "NO_APPROVED_TRANSFORMATION_RULE"
+            },
+            "bfo_projection": {
+              "status": "deferred",
+              "reason_code": "NO_APPROVED_TRANSFORMATION_RULE"
+            },
+            "cco_extension": {
+              "status": "emitted_unchanged"
+            }
+          }
+        }
+      ],
+      "row_product_dispositions": null
+    },
+    {
+      "row_id": "urn:uuid:51c8556f-9b82-4113-a9d7-c733e70cf8cd",
+      "location": {
+        "worksheet": "Sheet2",
+        "row": 62
+      },
+      "subject": {
+        "lexical": "ssn:wasOriginatedBy",
+        "iri": "http://www.w3.org/ns/ssn/wasOriginatedBy"
+      },
+      "predicate": {
+        "lexical": "rdfs:subPropertyOf",
+        "iri": "http://www.w3.org/2000/01/rdf-schema#subPropertyOf"
+      },
+      "authoritative_target_lexical": "cco:process_started_by",
+      "canonical_row_expression": {
+        "canonicalization": "coms-row-expression-v1",
+        "mapping_type": "object_property_mapping",
+        "predicate_iri": "http://www.w3.org/2000/01/rdf-schema#subPropertyOf",
+        "subject_iri": "http://www.w3.org/ns/ssn/wasOriginatedBy",
+        "target": "<https://www.commoncoreontologies.org/ont00001962>"
+      },
+      "source_expression_sha256": "fe8a979e62b1dfe2f2f00c6a65df77262575c4c615fa293e1c5f5095ef61b44c",
+      "mapping_type": "object_property_mapping",
+      "coverage_classification": "relation_mapping",
+      "reasoning": "",
+      "authoritative_axioms": [
+        {
+          "axiom_id": "sha256:66b0f4f770429025a37f6fe8844978ab9e46dc963d0a33ad2a0a55839199cdd1",
+          "canonical_expression": "SubObjectPropertyOf(<http://www.w3.org/ns/ssn/wasOriginatedBy> <https://www.commoncoreontologies.org/ont00001962>)",
+          "referenced_iris": [
+            "http://www.w3.org/2000/01/rdf-schema#subPropertyOf",
+            "http://www.w3.org/ns/ssn/wasOriginatedBy",
+            "https://www.commoncoreontologies.org/ont00001962"
+          ],
+          "target_category": "cco_bearing",
+          "product_dispositions": {
+            "integrated": {
+              "status": "emitted_unchanged"
+            },
+            "alignment_core": {
+              "status": "not_applicable",
+              "reason_code": "TARGET_SPECIFIC"
+            },
+            "strict_bfo_mapping": {
+              "status": "deferred",
+              "reason_code": "NO_APPROVED_TRANSFORMATION_RULE"
+            },
+            "bfo_projection": {
+              "status": "deferred",
+              "reason_code": "NO_APPROVED_TRANSFORMATION_RULE"
+            },
+            "cco_extension": {
+              "status": "emitted_unchanged"
+            }
+          }
+        }
+      ],
+      "row_product_dispositions": null
+    },
+    {
+      "row_id": "urn:uuid:5ce06556-de99-44be-922d-a3d092a00dbb",
+      "location": {
+        "worksheet": "Sheet2",
+        "row": 24
+      },
+      "subject": {
+        "lexical": "sosa:observes",
+        "iri": "http://www.w3.org/ns/sosa/observes"
+      },
+      "predicate": {
+        "lexical": "rdfs:range",
+        "iri": "http://www.w3.org/2000/01/rdf-schema#range"
+      },
+      "authoritative_target_lexical": "sosa:ObservableProperty",
+      "canonical_row_expression": {
+        "canonicalization": "coms-row-expression-v1",
+        "mapping_type": "range",
+        "predicate_iri": "http://www.w3.org/2000/01/rdf-schema#range",
+        "subject_iri": "http://www.w3.org/ns/sosa/observes",
+        "target": "<http://www.w3.org/ns/sosa/ObservableProperty>"
+      },
+      "source_expression_sha256": "40def499db727e011d4b1a88c5e98174923a2bc9b23ad00d6b7e46398b1934fb",
+      "mapping_type": "range",
+      "coverage_classification": "property_typing",
+      "reasoning": "",
+      "authoritative_axioms": [
+        {
+          "axiom_id": "sha256:5c980e110913e59c68de989465bb1ecc8b07e55d4ef9801e8e46783cb89cf1b1",
+          "canonical_expression": "ObjectPropertyRange(<http://www.w3.org/ns/sosa/observes> <http://www.w3.org/ns/sosa/ObservableProperty>)",
+          "referenced_iris": [
+            "http://www.w3.org/2000/01/rdf-schema#range",
+            "http://www.w3.org/ns/sosa/ObservableProperty",
+            "http://www.w3.org/ns/sosa/observes"
+          ],
+          "target_category": "target_neutral",
+          "product_dispositions": {
+            "integrated": {
+              "status": "emitted_unchanged"
+            },
+            "alignment_core": {
+              "status": "emitted_unchanged"
+            },
+            "strict_bfo_mapping": {
+              "status": "provided_through_import"
+            },
+            "bfo_projection": {
+              "status": "provided_transitively"
+            },
+            "cco_extension": {
+              "status": "provided_transitively"
+            }
+          }
+        }
+      ],
+      "row_product_dispositions": null
+    },
+    {
+      "row_id": "urn:uuid:5ec3234d-bd10-4f5b-89f9-f2abb75764ec",
+      "location": {
+        "worksheet": "Sheet2",
+        "row": 2
+      },
+      "subject": {
+        "lexical": "sampling:hasSampleRelationship",
+        "iri": "http://www.w3.org/ns/sosa/sampling/hasSampleRelationship"
+      },
+      "predicate": {
+        "lexical": "rdfs:subPropertyOf",
+        "iri": "http://www.w3.org/2000/01/rdf-schema#subPropertyOf"
+      },
+      "authoritative_target_lexical": "cco:is_subject_of",
+      "canonical_row_expression": {
+        "canonicalization": "coms-row-expression-v1",
+        "mapping_type": "object_property_mapping",
+        "predicate_iri": "http://www.w3.org/2000/01/rdf-schema#subPropertyOf",
+        "subject_iri": "http://www.w3.org/ns/sosa/sampling/hasSampleRelationship",
+        "target": "<https://www.commoncoreontologies.org/ont00001801>"
+      },
+      "source_expression_sha256": "30b0ba8398ec4a4a5215332bb3d11a737a3a6469cdb3a05fb9c373f570d5c1a4",
+      "mapping_type": "object_property_mapping",
+      "coverage_classification": "relation_mapping",
+      "reasoning": "",
+      "authoritative_axioms": [
+        {
+          "axiom_id": "sha256:bfcbd5b2f93ee1e69874a2c6918895e693d5f41d44568d2dff24404d9bc519f1",
+          "canonical_expression": "SubObjectPropertyOf(<http://www.w3.org/ns/sosa/sampling/hasSampleRelationship> <https://www.commoncoreontologies.org/ont00001801>)",
+          "referenced_iris": [
+            "http://www.w3.org/2000/01/rdf-schema#subPropertyOf",
+            "http://www.w3.org/ns/sosa/sampling/hasSampleRelationship",
+            "https://www.commoncoreontologies.org/ont00001801"
+          ],
+          "target_category": "cco_bearing",
+          "product_dispositions": {
+            "integrated": {
+              "status": "emitted_unchanged"
+            },
+            "alignment_core": {
+              "status": "not_applicable",
+              "reason_code": "TARGET_SPECIFIC"
+            },
+            "strict_bfo_mapping": {
+              "status": "deferred",
+              "reason_code": "NO_APPROVED_TRANSFORMATION_RULE"
+            },
+            "bfo_projection": {
+              "status": "deferred",
+              "reason_code": "NO_APPROVED_TRANSFORMATION_RULE"
+            },
+            "cco_extension": {
+              "status": "emitted_unchanged"
+            }
+          }
+        }
+      ],
+      "row_product_dispositions": null
+    },
+    {
+      "row_id": "urn:uuid:5f25dce9-54a0-442e-a9de-f18cd21aab1d",
+      "location": {
+        "worksheet": "Sheet2",
+        "row": 43
+      },
+      "subject": {
+        "lexical": "ssn-system:hasSystemCapability",
+        "iri": "http://www.w3.org/ns/ssn/systems/hasSystemCapability"
+      },
+      "predicate": {
+        "lexical": "rdfs:domain",
+        "iri": "http://www.w3.org/2000/01/rdf-schema#domain"
+      },
+      "authoritative_target_lexical": "ssn:System",
+      "canonical_row_expression": {
+        "canonicalization": "coms-row-expression-v1",
+        "mapping_type": "domain",
+        "predicate_iri": "http://www.w3.org/2000/01/rdf-schema#domain",
+        "subject_iri": "http://www.w3.org/ns/ssn/systems/hasSystemCapability",
+        "target": "<http://www.w3.org/ns/ssn/System>"
+      },
+      "source_expression_sha256": "ddebb2c5b741612c38258e89574653ffb5acb9f3e5758d5ee008b901a7ca7e00",
+      "mapping_type": "domain",
+      "coverage_classification": "property_typing",
+      "reasoning": "",
+      "authoritative_axioms": [
+        {
+          "axiom_id": "sha256:7bed0226c2da616898792bcdfc1f0ca3319d07f1934781cfec1282ebe747fe80",
+          "canonical_expression": "ObjectPropertyDomain(<http://www.w3.org/ns/ssn/systems/hasSystemCapability> <http://www.w3.org/ns/ssn/System>)",
+          "referenced_iris": [
+            "http://www.w3.org/2000/01/rdf-schema#domain",
+            "http://www.w3.org/ns/ssn/System",
+            "http://www.w3.org/ns/ssn/systems/hasSystemCapability"
+          ],
+          "target_category": "target_neutral",
+          "product_dispositions": {
+            "integrated": {
+              "status": "emitted_unchanged"
+            },
+            "alignment_core": {
+              "status": "emitted_unchanged"
+            },
+            "strict_bfo_mapping": {
+              "status": "provided_through_import"
+            },
+            "bfo_projection": {
+              "status": "provided_transitively"
+            },
+            "cco_extension": {
+              "status": "provided_transitively"
+            }
+          }
+        }
+      ],
+      "row_product_dispositions": null
+    },
+    {
+      "row_id": "urn:uuid:6142726b-21b1-4dba-b5ec-a7d6dca4afab",
+      "location": {
+        "worksheet": "Sheet2",
+        "row": 58
+      },
+      "subject": {
+        "lexical": "ssn:implements",
+        "iri": "http://www.w3.org/ns/ssn/implements"
+      },
+      "predicate": {
+        "lexical": "rdfs:subPropertyOf",
+        "iri": "http://www.w3.org/2000/01/rdf-schema#subPropertyOf"
+      },
+      "authoritative_target_lexical": "cco:prescribed_by",
+      "canonical_row_expression": {
+        "canonicalization": "coms-row-expression-v1",
+        "mapping_type": "object_property_mapping",
+        "predicate_iri": "http://www.w3.org/2000/01/rdf-schema#subPropertyOf",
+        "subject_iri": "http://www.w3.org/ns/ssn/implements",
+        "target": "<https://www.commoncoreontologies.org/ont00001920>"
+      },
+      "source_expression_sha256": "20dae62e65511464178b54e802ceac8a72064fe1ccf040205b2cbf4a70546373",
+      "mapping_type": "object_property_mapping",
+      "coverage_classification": "relation_mapping",
+      "reasoning": "",
+      "authoritative_axioms": [
+        {
+          "axiom_id": "sha256:392dd07207293b5643eb67b0770ba70c84452967e49f1986ccb747ebe8424d6d",
+          "canonical_expression": "SubObjectPropertyOf(<http://www.w3.org/ns/ssn/implements> <https://www.commoncoreontologies.org/ont00001920>)",
+          "referenced_iris": [
+            "http://www.w3.org/2000/01/rdf-schema#subPropertyOf",
+            "http://www.w3.org/ns/ssn/implements",
+            "https://www.commoncoreontologies.org/ont00001920"
+          ],
+          "target_category": "cco_bearing",
+          "product_dispositions": {
+            "integrated": {
+              "status": "emitted_unchanged"
+            },
+            "alignment_core": {
+              "status": "not_applicable",
+              "reason_code": "TARGET_SPECIFIC"
+            },
+            "strict_bfo_mapping": {
+              "status": "deferred",
+              "reason_code": "NO_APPROVED_TRANSFORMATION_RULE"
+            },
+            "bfo_projection": {
+              "status": "deferred",
+              "reason_code": "NO_APPROVED_TRANSFORMATION_RULE"
+            },
+            "cco_extension": {
+              "status": "emitted_unchanged"
+            }
+          }
+        }
+      ],
+      "row_product_dispositions": null
+    },
+    {
+      "row_id": "urn:uuid:61fc3404-f33a-4c4c-a25c-412d9972016c",
+      "location": {
+        "worksheet": "Sheet2",
+        "row": 23
+      },
+      "subject": {
+        "lexical": "sosa:observes",
+        "iri": "http://www.w3.org/ns/sosa/observes"
+      },
+      "predicate": {
+        "lexical": "rdfs:domain",
+        "iri": "http://www.w3.org/2000/01/rdf-schema#domain"
+      },
+      "authoritative_target_lexical": "sosa:Sensor",
+      "canonical_row_expression": {
+        "canonicalization": "coms-row-expression-v1",
+        "mapping_type": "domain",
+        "predicate_iri": "http://www.w3.org/2000/01/rdf-schema#domain",
+        "subject_iri": "http://www.w3.org/ns/sosa/observes",
+        "target": "<http://www.w3.org/ns/sosa/Sensor>"
+      },
+      "source_expression_sha256": "08f45d9daa6aa212c9fe32978de8d58ee3b1ecf098e692256b1aacb860518d63",
+      "mapping_type": "domain",
+      "coverage_classification": "property_typing",
+      "reasoning": "",
+      "authoritative_axioms": [
+        {
+          "axiom_id": "sha256:96693821f15cd413fae70f98804b76a37e4b549eb952782af48daab19adc0c43",
+          "canonical_expression": "ObjectPropertyDomain(<http://www.w3.org/ns/sosa/observes> <http://www.w3.org/ns/sosa/Sensor>)",
+          "referenced_iris": [
+            "http://www.w3.org/2000/01/rdf-schema#domain",
+            "http://www.w3.org/ns/sosa/Sensor",
+            "http://www.w3.org/ns/sosa/observes"
+          ],
+          "target_category": "target_neutral",
+          "product_dispositions": {
+            "integrated": {
+              "status": "emitted_unchanged"
+            },
+            "alignment_core": {
+              "status": "emitted_unchanged"
+            },
+            "strict_bfo_mapping": {
+              "status": "provided_through_import"
+            },
+            "bfo_projection": {
+              "status": "provided_transitively"
+            },
+            "cco_extension": {
+              "status": "provided_transitively"
+            }
+          }
+        }
+      ],
+      "row_product_dispositions": null
+    },
+    {
+      "row_id": "urn:uuid:624eaef2-892a-4b9d-8ed6-08c79571710f",
+      "location": {
+        "worksheet": "Sheet1",
+        "row": 27
+      },
+      "subject": {
+        "lexical": "ssn-system:Sensitivity",
+        "iri": "http://www.w3.org/ns/ssn/systems/Sensitivity"
+      },
+      "predicate": {
+        "lexical": "rdfs:subClassOf",
+        "iri": "http://www.w3.org/2000/01/rdf-schema#subClassOf"
+      },
+      "authoritative_target_lexical": "bfo:Function and bfo:has_realization some (bfo:Process and cco:is_subject_of some (cco:DescriptiveInformationContentEntity and cco:is_measured_by some (cco:RatioMeasurementInformationContentEntity and cco:prescribed_by some cco:ArtifactFunctionSpecification)))",
+      "canonical_row_expression": {
+        "canonicalization": "coms-row-expression-v1",
+        "mapping_type": "class_mapping",
+        "predicate_iri": "http://www.w3.org/2000/01/rdf-schema#subClassOf",
+        "subject_iri": "http://www.w3.org/ns/ssn/systems/Sensitivity",
+        "target": "ObjectIntersectionOf(<http://purl.obolibrary.org/obo/BFO_0000034> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000054> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/BFO_0000015> ObjectSomeValuesFrom(<https://www.commoncoreontologies.org/ont00001801> ObjectIntersectionOf(<https://www.commoncoreontologies.org/ont00000853> ObjectSomeValuesFrom(<https://www.commoncoreontologies.org/ont00001904> ObjectIntersectionOf(<https://www.commoncoreontologies.org/ont00001022> ObjectSomeValuesFrom(<https://www.commoncoreontologies.org/ont00001920> <https://www.commoncoreontologies.org/ont00000118>))))))))"
+      },
+      "source_expression_sha256": "be77705e2453a1ef9aa69d8177d99b0c696af3c83c36ae2b532117deea5f0102",
+      "mapping_type": "class_mapping",
+      "coverage_classification": "class_mapping",
+      "reasoning": "",
+      "authoritative_axioms": [
+        {
+          "axiom_id": "sha256:f7079e239ac89c931c0bf767439ded105c7d1760b7b6e0346551ef3c46d3f759",
+          "canonical_expression": "SubClassOf(<http://www.w3.org/ns/ssn/systems/Sensitivity> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/BFO_0000034> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000054> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/BFO_0000015> ObjectSomeValuesFrom(<https://www.commoncoreontologies.org/ont00001801> ObjectIntersectionOf(<https://www.commoncoreontologies.org/ont00000853> ObjectSomeValuesFrom(<https://www.commoncoreontologies.org/ont00001904> ObjectIntersectionOf(<https://www.commoncoreontologies.org/ont00001022> ObjectSomeValuesFrom(<https://www.commoncoreontologies.org/ont00001920> <https://www.commoncoreontologies.org/ont00000118>)))))))))",
+          "referenced_iris": [
+            "http://purl.obolibrary.org/obo/BFO_0000015",
+            "http://purl.obolibrary.org/obo/BFO_0000034",
+            "http://purl.obolibrary.org/obo/BFO_0000054",
+            "http://www.w3.org/2000/01/rdf-schema#subClassOf",
+            "http://www.w3.org/ns/ssn/systems/Sensitivity",
+            "https://www.commoncoreontologies.org/ont00000118",
+            "https://www.commoncoreontologies.org/ont00000853",
+            "https://www.commoncoreontologies.org/ont00001022",
+            "https://www.commoncoreontologies.org/ont00001801",
+            "https://www.commoncoreontologies.org/ont00001904",
+            "https://www.commoncoreontologies.org/ont00001920"
+          ],
+          "target_category": "mixed_bfo_cco",
+          "product_dispositions": {
+            "integrated": {
+              "status": "emitted_unchanged"
+            },
+            "alignment_core": {
+              "status": "not_applicable",
+              "reason_code": "TARGET_SPECIFIC"
+            },
+            "strict_bfo_mapping": {
+              "status": "deferred",
+              "reason_code": "NO_APPROVED_TRANSFORMATION_RULE"
+            },
+            "bfo_projection": {
+              "status": "deferred",
+              "reason_code": "NO_APPROVED_TRANSFORMATION_RULE"
+            },
+            "cco_extension": {
+              "status": "emitted_unchanged"
+            }
+          }
+        }
+      ],
+      "row_product_dispositions": null
+    },
+    {
+      "row_id": "urn:uuid:6335c13d-fb23-49fd-9662-fd682c79f172",
+      "location": {
+        "worksheet": "Sheet2",
+        "row": 48
+      },
+      "subject": {
+        "lexical": "ssn:detects",
+        "iri": "http://www.w3.org/ns/ssn/detects"
+      },
+      "predicate": {
+        "lexical": "rdfs:subPropertyOf",
+        "iri": "http://www.w3.org/2000/01/rdf-schema#subPropertyOf"
+      },
+      "authoritative_target_lexical": "cco:is_affected_by",
+      "canonical_row_expression": {
+        "canonicalization": "coms-row-expression-v1",
+        "mapping_type": "object_property_mapping",
+        "predicate_iri": "http://www.w3.org/2000/01/rdf-schema#subPropertyOf",
+        "subject_iri": "http://www.w3.org/ns/ssn/detects",
+        "target": "<https://www.commoncoreontologies.org/ont00001886>"
+      },
+      "source_expression_sha256": "ed695cce8fbcd13007bc517530f5fb2fc7f402d895ade3b37e801cc4b1cf32c1",
+      "mapping_type": "object_property_mapping",
+      "coverage_classification": "relation_mapping",
+      "reasoning": "",
+      "authoritative_axioms": [
+        {
+          "axiom_id": "sha256:fbdef9082a1ce45abecc3ed037f0fb12bb6c376dea196c3912566ee664f50370",
+          "canonical_expression": "SubObjectPropertyOf(<http://www.w3.org/ns/ssn/detects> <https://www.commoncoreontologies.org/ont00001886>)",
+          "referenced_iris": [
+            "http://www.w3.org/2000/01/rdf-schema#subPropertyOf",
+            "http://www.w3.org/ns/ssn/detects",
+            "https://www.commoncoreontologies.org/ont00001886"
+          ],
+          "target_category": "cco_bearing",
+          "product_dispositions": {
+            "integrated": {
+              "status": "emitted_unchanged"
+            },
+            "alignment_core": {
+              "status": "not_applicable",
+              "reason_code": "TARGET_SPECIFIC"
+            },
+            "strict_bfo_mapping": {
+              "status": "deferred",
+              "reason_code": "NO_APPROVED_TRANSFORMATION_RULE"
+            },
+            "bfo_projection": {
+              "status": "deferred",
+              "reason_code": "NO_APPROVED_TRANSFORMATION_RULE"
+            },
+            "cco_extension": {
+              "status": "emitted_unchanged"
+            }
+          }
+        }
+      ],
+      "row_product_dispositions": null
+    },
+    {
+      "row_id": "urn:uuid:637399a9-a264-49f7-bab8-33f2128646ab",
+      "location": {
+        "worksheet": "Sheet2",
+        "row": 17
+      },
+      "subject": {
+        "lexical": "sosa:isSampleOf",
+        "iri": "http://www.w3.org/ns/sosa/isSampleOf"
+      },
+      "predicate": {
+        "lexical": "owl:propertyChainAxiom",
+        "iri": "http://www.w3.org/2002/07/owl#propertyChainAxiom"
+      },
+      "authoritative_target_lexical": "bfo:is_carrier_of o cco:represents",
+      "canonical_row_expression": {
+        "canonicalization": "coms-row-expression-v1",
+        "mapping_type": "property_chain",
+        "predicate_iri": "http://www.w3.org/2002/07/owl#propertyChainAxiom",
+        "subject_iri": "http://www.w3.org/ns/sosa/isSampleOf",
+        "target": "ObjectPropertyChain(<http://purl.obolibrary.org/obo/BFO_0000101> <https://www.commoncoreontologies.org/ont00001938>)"
+      },
+      "source_expression_sha256": "b1a2c6cce4e6700710ae9ca757188aa405e374fd6751a4cfc8793c257116fb7e",
+      "mapping_type": "property_chain",
+      "coverage_classification": "property_chain",
+      "reasoning": "",
+      "authoritative_axioms": [
+        {
+          "axiom_id": "sha256:84f1b6aa230d7c28f6304184fc7fac90089a78438b92a07b92a9e45763c9b951",
+          "canonical_expression": "SubObjectPropertyOf(ObjectPropertyChain(<http://purl.obolibrary.org/obo/BFO_0000101> <https://www.commoncoreontologies.org/ont00001938>) <http://www.w3.org/ns/sosa/isSampleOf>)",
+          "referenced_iris": [
+            "http://purl.obolibrary.org/obo/BFO_0000101",
+            "http://www.w3.org/2002/07/owl#propertyChainAxiom",
+            "http://www.w3.org/ns/sosa/isSampleOf",
+            "https://www.commoncoreontologies.org/ont00001938"
+          ],
+          "target_category": "mixed_bfo_cco",
+          "product_dispositions": {
+            "integrated": {
+              "status": "emitted_unchanged"
+            },
+            "alignment_core": {
+              "status": "not_applicable",
+              "reason_code": "TARGET_SPECIFIC"
+            },
+            "strict_bfo_mapping": {
+              "status": "deferred",
+              "reason_code": "NO_APPROVED_TRANSFORMATION_RULE"
+            },
+            "bfo_projection": {
+              "status": "deferred",
+              "reason_code": "NO_APPROVED_TRANSFORMATION_RULE"
+            },
+            "cco_extension": {
+              "status": "emitted_unchanged"
+            }
+          }
+        }
+      ],
+      "row_product_dispositions": null
+    },
+    {
+      "row_id": "urn:uuid:66010702-8134-4e08-a972-f0767ec8dead",
+      "location": {
+        "worksheet": "Sheet1",
+        "row": 36
+      },
+      "subject": {
+        "lexical": "ssn:System",
+        "iri": "http://www.w3.org/ns/ssn/System"
+      },
+      "predicate": {
+        "lexical": "owl:equivalentClass",
+        "iri": "http://www.w3.org/2002/07/owl#equivalentClass"
+      },
+      "authoritative_target_lexical": "bfo:MaterialEntity and (ssn:implements some sosa:Procedure)",
+      "canonical_row_expression": {
+        "canonicalization": "coms-row-expression-v1",
+        "mapping_type": "class_mapping",
+        "predicate_iri": "http://www.w3.org/2002/07/owl#equivalentClass",
+        "subject_iri": "http://www.w3.org/ns/ssn/System",
+        "target": "ObjectIntersectionOf(<http://purl.obolibrary.org/obo/BFO_0000040> ObjectSomeValuesFrom(<http://www.w3.org/ns/ssn/implements> <http://www.w3.org/ns/sosa/Procedure>))"
+      },
+      "source_expression_sha256": "43e7759ead3c66f83889b2fd88922b18b3a61f1f27c8de10896ae81fc4b51a43",
+      "mapping_type": "class_mapping",
+      "coverage_classification": "class_mapping",
+      "reasoning": "",
+      "authoritative_axioms": [
+        {
+          "axiom_id": "sha256:0db60d0e9764151246aa7f88574dbc9fb112eecb2191d00822192f51ec298678",
+          "canonical_expression": "EquivalentClasses(<http://www.w3.org/ns/ssn/System> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/BFO_0000040> ObjectSomeValuesFrom(<http://www.w3.org/ns/ssn/implements> <http://www.w3.org/ns/sosa/Procedure>)))",
+          "referenced_iris": [
+            "http://purl.obolibrary.org/obo/BFO_0000040",
+            "http://www.w3.org/2002/07/owl#equivalentClass",
+            "http://www.w3.org/ns/sosa/Procedure",
+            "http://www.w3.org/ns/ssn/System",
+            "http://www.w3.org/ns/ssn/implements"
+          ],
+          "target_category": "bfo_bearing",
+          "product_dispositions": {
+            "integrated": {
+              "status": "emitted_unchanged"
+            },
+            "alignment_core": {
+              "status": "not_applicable",
+              "reason_code": "TARGET_SPECIFIC"
+            },
+            "strict_bfo_mapping": {
+              "status": "emitted_unchanged"
+            },
+            "bfo_projection": {
+              "status": "provided_through_import"
+            },
+            "cco_extension": {
+              "status": "provided_through_import"
+            }
+          }
+        }
+      ],
+      "row_product_dispositions": null
+    },
+    {
+      "row_id": "urn:uuid:675bb221-ad63-4033-9f22-5190d0b6d545",
+      "location": {
+        "worksheet": "Sheet2",
+        "row": 28
+      },
+      "subject": {
+        "lexical": "sosa:madeByActuator",
+        "iri": "http://www.w3.org/ns/sosa/madeByActuator"
+      },
+      "predicate": {
+        "lexical": "rdfs:domain",
+        "iri": "http://www.w3.org/2000/01/rdf-schema#domain"
+      },
+      "authoritative_target_lexical": "sosa:Actuation",
+      "canonical_row_expression": {
+        "canonicalization": "coms-row-expression-v1",
+        "mapping_type": "domain",
+        "predicate_iri": "http://www.w3.org/2000/01/rdf-schema#domain",
+        "subject_iri": "http://www.w3.org/ns/sosa/madeByActuator",
+        "target": "<http://www.w3.org/ns/sosa/Actuation>"
+      },
+      "source_expression_sha256": "0ed4203735fb46297727736073cd3a76748f7674a0ca364d8529eb30886e974b",
+      "mapping_type": "domain",
+      "coverage_classification": "property_typing",
+      "reasoning": "",
+      "authoritative_axioms": [
+        {
+          "axiom_id": "sha256:6e391f29bd41a8d9690da48c2132f58a553fc72e2df3f7f2f4c116b0d574f189",
+          "canonical_expression": "ObjectPropertyDomain(<http://www.w3.org/ns/sosa/madeByActuator> <http://www.w3.org/ns/sosa/Actuation>)",
+          "referenced_iris": [
+            "http://www.w3.org/2000/01/rdf-schema#domain",
+            "http://www.w3.org/ns/sosa/Actuation",
+            "http://www.w3.org/ns/sosa/madeByActuator"
+          ],
+          "target_category": "target_neutral",
+          "product_dispositions": {
+            "integrated": {
+              "status": "emitted_unchanged"
+            },
+            "alignment_core": {
+              "status": "emitted_unchanged"
+            },
+            "strict_bfo_mapping": {
+              "status": "provided_through_import"
+            },
+            "bfo_projection": {
+              "status": "provided_transitively"
+            },
+            "cco_extension": {
+              "status": "provided_transitively"
+            }
+          }
+        }
+      ],
+      "row_product_dispositions": null
+    },
+    {
+      "row_id": "urn:uuid:69e972da-23ad-4e50-822b-e41198c95795",
+      "location": {
+        "worksheet": "Sheet2",
+        "row": 5
+      },
+      "subject": {
+        "lexical": "sosa:actsOnProperty",
+        "iri": "http://www.w3.org/ns/sosa/actsOnProperty"
+      },
+      "predicate": {
+        "lexical": "rdfs:subPropertyOf",
+        "iri": "http://www.w3.org/2000/01/rdf-schema#subPropertyOf"
+      },
+      "authoritative_target_lexical": "cco:affects",
+      "canonical_row_expression": {
+        "canonicalization": "coms-row-expression-v1",
+        "mapping_type": "object_property_mapping",
+        "predicate_iri": "http://www.w3.org/2000/01/rdf-schema#subPropertyOf",
+        "subject_iri": "http://www.w3.org/ns/sosa/actsOnProperty",
+        "target": "<https://www.commoncoreontologies.org/ont00001834>"
+      },
+      "source_expression_sha256": "02573a746733f57a298ba130c29ce88c017e8fa1960bce7bdc1cc22d44867775",
+      "mapping_type": "object_property_mapping",
+      "coverage_classification": "relation_mapping",
+      "reasoning": "",
+      "authoritative_axioms": [
+        {
+          "axiom_id": "sha256:7b38f4108fd76423fec54f3d4d34f07cc4b4540d5b773f2fd8f52413c6f78f93",
+          "canonical_expression": "SubObjectPropertyOf(<http://www.w3.org/ns/sosa/actsOnProperty> <https://www.commoncoreontologies.org/ont00001834>)",
+          "referenced_iris": [
+            "http://www.w3.org/2000/01/rdf-schema#subPropertyOf",
+            "http://www.w3.org/ns/sosa/actsOnProperty",
+            "https://www.commoncoreontologies.org/ont00001834"
+          ],
+          "target_category": "cco_bearing",
+          "product_dispositions": {
+            "integrated": {
+              "status": "emitted_unchanged"
+            },
+            "alignment_core": {
+              "status": "not_applicable",
+              "reason_code": "TARGET_SPECIFIC"
+            },
+            "strict_bfo_mapping": {
+              "status": "deferred",
+              "reason_code": "NO_APPROVED_TRANSFORMATION_RULE"
+            },
+            "bfo_projection": {
+              "status": "deferred",
+              "reason_code": "NO_APPROVED_TRANSFORMATION_RULE"
+            },
+            "cco_extension": {
+              "status": "emitted_unchanged"
+            }
+          }
+        }
+      ],
+      "row_product_dispositions": null
+    },
+    {
+      "row_id": "urn:uuid:6c58598b-8de6-4559-82fa-53a6efc6a3c4",
+      "location": {
+        "worksheet": "Sheet2",
+        "row": 50
+      },
+      "subject": {
+        "lexical": "ssn:hasDeployment",
+        "iri": "http://www.w3.org/ns/ssn/hasDeployment"
+      },
+      "predicate": {
+        "lexical": "rdfs:subPropertyOf",
+        "iri": "http://www.w3.org/2000/01/rdf-schema#subPropertyOf"
+      },
+      "authoritative_target_lexical": "bfo:participates_in",
+      "canonical_row_expression": {
+        "canonicalization": "coms-row-expression-v1",
+        "mapping_type": "object_property_mapping",
+        "predicate_iri": "http://www.w3.org/2000/01/rdf-schema#subPropertyOf",
+        "subject_iri": "http://www.w3.org/ns/ssn/hasDeployment",
+        "target": "<http://purl.obolibrary.org/obo/BFO_0000056>"
+      },
+      "source_expression_sha256": "01eea28848f5c27b9b1094a05ae140f4d3ce6d931f9828578137328a8aa45473",
+      "mapping_type": "object_property_mapping",
+      "coverage_classification": "relation_mapping",
+      "reasoning": "",
+      "authoritative_axioms": [
+        {
+          "axiom_id": "sha256:205b4f09b9778256d60879903b8e03e20a284c0ce6d3dd085b87d5c2e3b44cad",
+          "canonical_expression": "SubObjectPropertyOf(<http://www.w3.org/ns/ssn/hasDeployment> <http://purl.obolibrary.org/obo/BFO_0000056>)",
+          "referenced_iris": [
+            "http://purl.obolibrary.org/obo/BFO_0000056",
+            "http://www.w3.org/2000/01/rdf-schema#subPropertyOf",
+            "http://www.w3.org/ns/ssn/hasDeployment"
+          ],
+          "target_category": "bfo_bearing",
+          "product_dispositions": {
+            "integrated": {
+              "status": "emitted_unchanged"
+            },
+            "alignment_core": {
+              "status": "not_applicable",
+              "reason_code": "TARGET_SPECIFIC"
+            },
+            "strict_bfo_mapping": {
+              "status": "emitted_unchanged"
+            },
+            "bfo_projection": {
+              "status": "provided_through_import"
+            },
+            "cco_extension": {
+              "status": "provided_through_import"
+            }
+          }
+        }
+      ],
+      "row_product_dispositions": null
+    },
+    {
+      "row_id": "urn:uuid:766c2e20-d125-448b-bc37-642daebaf088",
+      "location": {
+        "worksheet": "Sheet2",
+        "row": 54
+      },
+      "subject": {
+        "lexical": "ssn:hasOutput",
+        "iri": "http://www.w3.org/ns/ssn/hasOutput"
+      },
+      "predicate": {
+        "lexical": "rdfs:range",
+        "iri": "http://www.w3.org/2000/01/rdf-schema#range"
+      },
+      "authoritative_target_lexical": "ssn:Output",
+      "canonical_row_expression": {
+        "canonicalization": "coms-row-expression-v1",
+        "mapping_type": "range",
+        "predicate_iri": "http://www.w3.org/2000/01/rdf-schema#range",
+        "subject_iri": "http://www.w3.org/ns/ssn/hasOutput",
+        "target": "<http://www.w3.org/ns/ssn/Output>"
+      },
+      "source_expression_sha256": "235080b117c44da576d0930f0a91040d87a728eefc5bc7c0b3bb68596a098c57",
+      "mapping_type": "range",
+      "coverage_classification": "property_typing",
+      "reasoning": "",
+      "authoritative_axioms": [
+        {
+          "axiom_id": "sha256:390c9b5de75302a30d93d73ac3f3706f09cf39aa164a11314f85cb40fb518a56",
+          "canonical_expression": "ObjectPropertyRange(<http://www.w3.org/ns/ssn/hasOutput> <http://www.w3.org/ns/ssn/Output>)",
+          "referenced_iris": [
+            "http://www.w3.org/2000/01/rdf-schema#range",
+            "http://www.w3.org/ns/ssn/Output",
+            "http://www.w3.org/ns/ssn/hasOutput"
+          ],
+          "target_category": "target_neutral",
+          "product_dispositions": {
+            "integrated": {
+              "status": "emitted_unchanged"
+            },
+            "alignment_core": {
+              "status": "emitted_unchanged"
+            },
+            "strict_bfo_mapping": {
+              "status": "provided_through_import"
+            },
+            "bfo_projection": {
+              "status": "provided_transitively"
+            },
+            "cco_extension": {
+              "status": "provided_transitively"
+            }
+          }
+        }
+      ],
+      "row_product_dispositions": null
+    },
+    {
+      "row_id": "urn:uuid:79e12baa-9467-4494-bdf3-b6906f5a81a7",
+      "location": {
+        "worksheet": "Sheet2",
+        "row": 13
+      },
+      "subject": {
+        "lexical": "ssn-system:inCondition",
+        "iri": "http://www.w3.org/ns/ssn/systems/inCondition"
+      },
+      "predicate": {
+        "lexical": "rdfs:domain",
+        "iri": "http://www.w3.org/2000/01/rdf-schema#domain"
+      },
+      "authoritative_target_lexical": "(ssn-system:SystemCapability or ssn-system:OperatingRange or ssn-system:SurvivalRange)",
+      "canonical_row_expression": {
+        "canonicalization": "coms-row-expression-v1",
+        "mapping_type": "domain",
+        "predicate_iri": "http://www.w3.org/2000/01/rdf-schema#domain",
+        "subject_iri": "http://www.w3.org/ns/ssn/systems/inCondition",
+        "target": "ObjectUnionOf(<http://www.w3.org/ns/ssn/systems/OperatingRange> <http://www.w3.org/ns/ssn/systems/SurvivalRange> <http://www.w3.org/ns/ssn/systems/SystemCapability>)"
+      },
+      "source_expression_sha256": "a9b704a9c29dddd44336baec70b661c6f8c99801c1b767194966c92924195b3c",
+      "mapping_type": "domain",
+      "coverage_classification": "property_typing",
+      "reasoning": "",
+      "authoritative_axioms": [
+        {
+          "axiom_id": "sha256:1149dc67a0411aa63c8ac06b3be6ecee8eaf03d62268b48079df3ca3c134dc62",
+          "canonical_expression": "ObjectPropertyDomain(<http://www.w3.org/ns/ssn/systems/inCondition> ObjectUnionOf(<http://www.w3.org/ns/ssn/systems/OperatingRange> <http://www.w3.org/ns/ssn/systems/SurvivalRange> <http://www.w3.org/ns/ssn/systems/SystemCapability>))",
+          "referenced_iris": [
+            "http://www.w3.org/2000/01/rdf-schema#domain",
+            "http://www.w3.org/ns/ssn/systems/OperatingRange",
+            "http://www.w3.org/ns/ssn/systems/SurvivalRange",
+            "http://www.w3.org/ns/ssn/systems/SystemCapability",
+            "http://www.w3.org/ns/ssn/systems/inCondition"
+          ],
+          "target_category": "target_neutral",
+          "product_dispositions": {
+            "integrated": {
+              "status": "emitted_unchanged"
+            },
+            "alignment_core": {
+              "status": "emitted_unchanged"
+            },
+            "strict_bfo_mapping": {
+              "status": "provided_through_import"
+            },
+            "bfo_projection": {
+              "status": "provided_transitively"
+            },
+            "cco_extension": {
+              "status": "provided_transitively"
+            }
+          }
+        }
+      ],
+      "row_product_dispositions": null
+    },
+    {
+      "row_id": "urn:uuid:7b3f908b-b717-4336-9968-8b1083f847d3",
+      "location": {
+        "worksheet": "Sheet1",
+        "row": 12
+      },
+      "subject": {
+        "lexical": "sosa:Sampling",
+        "iri": "http://www.w3.org/ns/sosa/Sampling"
+      },
+      "predicate": {
+        "lexical": "owl:equivalentClass",
+        "iri": "http://www.w3.org/2002/07/owl#equivalentClass"
+      },
+      "authoritative_target_lexical": "cco:PlannedAct and (cco:prescribed_by some sosa:Procedure) and (cco:has_output some sosa:Sample)",
+      "canonical_row_expression": {
+        "canonicalization": "coms-row-expression-v1",
+        "mapping_type": "class_mapping",
+        "predicate_iri": "http://www.w3.org/2002/07/owl#equivalentClass",
+        "subject_iri": "http://www.w3.org/ns/sosa/Sampling",
+        "target": "ObjectIntersectionOf(<https://www.commoncoreontologies.org/ont00000228> ObjectSomeValuesFrom(<https://www.commoncoreontologies.org/ont00001920> <http://www.w3.org/ns/sosa/Procedure>) ObjectSomeValuesFrom(<https://www.commoncoreontologies.org/ont00001986> <http://www.w3.org/ns/sosa/Sample>))"
+      },
+      "source_expression_sha256": "9a543be1fc872ce1fc146d2e5206ae7787f38984b93aa5000716c75e3bba8aad",
+      "mapping_type": "class_mapping",
+      "coverage_classification": "class_mapping",
+      "reasoning": "",
+      "authoritative_axioms": [
+        {
+          "axiom_id": "sha256:e69a0d20905384f1a3b3e5f9df6b82987f1a1da4e90db05becbc99d980b39168",
+          "canonical_expression": "EquivalentClasses(<http://www.w3.org/ns/sosa/Sampling> ObjectIntersectionOf(<https://www.commoncoreontologies.org/ont00000228> ObjectSomeValuesFrom(<https://www.commoncoreontologies.org/ont00001920> <http://www.w3.org/ns/sosa/Procedure>) ObjectSomeValuesFrom(<https://www.commoncoreontologies.org/ont00001986> <http://www.w3.org/ns/sosa/Sample>)))",
+          "referenced_iris": [
+            "http://www.w3.org/2002/07/owl#equivalentClass",
+            "http://www.w3.org/ns/sosa/Procedure",
+            "http://www.w3.org/ns/sosa/Sample",
+            "http://www.w3.org/ns/sosa/Sampling",
+            "https://www.commoncoreontologies.org/ont00000228",
+            "https://www.commoncoreontologies.org/ont00001920",
+            "https://www.commoncoreontologies.org/ont00001986"
+          ],
+          "target_category": "cco_bearing",
+          "product_dispositions": {
+            "integrated": {
+              "status": "emitted_unchanged"
+            },
+            "alignment_core": {
+              "status": "not_applicable",
+              "reason_code": "TARGET_SPECIFIC"
+            },
+            "strict_bfo_mapping": {
+              "status": "deferred",
+              "reason_code": "NO_APPROVED_TRANSFORMATION_RULE"
+            },
+            "bfo_projection": {
+              "status": "deferred",
+              "reason_code": "NO_APPROVED_TRANSFORMATION_RULE"
+            },
+            "cco_extension": {
+              "status": "emitted_unchanged"
+            }
+          }
+        }
+      ],
+      "row_product_dispositions": null
+    },
+    {
+      "row_id": "urn:uuid:7caa02f4-26a1-4e81-b709-5c2116636f65",
+      "location": {
+        "worksheet": "Sheet1",
+        "row": 41
+      },
+      "subject": {
+        "lexical": "ssn-system:ActuationRange",
+        "iri": "http://www.w3.org/ns/ssn/systems/ActuationRange"
+      },
+      "predicate": {
+        "lexical": "rdfs:subClassOf",
+        "iri": "http://www.w3.org/2000/01/rdf-schema#subClassOf"
+      },
+      "authoritative_target_lexical": "bfo:Function and (bfo:has_realization some (sosa:Actuation and ((cco:has_output some bfo:SpecificallyDependentContinuant) and (cco:prescribed_by some cco:ArtifactFunctionSpecification))))",
+      "canonical_row_expression": {
+        "canonicalization": "coms-row-expression-v1",
+        "mapping_type": "class_mapping",
+        "predicate_iri": "http://www.w3.org/2000/01/rdf-schema#subClassOf",
+        "subject_iri": "http://www.w3.org/ns/ssn/systems/ActuationRange",
+        "target": "ObjectIntersectionOf(<http://purl.obolibrary.org/obo/BFO_0000034> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000054> ObjectIntersectionOf(<http://www.w3.org/ns/sosa/Actuation> ObjectSomeValuesFrom(<https://www.commoncoreontologies.org/ont00001920> <https://www.commoncoreontologies.org/ont00000118>) ObjectSomeValuesFrom(<https://www.commoncoreontologies.org/ont00001986> <http://purl.obolibrary.org/obo/BFO_0000020>))))"
+      },
+      "source_expression_sha256": "5e3bcc79d73e5ff6739754d93fa976584ef66c2e9407d0ff1cc168bb3ce2b335",
+      "mapping_type": "class_mapping",
+      "coverage_classification": "class_mapping",
+      "reasoning": "",
+      "authoritative_axioms": [
+        {
+          "axiom_id": "sha256:04f2e1c545b6c6f252d9cf377e1e1f325bafa846d37c6b75a975a692ea059963",
+          "canonical_expression": "SubClassOf(<http://www.w3.org/ns/ssn/systems/ActuationRange> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/BFO_0000034> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000054> ObjectIntersectionOf(<http://www.w3.org/ns/sosa/Actuation> ObjectSomeValuesFrom(<https://www.commoncoreontologies.org/ont00001920> <https://www.commoncoreontologies.org/ont00000118>) ObjectSomeValuesFrom(<https://www.commoncoreontologies.org/ont00001986> <http://purl.obolibrary.org/obo/BFO_0000020>)))))",
+          "referenced_iris": [
+            "http://purl.obolibrary.org/obo/BFO_0000020",
+            "http://purl.obolibrary.org/obo/BFO_0000034",
+            "http://purl.obolibrary.org/obo/BFO_0000054",
+            "http://www.w3.org/2000/01/rdf-schema#subClassOf",
+            "http://www.w3.org/ns/sosa/Actuation",
+            "http://www.w3.org/ns/ssn/systems/ActuationRange",
+            "https://www.commoncoreontologies.org/ont00000118",
+            "https://www.commoncoreontologies.org/ont00001920",
+            "https://www.commoncoreontologies.org/ont00001986"
+          ],
+          "target_category": "mixed_bfo_cco",
+          "product_dispositions": {
+            "integrated": {
+              "status": "emitted_unchanged"
+            },
+            "alignment_core": {
+              "status": "not_applicable",
+              "reason_code": "TARGET_SPECIFIC"
+            },
+            "strict_bfo_mapping": {
+              "status": "deferred",
+              "reason_code": "NO_APPROVED_TRANSFORMATION_RULE"
+            },
+            "bfo_projection": {
+              "status": "deferred",
+              "reason_code": "NO_APPROVED_TRANSFORMATION_RULE"
+            },
+            "cco_extension": {
+              "status": "emitted_unchanged"
+            }
+          }
+        }
+      ],
+      "row_product_dispositions": null
+    },
+    {
+      "row_id": "urn:uuid:823bbbdf-b4f1-4e45-8b0a-5597306e6b69",
+      "location": {
+        "worksheet": "Sheet1",
+        "row": 16
+      },
+      "subject": {
+        "lexical": "ssn-system:Drift",
+        "iri": "http://www.w3.org/ns/ssn/systems/Drift"
+      },
+      "predicate": {
+        "lexical": "rdfs:subClassOf",
+        "iri": "http://www.w3.org/2000/01/rdf-schema#subClassOf"
+      },
+      "authoritative_target_lexical": "bfo:Function and bfo:has_realization some (bfo:Process and cco:is_subject_of some (cco:DescriptiveInformationContentEntity and cco:is_measured_by some (cco:DeviationMeasurementInformationContentEntity and cco:prescribed_by some cco:ArtifactFunctionSpecification)))",
+      "canonical_row_expression": {
+        "canonicalization": "coms-row-expression-v1",
+        "mapping_type": "class_mapping",
+        "predicate_iri": "http://www.w3.org/2000/01/rdf-schema#subClassOf",
+        "subject_iri": "http://www.w3.org/ns/ssn/systems/Drift",
+        "target": "ObjectIntersectionOf(<http://purl.obolibrary.org/obo/BFO_0000034> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000054> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/BFO_0000015> ObjectSomeValuesFrom(<https://www.commoncoreontologies.org/ont00001801> ObjectIntersectionOf(<https://www.commoncoreontologies.org/ont00000853> ObjectSomeValuesFrom(<https://www.commoncoreontologies.org/ont00001904> ObjectIntersectionOf(<https://www.commoncoreontologies.org/ont00000731> ObjectSomeValuesFrom(<https://www.commoncoreontologies.org/ont00001920> <https://www.commoncoreontologies.org/ont00000118>))))))))"
+      },
+      "source_expression_sha256": "2c44d5f805e49ba8f4d61788e71d6bd70044a33de1ffad849b068a53f073b947",
+      "mapping_type": "class_mapping",
+      "coverage_classification": "class_mapping",
+      "reasoning": "",
+      "authoritative_axioms": [
+        {
+          "axiom_id": "sha256:7bfe203db92e7e2b6f107641f3edbbcc111a4b9879471d70e1928b2817c0b853",
+          "canonical_expression": "SubClassOf(<http://www.w3.org/ns/ssn/systems/Drift> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/BFO_0000034> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000054> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/BFO_0000015> ObjectSomeValuesFrom(<https://www.commoncoreontologies.org/ont00001801> ObjectIntersectionOf(<https://www.commoncoreontologies.org/ont00000853> ObjectSomeValuesFrom(<https://www.commoncoreontologies.org/ont00001904> ObjectIntersectionOf(<https://www.commoncoreontologies.org/ont00000731> ObjectSomeValuesFrom(<https://www.commoncoreontologies.org/ont00001920> <https://www.commoncoreontologies.org/ont00000118>)))))))))",
+          "referenced_iris": [
+            "http://purl.obolibrary.org/obo/BFO_0000015",
+            "http://purl.obolibrary.org/obo/BFO_0000034",
+            "http://purl.obolibrary.org/obo/BFO_0000054",
+            "http://www.w3.org/2000/01/rdf-schema#subClassOf",
+            "http://www.w3.org/ns/ssn/systems/Drift",
+            "https://www.commoncoreontologies.org/ont00000118",
+            "https://www.commoncoreontologies.org/ont00000731",
+            "https://www.commoncoreontologies.org/ont00000853",
+            "https://www.commoncoreontologies.org/ont00001801",
+            "https://www.commoncoreontologies.org/ont00001904",
+            "https://www.commoncoreontologies.org/ont00001920"
+          ],
+          "target_category": "mixed_bfo_cco",
+          "product_dispositions": {
+            "integrated": {
+              "status": "emitted_unchanged"
+            },
+            "alignment_core": {
+              "status": "not_applicable",
+              "reason_code": "TARGET_SPECIFIC"
+            },
+            "strict_bfo_mapping": {
+              "status": "deferred",
+              "reason_code": "NO_APPROVED_TRANSFORMATION_RULE"
+            },
+            "bfo_projection": {
+              "status": "deferred",
+              "reason_code": "NO_APPROVED_TRANSFORMATION_RULE"
+            },
+            "cco_extension": {
+              "status": "emitted_unchanged"
+            }
+          }
+        }
+      ],
+      "row_product_dispositions": null
+    },
+    {
+      "row_id": "urn:uuid:82ce9316-b7a7-4655-9c98-e16c314a0244",
+      "location": {
+        "worksheet": "Sheet2",
+        "row": 41
+      },
+      "subject": {
+        "lexical": "ssn-system:hasSurvivalRange",
+        "iri": "http://www.w3.org/ns/ssn/systems/hasSurvivalRange"
+      },
+      "predicate": {
+        "lexical": "rdfs:domain",
+        "iri": "http://www.w3.org/2000/01/rdf-schema#domain"
+      },
+      "authoritative_target_lexical": "ssn:System",
+      "canonical_row_expression": {
+        "canonicalization": "coms-row-expression-v1",
+        "mapping_type": "domain",
+        "predicate_iri": "http://www.w3.org/2000/01/rdf-schema#domain",
+        "subject_iri": "http://www.w3.org/ns/ssn/systems/hasSurvivalRange",
+        "target": "<http://www.w3.org/ns/ssn/System>"
+      },
+      "source_expression_sha256": "26ff1947816d05739895b400d159bc59e7aa6aa9a614f461b8f00d11ca5ef42c",
+      "mapping_type": "domain",
+      "coverage_classification": "property_typing",
+      "reasoning": "",
+      "authoritative_axioms": [
+        {
+          "axiom_id": "sha256:0a66d02476e30d96f3c00a905a1cce9a4e5ff745c4a3745a238efc8291a4f691",
+          "canonical_expression": "ObjectPropertyDomain(<http://www.w3.org/ns/ssn/systems/hasSurvivalRange> <http://www.w3.org/ns/ssn/System>)",
+          "referenced_iris": [
+            "http://www.w3.org/2000/01/rdf-schema#domain",
+            "http://www.w3.org/ns/ssn/System",
+            "http://www.w3.org/ns/ssn/systems/hasSurvivalRange"
+          ],
+          "target_category": "target_neutral",
+          "product_dispositions": {
+            "integrated": {
+              "status": "emitted_unchanged"
+            },
+            "alignment_core": {
+              "status": "emitted_unchanged"
+            },
+            "strict_bfo_mapping": {
+              "status": "provided_through_import"
+            },
+            "bfo_projection": {
+              "status": "provided_transitively"
+            },
+            "cco_extension": {
+              "status": "provided_transitively"
+            }
+          }
+        }
+      ],
+      "row_product_dispositions": null
+    },
+    {
+      "row_id": "urn:uuid:839fa73d-6601-4b17-9331-062846ba0f3e",
+      "location": {
+        "worksheet": "Sheet2",
+        "row": 34
+      },
+      "subject": {
+        "lexical": "sosa:madeObservation",
+        "iri": "http://www.w3.org/ns/sosa/madeObservation"
+      },
+      "predicate": {
+        "lexical": "rdfs:domain",
+        "iri": "http://www.w3.org/2000/01/rdf-schema#domain"
+      },
+      "authoritative_target_lexical": "sosa:Sensor",
+      "canonical_row_expression": {
+        "canonicalization": "coms-row-expression-v1",
+        "mapping_type": "domain",
+        "predicate_iri": "http://www.w3.org/2000/01/rdf-schema#domain",
+        "subject_iri": "http://www.w3.org/ns/sosa/madeObservation",
+        "target": "<http://www.w3.org/ns/sosa/Sensor>"
+      },
+      "source_expression_sha256": "ab4eee02dd847ca8572bfd7da5bfbec8a3a073fb5888231a33e8ee761f4e1c85",
+      "mapping_type": "domain",
+      "coverage_classification": "property_typing",
+      "reasoning": "",
+      "authoritative_axioms": [
+        {
+          "axiom_id": "sha256:157aece9de6259bc9ad10c9023b8e620c03f9f88bc688cceb058f1e68c7d39b2",
+          "canonical_expression": "ObjectPropertyDomain(<http://www.w3.org/ns/sosa/madeObservation> <http://www.w3.org/ns/sosa/Sensor>)",
+          "referenced_iris": [
+            "http://www.w3.org/2000/01/rdf-schema#domain",
+            "http://www.w3.org/ns/sosa/Sensor",
+            "http://www.w3.org/ns/sosa/madeObservation"
+          ],
+          "target_category": "target_neutral",
+          "product_dispositions": {
+            "integrated": {
+              "status": "emitted_unchanged"
+            },
+            "alignment_core": {
+              "status": "emitted_unchanged"
+            },
+            "strict_bfo_mapping": {
+              "status": "provided_through_import"
+            },
+            "bfo_projection": {
+              "status": "provided_transitively"
+            },
+            "cco_extension": {
+              "status": "provided_transitively"
+            }
+          }
+        }
+      ],
+      "row_product_dispositions": null
+    },
+    {
+      "row_id": "urn:uuid:86e97aa4-dc26-4d62-bef6-52cf36869bc8",
+      "location": {
+        "worksheet": "Sheet1",
+        "row": 15
+      },
+      "subject": {
+        "lexical": "ssn-system:DetectionLimit",
+        "iri": "http://www.w3.org/ns/ssn/systems/DetectionLimit"
+      },
+      "predicate": {
+        "lexical": "rdfs:subClassOf",
+        "iri": "http://www.w3.org/2000/01/rdf-schema#subClassOf"
+      },
+      "authoritative_target_lexical": "bfo:Function and bfo:has_realization some (bfo:Process and cco:is_subject_of some (cco:DescriptiveInformationContentEntity and cco:is_measured_by some (cco:VeracityMeasurementInformationContentEntity and cco:prescribed_by some cco:ArtifactFunctionSpecification)))",
+      "canonical_row_expression": {
+        "canonicalization": "coms-row-expression-v1",
+        "mapping_type": "class_mapping",
+        "predicate_iri": "http://www.w3.org/2000/01/rdf-schema#subClassOf",
+        "subject_iri": "http://www.w3.org/ns/ssn/systems/DetectionLimit",
+        "target": "ObjectIntersectionOf(<http://purl.obolibrary.org/obo/BFO_0000034> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000054> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/BFO_0000015> ObjectSomeValuesFrom(<https://www.commoncoreontologies.org/ont00001801> ObjectIntersectionOf(<https://www.commoncoreontologies.org/ont00000853> ObjectSomeValuesFrom(<https://www.commoncoreontologies.org/ont00001904> ObjectIntersectionOf(<https://www.commoncoreontologies.org/ont00000592> ObjectSomeValuesFrom(<https://www.commoncoreontologies.org/ont00001920> <https://www.commoncoreontologies.org/ont00000118>))))))))"
+      },
+      "source_expression_sha256": "0ee977776b5234128624d290ca51e38a035ae70de7e50e0d91833ec57745520f",
+      "mapping_type": "class_mapping",
+      "coverage_classification": "class_mapping",
+      "reasoning": "",
+      "authoritative_axioms": [
+        {
+          "axiom_id": "sha256:25eb572d7c35d5e480c606eddf558b7b5e986136f82f7da5657c857653b81705",
+          "canonical_expression": "SubClassOf(<http://www.w3.org/ns/ssn/systems/DetectionLimit> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/BFO_0000034> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000054> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/BFO_0000015> ObjectSomeValuesFrom(<https://www.commoncoreontologies.org/ont00001801> ObjectIntersectionOf(<https://www.commoncoreontologies.org/ont00000853> ObjectSomeValuesFrom(<https://www.commoncoreontologies.org/ont00001904> ObjectIntersectionOf(<https://www.commoncoreontologies.org/ont00000592> ObjectSomeValuesFrom(<https://www.commoncoreontologies.org/ont00001920> <https://www.commoncoreontologies.org/ont00000118>)))))))))",
+          "referenced_iris": [
+            "http://purl.obolibrary.org/obo/BFO_0000015",
+            "http://purl.obolibrary.org/obo/BFO_0000034",
+            "http://purl.obolibrary.org/obo/BFO_0000054",
+            "http://www.w3.org/2000/01/rdf-schema#subClassOf",
+            "http://www.w3.org/ns/ssn/systems/DetectionLimit",
+            "https://www.commoncoreontologies.org/ont00000118",
+            "https://www.commoncoreontologies.org/ont00000592",
+            "https://www.commoncoreontologies.org/ont00000853",
+            "https://www.commoncoreontologies.org/ont00001801",
+            "https://www.commoncoreontologies.org/ont00001904",
+            "https://www.commoncoreontologies.org/ont00001920"
+          ],
+          "target_category": "mixed_bfo_cco",
+          "product_dispositions": {
+            "integrated": {
+              "status": "emitted_unchanged"
+            },
+            "alignment_core": {
+              "status": "not_applicable",
+              "reason_code": "TARGET_SPECIFIC"
+            },
+            "strict_bfo_mapping": {
+              "status": "deferred",
+              "reason_code": "NO_APPROVED_TRANSFORMATION_RULE"
+            },
+            "bfo_projection": {
+              "status": "deferred",
+              "reason_code": "NO_APPROVED_TRANSFORMATION_RULE"
+            },
+            "cco_extension": {
+              "status": "emitted_unchanged"
+            }
+          }
+        }
+      ],
+      "row_product_dispositions": null
+    },
+    {
+      "row_id": "urn:uuid:8897fadf-b70f-4d81-a08c-a072f873f82b",
+      "location": {
+        "worksheet": "Sheet1",
+        "row": 13
+      },
+      "subject": {
+        "lexical": "ssn-system:Accuracy",
+        "iri": "http://www.w3.org/ns/ssn/systems/Accuracy"
+      },
+      "predicate": {
+        "lexical": "rdfs:subClassOf",
+        "iri": "http://www.w3.org/2000/01/rdf-schema#subClassOf"
+      },
+      "authoritative_target_lexical": "bfo:Function and bfo:has_realization some (bfo:Process and cco:is_subject_of some (cco:DescriptiveInformationContentEntity and cco:is_measured_by some (cco:VeracityMeasurementInformationContentEntity and cco:prescribed_by some cco:ArtifactFunctionSpecification)))",
+      "canonical_row_expression": {
+        "canonicalization": "coms-row-expression-v1",
+        "mapping_type": "class_mapping",
+        "predicate_iri": "http://www.w3.org/2000/01/rdf-schema#subClassOf",
+        "subject_iri": "http://www.w3.org/ns/ssn/systems/Accuracy",
+        "target": "ObjectIntersectionOf(<http://purl.obolibrary.org/obo/BFO_0000034> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000054> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/BFO_0000015> ObjectSomeValuesFrom(<https://www.commoncoreontologies.org/ont00001801> ObjectIntersectionOf(<https://www.commoncoreontologies.org/ont00000853> ObjectSomeValuesFrom(<https://www.commoncoreontologies.org/ont00001904> ObjectIntersectionOf(<https://www.commoncoreontologies.org/ont00000592> ObjectSomeValuesFrom(<https://www.commoncoreontologies.org/ont00001920> <https://www.commoncoreontologies.org/ont00000118>))))))))"
+      },
+      "source_expression_sha256": "b747359b164bb0677e13958d4c23918897e59f844569f24e87db9bc87b90d784",
+      "mapping_type": "class_mapping",
+      "coverage_classification": "class_mapping",
+      "reasoning": "",
+      "authoritative_axioms": [
+        {
+          "axiom_id": "sha256:0aae335885ecdd46575658fe71c7cf073d4dcdda299250671a41f4ab3447536c",
+          "canonical_expression": "SubClassOf(<http://www.w3.org/ns/ssn/systems/Accuracy> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/BFO_0000034> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000054> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/BFO_0000015> ObjectSomeValuesFrom(<https://www.commoncoreontologies.org/ont00001801> ObjectIntersectionOf(<https://www.commoncoreontologies.org/ont00000853> ObjectSomeValuesFrom(<https://www.commoncoreontologies.org/ont00001904> ObjectIntersectionOf(<https://www.commoncoreontologies.org/ont00000592> ObjectSomeValuesFrom(<https://www.commoncoreontologies.org/ont00001920> <https://www.commoncoreontologies.org/ont00000118>)))))))))",
+          "referenced_iris": [
+            "http://purl.obolibrary.org/obo/BFO_0000015",
+            "http://purl.obolibrary.org/obo/BFO_0000034",
+            "http://purl.obolibrary.org/obo/BFO_0000054",
+            "http://www.w3.org/2000/01/rdf-schema#subClassOf",
+            "http://www.w3.org/ns/ssn/systems/Accuracy",
+            "https://www.commoncoreontologies.org/ont00000118",
+            "https://www.commoncoreontologies.org/ont00000592",
+            "https://www.commoncoreontologies.org/ont00000853",
+            "https://www.commoncoreontologies.org/ont00001801",
+            "https://www.commoncoreontologies.org/ont00001904",
+            "https://www.commoncoreontologies.org/ont00001920"
+          ],
+          "target_category": "mixed_bfo_cco",
+          "product_dispositions": {
+            "integrated": {
+              "status": "emitted_unchanged"
+            },
+            "alignment_core": {
+              "status": "not_applicable",
+              "reason_code": "TARGET_SPECIFIC"
+            },
+            "strict_bfo_mapping": {
+              "status": "deferred",
+              "reason_code": "NO_APPROVED_TRANSFORMATION_RULE"
+            },
+            "bfo_projection": {
+              "status": "deferred",
+              "reason_code": "NO_APPROVED_TRANSFORMATION_RULE"
+            },
+            "cco_extension": {
+              "status": "emitted_unchanged"
+            }
+          }
+        }
+      ],
+      "row_product_dispositions": null
+    },
+    {
+      "row_id": "urn:uuid:89f70432-c87d-41dd-bff2-e6120c02b5a4",
+      "location": {
+        "worksheet": "Sheet1",
+        "row": 33
+      },
+      "subject": {
+        "lexical": "ssn:Output",
+        "iri": "http://www.w3.org/ns/ssn/Output"
+      },
+      "predicate": {
+        "lexical": "rdfs:subClassOf",
+        "iri": "http://www.w3.org/2000/01/rdf-schema#subClassOf"
+      },
+      "authoritative_target_lexical": "cco:InformationContentEntity",
+      "canonical_row_expression": {
+        "canonicalization": "coms-row-expression-v1",
+        "mapping_type": "class_mapping",
+        "predicate_iri": "http://www.w3.org/2000/01/rdf-schema#subClassOf",
+        "subject_iri": "http://www.w3.org/ns/ssn/Output",
+        "target": "<https://www.commoncoreontologies.org/ont00000958>"
+      },
+      "source_expression_sha256": "538cb51989eced139509e2d3c2a8c6e4c2d290eb829ff316c7deb609c83924da",
+      "mapping_type": "class_mapping",
+      "coverage_classification": "class_mapping",
+      "reasoning": "",
+      "authoritative_axioms": [
+        {
+          "axiom_id": "sha256:c77542ac30e2120d22aefdad6fd59cd22a77690848d2279060e2b545b97e177d",
+          "canonical_expression": "SubClassOf(<http://www.w3.org/ns/ssn/Output> <https://www.commoncoreontologies.org/ont00000958>)",
+          "referenced_iris": [
+            "http://www.w3.org/2000/01/rdf-schema#subClassOf",
+            "http://www.w3.org/ns/ssn/Output",
+            "https://www.commoncoreontologies.org/ont00000958"
+          ],
+          "target_category": "cco_bearing",
+          "product_dispositions": {
+            "integrated": {
+              "status": "emitted_unchanged"
+            },
+            "alignment_core": {
+              "status": "not_applicable",
+              "reason_code": "TARGET_SPECIFIC"
+            },
+            "strict_bfo_mapping": {
+              "status": "deferred",
+              "reason_code": "NO_APPROVED_TRANSFORMATION_RULE"
+            },
+            "bfo_projection": {
+              "status": "deferred",
+              "reason_code": "NO_APPROVED_TRANSFORMATION_RULE"
+            },
+            "cco_extension": {
+              "status": "emitted_unchanged"
+            }
+          }
+        }
+      ],
+      "row_product_dispositions": null
+    },
+    {
+      "row_id": "urn:uuid:8b87dd5b-298e-4ae7-8724-3778c0a67234",
+      "location": {
+        "worksheet": "Sheet2",
+        "row": 39
+      },
+      "subject": {
+        "lexical": "ssn-system:hasOperatingRange",
+        "iri": "http://www.w3.org/ns/ssn/systems/hasOperatingRange"
+      },
+      "predicate": {
+        "lexical": "rdfs:range",
+        "iri": "http://www.w3.org/2000/01/rdf-schema#range"
+      },
+      "authoritative_target_lexical": "ssn-system:OperatingRange",
+      "canonical_row_expression": {
+        "canonicalization": "coms-row-expression-v1",
+        "mapping_type": "range",
+        "predicate_iri": "http://www.w3.org/2000/01/rdf-schema#range",
+        "subject_iri": "http://www.w3.org/ns/ssn/systems/hasOperatingRange",
+        "target": "<http://www.w3.org/ns/ssn/systems/OperatingRange>"
+      },
+      "source_expression_sha256": "ceafff8b76962f198ca1f184ff076c3536247fe1c33bd964f725ea59da6a7da8",
+      "mapping_type": "range",
+      "coverage_classification": "property_typing",
+      "reasoning": "",
+      "authoritative_axioms": [
+        {
+          "axiom_id": "sha256:e780a611c30f9c3cf0e4dbe0bb60f281891360af5bb0c7c443caf882dd5fc33f",
+          "canonical_expression": "ObjectPropertyRange(<http://www.w3.org/ns/ssn/systems/hasOperatingRange> <http://www.w3.org/ns/ssn/systems/OperatingRange>)",
+          "referenced_iris": [
+            "http://www.w3.org/2000/01/rdf-schema#range",
+            "http://www.w3.org/ns/ssn/systems/OperatingRange",
+            "http://www.w3.org/ns/ssn/systems/hasOperatingRange"
+          ],
+          "target_category": "target_neutral",
+          "product_dispositions": {
+            "integrated": {
+              "status": "emitted_unchanged"
+            },
+            "alignment_core": {
+              "status": "emitted_unchanged"
+            },
+            "strict_bfo_mapping": {
+              "status": "provided_through_import"
+            },
+            "bfo_projection": {
+              "status": "provided_transitively"
+            },
+            "cco_extension": {
+              "status": "provided_transitively"
+            }
+          }
+        }
+      ],
+      "row_product_dispositions": null
+    },
+    {
+      "row_id": "urn:uuid:8c9662e8-a69c-4ce1-9d17-381ec3cdc162",
+      "location": {
+        "worksheet": "Sheet2",
+        "row": 20
+      },
+      "subject": {
+        "lexical": "sosa:isActedOnBy",
+        "iri": "http://www.w3.org/ns/sosa/isActedOnBy"
+      },
+      "predicate": {
+        "lexical": "rdfs:subPropertyOf",
+        "iri": "http://www.w3.org/2000/01/rdf-schema#subPropertyOf"
+      },
+      "authoritative_target_lexical": "cco:is_affected_by",
+      "canonical_row_expression": {
+        "canonicalization": "coms-row-expression-v1",
+        "mapping_type": "object_property_mapping",
+        "predicate_iri": "http://www.w3.org/2000/01/rdf-schema#subPropertyOf",
+        "subject_iri": "http://www.w3.org/ns/sosa/isActedOnBy",
+        "target": "<https://www.commoncoreontologies.org/ont00001886>"
+      },
+      "source_expression_sha256": "d409b9408fd1ef69731e7ee34fc04e7f296348e55bddb62b6d6c0941aa660061",
+      "mapping_type": "object_property_mapping",
+      "coverage_classification": "relation_mapping",
+      "reasoning": "",
+      "authoritative_axioms": [
+        {
+          "axiom_id": "sha256:cec49555cfb61f5cf5707fd755d31d71059b3b3ead5956a01ebfb820d1ee4eb5",
+          "canonical_expression": "SubObjectPropertyOf(<http://www.w3.org/ns/sosa/isActedOnBy> <https://www.commoncoreontologies.org/ont00001886>)",
+          "referenced_iris": [
+            "http://www.w3.org/2000/01/rdf-schema#subPropertyOf",
+            "http://www.w3.org/ns/sosa/isActedOnBy",
+            "https://www.commoncoreontologies.org/ont00001886"
+          ],
+          "target_category": "cco_bearing",
+          "product_dispositions": {
+            "integrated": {
+              "status": "emitted_unchanged"
+            },
+            "alignment_core": {
+              "status": "not_applicable",
+              "reason_code": "TARGET_SPECIFIC"
+            },
+            "strict_bfo_mapping": {
+              "status": "deferred",
+              "reason_code": "NO_APPROVED_TRANSFORMATION_RULE"
+            },
+            "bfo_projection": {
+              "status": "deferred",
+              "reason_code": "NO_APPROVED_TRANSFORMATION_RULE"
+            },
+            "cco_extension": {
+              "status": "emitted_unchanged"
+            }
+          }
+        }
+      ],
+      "row_product_dispositions": null
+    },
+    {
+      "row_id": "urn:uuid:98b1044d-6bfe-41d2-89aa-cdc87e524e4c",
+      "location": {
+        "worksheet": "Sheet1",
+        "row": 40
+      },
+      "subject": {
+        "lexical": "sosa:Sampler",
+        "iri": "http://www.w3.org/ns/sosa/Sampler"
+      },
+      "predicate": {
+        "lexical": "owl:equivalentClass",
+        "iri": "http://www.w3.org/2002/07/owl#equivalentClass"
+      },
+      "authoritative_target_lexical": "bfo:MaterialEntity and (bfo:bearer_of some (bfo:RealizableEntity and (bfo:has_realization some sosa:Sampling))) and (cco:agent_in some sosa:Sampling)",
+      "canonical_row_expression": {
+        "canonicalization": "coms-row-expression-v1",
+        "mapping_type": "class_mapping",
+        "predicate_iri": "http://www.w3.org/2002/07/owl#equivalentClass",
+        "subject_iri": "http://www.w3.org/ns/sosa/Sampler",
+        "target": "ObjectIntersectionOf(<http://purl.obolibrary.org/obo/BFO_0000040> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000196> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/BFO_0000017> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000054> <http://www.w3.org/ns/sosa/Sampling>))) ObjectSomeValuesFrom(<https://www.commoncoreontologies.org/ont00001787> <http://www.w3.org/ns/sosa/Sampling>))"
+      },
+      "source_expression_sha256": "afdb1a808d715d603eb55cd484a748eae0c59746551a1dd906430ab5db351215",
+      "mapping_type": "class_mapping",
+      "coverage_classification": "class_mapping",
+      "reasoning": "",
+      "authoritative_axioms": [
+        {
+          "axiom_id": "sha256:a80712efe3f50de428bfde449a3ebdf23c87750872d13a182cf065db7d0b9ae8",
+          "canonical_expression": "EquivalentClasses(<http://www.w3.org/ns/sosa/Sampler> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/BFO_0000040> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000196> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/BFO_0000017> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000054> <http://www.w3.org/ns/sosa/Sampling>))) ObjectSomeValuesFrom(<https://www.commoncoreontologies.org/ont00001787> <http://www.w3.org/ns/sosa/Sampling>)))",
+          "referenced_iris": [
+            "http://purl.obolibrary.org/obo/BFO_0000017",
+            "http://purl.obolibrary.org/obo/BFO_0000040",
+            "http://purl.obolibrary.org/obo/BFO_0000054",
+            "http://purl.obolibrary.org/obo/BFO_0000196",
+            "http://www.w3.org/2002/07/owl#equivalentClass",
+            "http://www.w3.org/ns/sosa/Sampler",
+            "http://www.w3.org/ns/sosa/Sampling",
+            "https://www.commoncoreontologies.org/ont00001787"
+          ],
+          "target_category": "mixed_bfo_cco",
+          "product_dispositions": {
+            "integrated": {
+              "status": "emitted_unchanged"
+            },
+            "alignment_core": {
+              "status": "not_applicable",
+              "reason_code": "TARGET_SPECIFIC"
+            },
+            "strict_bfo_mapping": {
+              "status": "deferred",
+              "reason_code": "NO_APPROVED_TRANSFORMATION_RULE"
+            },
+            "bfo_projection": {
+              "status": "deferred",
+              "reason_code": "NO_APPROVED_TRANSFORMATION_RULE"
+            },
+            "cco_extension": {
+              "status": "emitted_unchanged"
+            }
+          }
+        }
+      ],
+      "row_product_dispositions": null
+    },
+    {
+      "row_id": "urn:uuid:99b22791-b2d1-4667-901e-861a44f2b8a2",
+      "location": {
+        "worksheet": "Sheet1",
+        "row": 7
+      },
+      "subject": {
+        "lexical": "sosa:ObservableProperty",
+        "iri": "http://www.w3.org/ns/sosa/ObservableProperty"
+      },
+      "predicate": {
+        "lexical": "rdfs:subClassOf",
+        "iri": "http://www.w3.org/2000/01/rdf-schema#subClassOf"
+      },
+      "authoritative_target_lexical": "(bfo:SpecificallyDependentContinuant and bfo:inheres_in some sosa:FeatureOfInterest) or (bfo:ProcessProfile and bfo:occurrent_part_of some sosa:FeatureOfInterest)",
+      "canonical_row_expression": {
+        "canonicalization": "coms-row-expression-v1",
+        "mapping_type": "class_mapping",
+        "predicate_iri": "http://www.w3.org/2000/01/rdf-schema#subClassOf",
+        "subject_iri": "http://www.w3.org/ns/sosa/ObservableProperty",
+        "target": "ObjectUnionOf(ObjectIntersectionOf(<http://purl.obolibrary.org/obo/BFO_0000020> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000197> <http://www.w3.org/ns/sosa/FeatureOfInterest>)) ObjectIntersectionOf(<http://purl.obolibrary.org/obo/BFO_0000144> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000132> <http://www.w3.org/ns/sosa/FeatureOfInterest>)))"
+      },
+      "source_expression_sha256": "308287a0820e7928181bc83d4f35ae4dc97e94f54d4a8e98bb71ba9a3728feda",
+      "mapping_type": "class_mapping",
+      "coverage_classification": "class_mapping",
+      "reasoning": "",
+      "authoritative_axioms": [
+        {
+          "axiom_id": "sha256:5606980322dc337a4e5d0eb2daef2e5acbba7ee42a782247375fcf3f39d12e00",
+          "canonical_expression": "SubClassOf(<http://www.w3.org/ns/sosa/ObservableProperty> ObjectUnionOf(ObjectIntersectionOf(<http://purl.obolibrary.org/obo/BFO_0000020> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000197> <http://www.w3.org/ns/sosa/FeatureOfInterest>)) ObjectIntersectionOf(<http://purl.obolibrary.org/obo/BFO_0000144> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000132> <http://www.w3.org/ns/sosa/FeatureOfInterest>))))",
+          "referenced_iris": [
+            "http://purl.obolibrary.org/obo/BFO_0000020",
+            "http://purl.obolibrary.org/obo/BFO_0000132",
+            "http://purl.obolibrary.org/obo/BFO_0000144",
+            "http://purl.obolibrary.org/obo/BFO_0000197",
+            "http://www.w3.org/2000/01/rdf-schema#subClassOf",
+            "http://www.w3.org/ns/sosa/FeatureOfInterest",
+            "http://www.w3.org/ns/sosa/ObservableProperty"
+          ],
+          "target_category": "bfo_bearing",
+          "product_dispositions": {
+            "integrated": {
+              "status": "emitted_unchanged"
+            },
+            "alignment_core": {
+              "status": "not_applicable",
+              "reason_code": "TARGET_SPECIFIC"
+            },
+            "strict_bfo_mapping": {
+              "status": "emitted_unchanged"
+            },
+            "bfo_projection": {
+              "status": "provided_through_import"
+            },
+            "cco_extension": {
+              "status": "provided_through_import"
+            }
+          }
+        }
+      ],
+      "row_product_dispositions": null
+    },
+    {
+      "row_id": "urn:uuid:99f8aba6-abaa-49de-a126-da1573f24c39",
+      "location": {
+        "worksheet": "Sheet2",
+        "row": 33
+      },
+      "subject": {
+        "lexical": "sosa:madeBySensor",
+        "iri": "http://www.w3.org/ns/sosa/madeBySensor"
+      },
+      "predicate": {
+        "lexical": "rdfs:range",
+        "iri": "http://www.w3.org/2000/01/rdf-schema#range"
+      },
+      "authoritative_target_lexical": "sosa:Sensor",
+      "canonical_row_expression": {
+        "canonicalization": "coms-row-expression-v1",
+        "mapping_type": "range",
+        "predicate_iri": "http://www.w3.org/2000/01/rdf-schema#range",
+        "subject_iri": "http://www.w3.org/ns/sosa/madeBySensor",
+        "target": "<http://www.w3.org/ns/sosa/Sensor>"
+      },
+      "source_expression_sha256": "58dbbeae401a187ac98660e8c310167621c763a06eb17106717ef5cd616f9a20",
+      "mapping_type": "range",
+      "coverage_classification": "property_typing",
+      "reasoning": "",
+      "authoritative_axioms": [
+        {
+          "axiom_id": "sha256:d695dd55dbcac9a40574027e8ef1396186bccd79631492fba6403bd67e16f44c",
+          "canonical_expression": "ObjectPropertyRange(<http://www.w3.org/ns/sosa/madeBySensor> <http://www.w3.org/ns/sosa/Sensor>)",
+          "referenced_iris": [
+            "http://www.w3.org/2000/01/rdf-schema#range",
+            "http://www.w3.org/ns/sosa/Sensor",
+            "http://www.w3.org/ns/sosa/madeBySensor"
+          ],
+          "target_category": "target_neutral",
+          "product_dispositions": {
+            "integrated": {
+              "status": "emitted_unchanged"
+            },
+            "alignment_core": {
+              "status": "emitted_unchanged"
+            },
+            "strict_bfo_mapping": {
+              "status": "provided_through_import"
+            },
+            "bfo_projection": {
+              "status": "provided_transitively"
+            },
+            "cco_extension": {
+              "status": "provided_transitively"
+            }
+          }
+        }
+      ],
+      "row_product_dispositions": null
+    },
+    {
+      "row_id": "urn:uuid:9c14f13e-16c8-4afd-bcee-8b4bb9d3f0ca",
+      "location": {
+        "worksheet": "Sheet2",
+        "row": 31
+      },
+      "subject": {
+        "lexical": "sosa:madeSampling",
+        "iri": "http://www.w3.org/ns/sosa/madeSampling"
+      },
+      "predicate": {
+        "lexical": "rdfs:subPropertyOf",
+        "iri": "http://www.w3.org/2000/01/rdf-schema#subPropertyOf"
+      },
+      "authoritative_target_lexical": "cco:agent_in",
+      "canonical_row_expression": {
+        "canonicalization": "coms-row-expression-v1",
+        "mapping_type": "object_property_mapping",
+        "predicate_iri": "http://www.w3.org/2000/01/rdf-schema#subPropertyOf",
+        "subject_iri": "http://www.w3.org/ns/sosa/madeSampling",
+        "target": "<https://www.commoncoreontologies.org/ont00001787>"
+      },
+      "source_expression_sha256": "0a70c5e59bc893392f0d1cfaf718fbceba3e1729e3a55dde8425297f9367757c",
+      "mapping_type": "object_property_mapping",
+      "coverage_classification": "relation_mapping",
+      "reasoning": "",
+      "authoritative_axioms": [
+        {
+          "axiom_id": "sha256:9210e36acd33fe0b2b119b7f01500e5e0b31c5a0a88808f7002efbcd8f0509b7",
+          "canonical_expression": "SubObjectPropertyOf(<http://www.w3.org/ns/sosa/madeSampling> <https://www.commoncoreontologies.org/ont00001787>)",
+          "referenced_iris": [
+            "http://www.w3.org/2000/01/rdf-schema#subPropertyOf",
+            "http://www.w3.org/ns/sosa/madeSampling",
+            "https://www.commoncoreontologies.org/ont00001787"
+          ],
+          "target_category": "cco_bearing",
+          "product_dispositions": {
+            "integrated": {
+              "status": "emitted_unchanged"
+            },
+            "alignment_core": {
+              "status": "not_applicable",
+              "reason_code": "TARGET_SPECIFIC"
+            },
+            "strict_bfo_mapping": {
+              "status": "deferred",
+              "reason_code": "NO_APPROVED_TRANSFORMATION_RULE"
+            },
+            "bfo_projection": {
+              "status": "deferred",
+              "reason_code": "NO_APPROVED_TRANSFORMATION_RULE"
+            },
+            "cco_extension": {
+              "status": "emitted_unchanged"
+            }
+          }
+        }
+      ],
+      "row_product_dispositions": null
+    },
+    {
+      "row_id": "urn:uuid:9ea02b02-c86b-4a0b-a56b-47c1dea0bfa4",
+      "location": {
+        "worksheet": "Sheet1",
+        "row": 45
+      },
+      "subject": {
+        "lexical": "ssn-system:SystemProperty",
+        "iri": "http://www.w3.org/ns/ssn/systems/SystemProperty"
+      },
+      "predicate": {
+        "lexical": "rdfs:subClassOf",
+        "iri": "http://www.w3.org/2000/01/rdf-schema#subClassOf"
+      },
+      "authoritative_target_lexical": "(bfo:SpecificallyDependentContinuant or bfo:ProcessProfile) and (cco:prescribed_by some cco:ArtifactFunctionSpecification)",
+      "canonical_row_expression": {
+        "canonicalization": "coms-row-expression-v1",
+        "mapping_type": "class_mapping",
+        "predicate_iri": "http://www.w3.org/2000/01/rdf-schema#subClassOf",
+        "subject_iri": "http://www.w3.org/ns/ssn/systems/SystemProperty",
+        "target": "ObjectIntersectionOf(ObjectSomeValuesFrom(<https://www.commoncoreontologies.org/ont00001920> <https://www.commoncoreontologies.org/ont00000118>) ObjectUnionOf(<http://purl.obolibrary.org/obo/BFO_0000020> <http://purl.obolibrary.org/obo/BFO_0000144>))"
+      },
+      "source_expression_sha256": "ce44916ee688759e7bae9c9202f0be28047a9e9ff7ff0ee719495bca5cad59e0",
+      "mapping_type": "class_mapping",
+      "coverage_classification": "class_mapping",
+      "reasoning": "",
+      "authoritative_axioms": [
+        {
+          "axiom_id": "sha256:69c3b2b4c146ceb3fddb1d600e12d656e8fe35fcf169d0c4fafa9dff68822b1e",
+          "canonical_expression": "SubClassOf(<http://www.w3.org/ns/ssn/systems/SystemProperty> ObjectIntersectionOf(ObjectSomeValuesFrom(<https://www.commoncoreontologies.org/ont00001920> <https://www.commoncoreontologies.org/ont00000118>) ObjectUnionOf(<http://purl.obolibrary.org/obo/BFO_0000020> <http://purl.obolibrary.org/obo/BFO_0000144>)))",
+          "referenced_iris": [
+            "http://purl.obolibrary.org/obo/BFO_0000020",
+            "http://purl.obolibrary.org/obo/BFO_0000144",
+            "http://www.w3.org/2000/01/rdf-schema#subClassOf",
+            "http://www.w3.org/ns/ssn/systems/SystemProperty",
+            "https://www.commoncoreontologies.org/ont00000118",
+            "https://www.commoncoreontologies.org/ont00001920"
+          ],
+          "target_category": "mixed_bfo_cco",
+          "product_dispositions": {
+            "integrated": {
+              "status": "emitted_unchanged"
+            },
+            "alignment_core": {
+              "status": "not_applicable",
+              "reason_code": "TARGET_SPECIFIC"
+            },
+            "strict_bfo_mapping": {
+              "status": "deferred",
+              "reason_code": "NO_APPROVED_TRANSFORMATION_RULE"
+            },
+            "bfo_projection": {
+              "status": "deferred",
+              "reason_code": "NO_APPROVED_TRANSFORMATION_RULE"
+            },
+            "cco_extension": {
+              "status": "emitted_unchanged"
+            }
+          }
+        }
+      ],
+      "row_product_dispositions": null
+    },
+    {
+      "row_id": "urn:uuid:a63a89a9-d9e6-4e7d-ba06-96ff17833866",
+      "location": {
+        "worksheet": "Sheet2",
+        "row": 30
+      },
+      "subject": {
+        "lexical": "sosa:madeBySampler",
+        "iri": "http://www.w3.org/ns/sosa/madeBySampler"
+      },
+      "predicate": {
+        "lexical": "rdfs:subPropertyOf",
+        "iri": "http://www.w3.org/2000/01/rdf-schema#subPropertyOf"
+      },
+      "authoritative_target_lexical": "cco:has_agent",
+      "canonical_row_expression": {
+        "canonicalization": "coms-row-expression-v1",
+        "mapping_type": "object_property_mapping",
+        "predicate_iri": "http://www.w3.org/2000/01/rdf-schema#subPropertyOf",
+        "subject_iri": "http://www.w3.org/ns/sosa/madeBySampler",
+        "target": "<https://www.commoncoreontologies.org/ont00001833>"
+      },
+      "source_expression_sha256": "256084a3fa83724cf983427926caff6ef9c9fa8f0276edb80309d42aa9949f81",
+      "mapping_type": "object_property_mapping",
+      "coverage_classification": "relation_mapping",
+      "reasoning": "",
+      "authoritative_axioms": [
+        {
+          "axiom_id": "sha256:7e4bf7f39c62e83876b0be229a205fc4bc9f52a846d5b86e049d16adc1f5c1be",
+          "canonical_expression": "SubObjectPropertyOf(<http://www.w3.org/ns/sosa/madeBySampler> <https://www.commoncoreontologies.org/ont00001833>)",
+          "referenced_iris": [
+            "http://www.w3.org/2000/01/rdf-schema#subPropertyOf",
+            "http://www.w3.org/ns/sosa/madeBySampler",
+            "https://www.commoncoreontologies.org/ont00001833"
+          ],
+          "target_category": "cco_bearing",
+          "product_dispositions": {
+            "integrated": {
+              "status": "emitted_unchanged"
+            },
+            "alignment_core": {
+              "status": "not_applicable",
+              "reason_code": "TARGET_SPECIFIC"
+            },
+            "strict_bfo_mapping": {
+              "status": "deferred",
+              "reason_code": "NO_APPROVED_TRANSFORMATION_RULE"
+            },
+            "bfo_projection": {
+              "status": "deferred",
+              "reason_code": "NO_APPROVED_TRANSFORMATION_RULE"
+            },
+            "cco_extension": {
+              "status": "emitted_unchanged"
+            }
+          }
+        }
+      ],
+      "row_product_dispositions": null
+    },
+    {
+      "row_id": "urn:uuid:ab19659f-7e70-4f35-87f1-46b59ae80884",
+      "location": {
+        "worksheet": "Sheet2",
+        "row": 52
+      },
+      "subject": {
+        "lexical": "ssn:hasInput",
+        "iri": "http://www.w3.org/ns/ssn/hasInput"
+      },
+      "predicate": {
+        "lexical": "rdfs:range",
+        "iri": "http://www.w3.org/2000/01/rdf-schema#range"
+      },
+      "authoritative_target_lexical": "ssn:Input",
+      "canonical_row_expression": {
+        "canonicalization": "coms-row-expression-v1",
+        "mapping_type": "range",
+        "predicate_iri": "http://www.w3.org/2000/01/rdf-schema#range",
+        "subject_iri": "http://www.w3.org/ns/ssn/hasInput",
+        "target": "<http://www.w3.org/ns/ssn/Input>"
+      },
+      "source_expression_sha256": "ce6f9db8353fb35a53387ba317ddf90c19b3a5b97d7c3ee463070de61e251171",
+      "mapping_type": "range",
+      "coverage_classification": "property_typing",
+      "reasoning": "",
+      "authoritative_axioms": [
+        {
+          "axiom_id": "sha256:0db509d9fc575ddc50b0183e97de46b32b5ba4383954670e5ea59d60474aeb59",
+          "canonical_expression": "ObjectPropertyRange(<http://www.w3.org/ns/ssn/hasInput> <http://www.w3.org/ns/ssn/Input>)",
+          "referenced_iris": [
+            "http://www.w3.org/2000/01/rdf-schema#range",
+            "http://www.w3.org/ns/ssn/Input",
+            "http://www.w3.org/ns/ssn/hasInput"
+          ],
+          "target_category": "target_neutral",
+          "product_dispositions": {
+            "integrated": {
+              "status": "emitted_unchanged"
+            },
+            "alignment_core": {
+              "status": "emitted_unchanged"
+            },
+            "strict_bfo_mapping": {
+              "status": "provided_through_import"
+            },
+            "bfo_projection": {
+              "status": "provided_transitively"
+            },
+            "cco_extension": {
+              "status": "provided_transitively"
+            }
+          }
+        }
+      ],
+      "row_product_dispositions": null
+    },
+    {
+      "row_id": "urn:uuid:ac30440d-7146-4db0-a8d0-8a5bf549b607",
+      "location": {
+        "worksheet": "Sheet2",
+        "row": 51
+      },
+      "subject": {
+        "lexical": "ssn:hasInput",
+        "iri": "http://www.w3.org/ns/ssn/hasInput"
+      },
+      "predicate": {
+        "lexical": "rdfs:domain",
+        "iri": "http://www.w3.org/2000/01/rdf-schema#domain"
+      },
+      "authoritative_target_lexical": "sosa:Procedure",
+      "canonical_row_expression": {
+        "canonicalization": "coms-row-expression-v1",
+        "mapping_type": "domain",
+        "predicate_iri": "http://www.w3.org/2000/01/rdf-schema#domain",
+        "subject_iri": "http://www.w3.org/ns/ssn/hasInput",
+        "target": "<http://www.w3.org/ns/sosa/Procedure>"
+      },
+      "source_expression_sha256": "478781e56bbb172a1c71b44efb3483918dc97746dae5d0060ff077cc87e5a025",
+      "mapping_type": "domain",
+      "coverage_classification": "property_typing",
+      "reasoning": "",
+      "authoritative_axioms": [
+        {
+          "axiom_id": "sha256:733a2295af690d2d2b86dfcd47dfd33214e84ed16606930d2b4246bfeab98d8b",
+          "canonical_expression": "ObjectPropertyDomain(<http://www.w3.org/ns/ssn/hasInput> <http://www.w3.org/ns/sosa/Procedure>)",
+          "referenced_iris": [
+            "http://www.w3.org/2000/01/rdf-schema#domain",
+            "http://www.w3.org/ns/sosa/Procedure",
+            "http://www.w3.org/ns/ssn/hasInput"
+          ],
+          "target_category": "target_neutral",
+          "product_dispositions": {
+            "integrated": {
+              "status": "emitted_unchanged"
+            },
+            "alignment_core": {
+              "status": "emitted_unchanged"
+            },
+            "strict_bfo_mapping": {
+              "status": "provided_through_import"
+            },
+            "bfo_projection": {
+              "status": "provided_transitively"
+            },
+            "cco_extension": {
+              "status": "provided_transitively"
+            }
+          }
+        }
+      ],
+      "row_product_dispositions": null
+    },
+    {
+      "row_id": "urn:uuid:ac95c1e2-0d93-48de-be9d-4defbe6525f0",
+      "location": {
+        "worksheet": "Sheet2",
+        "row": 29
+      },
+      "subject": {
+        "lexical": "sosa:madeByActuator",
+        "iri": "http://www.w3.org/ns/sosa/madeByActuator"
+      },
+      "predicate": {
+        "lexical": "rdfs:range",
+        "iri": "http://www.w3.org/2000/01/rdf-schema#range"
+      },
+      "authoritative_target_lexical": "sosa:Actuator",
+      "canonical_row_expression": {
+        "canonicalization": "coms-row-expression-v1",
+        "mapping_type": "range",
+        "predicate_iri": "http://www.w3.org/2000/01/rdf-schema#range",
+        "subject_iri": "http://www.w3.org/ns/sosa/madeByActuator",
+        "target": "<http://www.w3.org/ns/sosa/Actuator>"
+      },
+      "source_expression_sha256": "ddbf9961f6b455619cdba40745406218696f68eaac23ccd924c6db7e8465617f",
+      "mapping_type": "range",
+      "coverage_classification": "property_typing",
+      "reasoning": "",
+      "authoritative_axioms": [
+        {
+          "axiom_id": "sha256:ebc7ad7b88f4da2f7a42cc794943cbdbc4a2420c9a58378764be6964603cf30b",
+          "canonical_expression": "ObjectPropertyRange(<http://www.w3.org/ns/sosa/madeByActuator> <http://www.w3.org/ns/sosa/Actuator>)",
+          "referenced_iris": [
+            "http://www.w3.org/2000/01/rdf-schema#range",
+            "http://www.w3.org/ns/sosa/Actuator",
+            "http://www.w3.org/ns/sosa/madeByActuator"
+          ],
+          "target_category": "target_neutral",
+          "product_dispositions": {
+            "integrated": {
+              "status": "emitted_unchanged"
+            },
+            "alignment_core": {
+              "status": "emitted_unchanged"
+            },
+            "strict_bfo_mapping": {
+              "status": "provided_through_import"
+            },
+            "bfo_projection": {
+              "status": "provided_transitively"
+            },
+            "cco_extension": {
+              "status": "provided_transitively"
+            }
+          }
+        }
+      ],
+      "row_product_dispositions": null
+    },
+    {
+      "row_id": "urn:uuid:ad8cba71-f987-4e6a-b9c0-7660d5cbc8a7",
+      "location": {
+        "worksheet": "Sheet1",
+        "row": 30
+      },
+      "subject": {
+        "lexical": "ssn-system:SystemLifetime",
+        "iri": "http://www.w3.org/ns/ssn/systems/SystemLifetime"
+      },
+      "predicate": {
+        "lexical": "rdfs:subClassOf",
+        "iri": "http://www.w3.org/2000/01/rdf-schema#subClassOf"
+      },
+      "authoritative_target_lexical": "bfo:Function and bfo:has_realization some (cco:StasisOfArtifactOperationality and (cco:caused_by some (bfo:Process and bfo:realizes some (cco:Affordance and cco:prescribed_by some cco:ArtifactDesign))))",
+      "canonical_row_expression": {
+        "canonicalization": "coms-row-expression-v1",
+        "mapping_type": "class_mapping",
+        "predicate_iri": "http://www.w3.org/2000/01/rdf-schema#subClassOf",
+        "subject_iri": "http://www.w3.org/ns/ssn/systems/SystemLifetime",
+        "target": "ObjectIntersectionOf(<http://purl.obolibrary.org/obo/BFO_0000034> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000054> ObjectIntersectionOf(<https://www.commoncoreontologies.org/ont00001213> ObjectSomeValuesFrom(<https://www.commoncoreontologies.org/ont00001819> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/BFO_0000015> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000055> ObjectIntersectionOf(<https://www.commoncoreontologies.org/ont00000177> ObjectSomeValuesFrom(<https://www.commoncoreontologies.org/ont00001920> <https://www.commoncoreontologies.org/ont00000319>))))))))"
+      },
+      "source_expression_sha256": "88f002b065588248bb46ba34b62a6c9e6ecd3a5e85320d36d4501a3b3a0c4b47",
+      "mapping_type": "class_mapping",
+      "coverage_classification": "class_mapping",
+      "reasoning": "",
+      "authoritative_axioms": [
+        {
+          "axiom_id": "sha256:30d80749b62ad19d41ee9ffc6b0176426ab98d2d0b773aad7d4fdf16ee823ac0",
+          "canonical_expression": "SubClassOf(<http://www.w3.org/ns/ssn/systems/SystemLifetime> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/BFO_0000034> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000054> ObjectIntersectionOf(<https://www.commoncoreontologies.org/ont00001213> ObjectSomeValuesFrom(<https://www.commoncoreontologies.org/ont00001819> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/BFO_0000015> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000055> ObjectIntersectionOf(<https://www.commoncoreontologies.org/ont00000177> ObjectSomeValuesFrom(<https://www.commoncoreontologies.org/ont00001920> <https://www.commoncoreontologies.org/ont00000319>)))))))))",
+          "referenced_iris": [
+            "http://purl.obolibrary.org/obo/BFO_0000015",
+            "http://purl.obolibrary.org/obo/BFO_0000034",
+            "http://purl.obolibrary.org/obo/BFO_0000054",
+            "http://purl.obolibrary.org/obo/BFO_0000055",
+            "http://www.w3.org/2000/01/rdf-schema#subClassOf",
+            "http://www.w3.org/ns/ssn/systems/SystemLifetime",
+            "https://www.commoncoreontologies.org/ont00000177",
+            "https://www.commoncoreontologies.org/ont00000319",
+            "https://www.commoncoreontologies.org/ont00001213",
+            "https://www.commoncoreontologies.org/ont00001819",
+            "https://www.commoncoreontologies.org/ont00001920"
+          ],
+          "target_category": "mixed_bfo_cco",
+          "product_dispositions": {
+            "integrated": {
+              "status": "emitted_unchanged"
+            },
+            "alignment_core": {
+              "status": "not_applicable",
+              "reason_code": "TARGET_SPECIFIC"
+            },
+            "strict_bfo_mapping": {
+              "status": "deferred",
+              "reason_code": "NO_APPROVED_TRANSFORMATION_RULE"
+            },
+            "bfo_projection": {
+              "status": "deferred",
+              "reason_code": "NO_APPROVED_TRANSFORMATION_RULE"
+            },
+            "cco_extension": {
+              "status": "emitted_unchanged"
+            }
+          }
+        }
+      ],
+      "row_product_dispositions": null
+    },
+    {
+      "row_id": "urn:uuid:af48aae7-263f-436d-a76a-4e7232c609c5",
+      "location": {
+        "worksheet": "Sheet2",
+        "row": 46
+      },
+      "subject": {
+        "lexical": "ssn:deployedOnPlatform",
+        "iri": "http://www.w3.org/ns/ssn/deployedOnPlatform"
+      },
+      "predicate": {
+        "lexical": "rdfs:subPropertyOf",
+        "iri": "http://www.w3.org/2000/01/rdf-schema#subPropertyOf"
+      },
+      "authoritative_target_lexical": "bfo:has_participant",
+      "canonical_row_expression": {
+        "canonicalization": "coms-row-expression-v1",
+        "mapping_type": "object_property_mapping",
+        "predicate_iri": "http://www.w3.org/2000/01/rdf-schema#subPropertyOf",
+        "subject_iri": "http://www.w3.org/ns/ssn/deployedOnPlatform",
+        "target": "<http://purl.obolibrary.org/obo/BFO_0000057>"
+      },
+      "source_expression_sha256": "6f5b6bf0a17b9f7353f360b346133939c17833c9461b73b40fcb1a6aa6a6714b",
+      "mapping_type": "object_property_mapping",
+      "coverage_classification": "relation_mapping",
+      "reasoning": "",
+      "authoritative_axioms": [
+        {
+          "axiom_id": "sha256:20d91e47601ba6ee027a45b1292383a93db5223addd66a57f6b0ce832054b0d6",
+          "canonical_expression": "SubObjectPropertyOf(<http://www.w3.org/ns/ssn/deployedOnPlatform> <http://purl.obolibrary.org/obo/BFO_0000057>)",
+          "referenced_iris": [
+            "http://purl.obolibrary.org/obo/BFO_0000057",
+            "http://www.w3.org/2000/01/rdf-schema#subPropertyOf",
+            "http://www.w3.org/ns/ssn/deployedOnPlatform"
+          ],
+          "target_category": "bfo_bearing",
+          "product_dispositions": {
+            "integrated": {
+              "status": "emitted_unchanged"
+            },
+            "alignment_core": {
+              "status": "not_applicable",
+              "reason_code": "TARGET_SPECIFIC"
+            },
+            "strict_bfo_mapping": {
+              "status": "emitted_unchanged"
+            },
+            "bfo_projection": {
+              "status": "provided_through_import"
+            },
+            "cco_extension": {
+              "status": "provided_through_import"
+            }
+          }
+        }
+      ],
+      "row_product_dispositions": null
+    },
+    {
+      "row_id": "urn:uuid:afc3498b-5446-4c8b-928f-822a8e148b63",
+      "location": {
+        "worksheet": "Sheet1",
+        "row": 19
+      },
+      "subject": {
+        "lexical": "ssn-system:MaintenanceSchedule",
+        "iri": "http://www.w3.org/ns/ssn/systems/MaintenanceSchedule"
+      },
+      "predicate": {
+        "lexical": "rdfs:subClassOf",
+        "iri": "http://www.w3.org/2000/01/rdf-schema#subClassOf"
+      },
+      "authoritative_target_lexical": "bfo:Disposition and bfo:has_realization some (cco:Change and cco:affects some (bfo:SpecificallyDependentContinuant and bfo:participates_in some (cco:ActOfMaintenance and bfo:has_occurrent_part some (cco:Frequency and cco:prescribed_by some cco:ArtifactDesign))))",
+      "canonical_row_expression": {
+        "canonicalization": "coms-row-expression-v1",
+        "mapping_type": "class_mapping",
+        "predicate_iri": "http://www.w3.org/2000/01/rdf-schema#subClassOf",
+        "subject_iri": "http://www.w3.org/ns/ssn/systems/MaintenanceSchedule",
+        "target": "ObjectIntersectionOf(<http://purl.obolibrary.org/obo/BFO_0000016> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000054> ObjectIntersectionOf(<https://www.commoncoreontologies.org/ont00000004> ObjectSomeValuesFrom(<https://www.commoncoreontologies.org/ont00001834> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/BFO_0000020> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000056> ObjectIntersectionOf(<https://www.commoncoreontologies.org/ont00000950> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000117> ObjectIntersectionOf(<https://www.commoncoreontologies.org/ont00001047> ObjectSomeValuesFrom(<https://www.commoncoreontologies.org/ont00001920> <https://www.commoncoreontologies.org/ont00000319>))))))))))"
+      },
+      "source_expression_sha256": "7ac782b086f818af382db44d105231e4cf6dba24934ae24c076e6ecf7133c690",
+      "mapping_type": "class_mapping",
+      "coverage_classification": "class_mapping",
+      "reasoning": "",
+      "authoritative_axioms": [
+        {
+          "axiom_id": "sha256:c8c01d3cea6d9185b6c07763b28bec3b25a8e467d2abeeba7dda4edadb99ad61",
+          "canonical_expression": "SubClassOf(<http://www.w3.org/ns/ssn/systems/MaintenanceSchedule> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/BFO_0000016> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000054> ObjectIntersectionOf(<https://www.commoncoreontologies.org/ont00000004> ObjectSomeValuesFrom(<https://www.commoncoreontologies.org/ont00001834> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/BFO_0000020> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000056> ObjectIntersectionOf(<https://www.commoncoreontologies.org/ont00000950> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000117> ObjectIntersectionOf(<https://www.commoncoreontologies.org/ont00001047> ObjectSomeValuesFrom(<https://www.commoncoreontologies.org/ont00001920> <https://www.commoncoreontologies.org/ont00000319>)))))))))))",
+          "referenced_iris": [
+            "http://purl.obolibrary.org/obo/BFO_0000016",
+            "http://purl.obolibrary.org/obo/BFO_0000020",
+            "http://purl.obolibrary.org/obo/BFO_0000054",
+            "http://purl.obolibrary.org/obo/BFO_0000056",
+            "http://purl.obolibrary.org/obo/BFO_0000117",
+            "http://www.w3.org/2000/01/rdf-schema#subClassOf",
+            "http://www.w3.org/ns/ssn/systems/MaintenanceSchedule",
+            "https://www.commoncoreontologies.org/ont00000004",
+            "https://www.commoncoreontologies.org/ont00000319",
+            "https://www.commoncoreontologies.org/ont00000950",
+            "https://www.commoncoreontologies.org/ont00001047",
+            "https://www.commoncoreontologies.org/ont00001834",
+            "https://www.commoncoreontologies.org/ont00001920"
+          ],
+          "target_category": "mixed_bfo_cco",
+          "product_dispositions": {
+            "integrated": {
+              "status": "emitted_unchanged"
+            },
+            "alignment_core": {
+              "status": "not_applicable",
+              "reason_code": "TARGET_SPECIFIC"
+            },
+            "strict_bfo_mapping": {
+              "status": "deferred",
+              "reason_code": "NO_APPROVED_TRANSFORMATION_RULE"
+            },
+            "bfo_projection": {
+              "status": "deferred",
+              "reason_code": "NO_APPROVED_TRANSFORMATION_RULE"
+            },
+            "cco_extension": {
+              "status": "emitted_unchanged"
+            }
+          }
+        }
+      ],
+      "row_product_dispositions": null
+    },
+    {
+      "row_id": "urn:uuid:b05ab84c-eeff-45d1-a95d-39cf2d9f084f",
+      "location": {
+        "worksheet": "Sheet1",
+        "row": 10
+      },
+      "subject": {
+        "lexical": "sosa:Result",
+        "iri": "http://www.w3.org/ns/sosa/Result"
+      },
+      "predicate": {
+        "lexical": "owl:equivalentClass",
+        "iri": "http://www.w3.org/2002/07/owl#equivalentClass"
+      },
+      "authoritative_target_lexical": "(cco:InformationContentEntity or bfo:MaterialEntity) and (cco:is_output_of some (sosa:Observation or sosa:Actuation or sosa:Sampling))",
+      "canonical_row_expression": {
+        "canonicalization": "coms-row-expression-v1",
+        "mapping_type": "class_mapping",
+        "predicate_iri": "http://www.w3.org/2002/07/owl#equivalentClass",
+        "subject_iri": "http://www.w3.org/ns/sosa/Result",
+        "target": "ObjectIntersectionOf(ObjectSomeValuesFrom(<https://www.commoncoreontologies.org/ont00001816> ObjectUnionOf(<http://www.w3.org/ns/sosa/Actuation> <http://www.w3.org/ns/sosa/Observation> <http://www.w3.org/ns/sosa/Sampling>)) ObjectUnionOf(<http://purl.obolibrary.org/obo/BFO_0000040> <https://www.commoncoreontologies.org/ont00000958>))"
+      },
+      "source_expression_sha256": "888f4d97c4d62a60af5c4bed48e18ef060562feb484b5a39870c3ca8782b3a98",
+      "mapping_type": "class_mapping",
+      "coverage_classification": "class_mapping",
+      "reasoning": "",
+      "authoritative_axioms": [
+        {
+          "axiom_id": "sha256:4de8c53cc012a2f7e0322696f11d796ad9db81474e35fcb142b297bb3b714bde",
+          "canonical_expression": "EquivalentClasses(<http://www.w3.org/ns/sosa/Result> ObjectIntersectionOf(ObjectSomeValuesFrom(<https://www.commoncoreontologies.org/ont00001816> ObjectUnionOf(<http://www.w3.org/ns/sosa/Actuation> <http://www.w3.org/ns/sosa/Observation> <http://www.w3.org/ns/sosa/Sampling>)) ObjectUnionOf(<http://purl.obolibrary.org/obo/BFO_0000040> <https://www.commoncoreontologies.org/ont00000958>)))",
+          "referenced_iris": [
+            "http://purl.obolibrary.org/obo/BFO_0000040",
+            "http://www.w3.org/2002/07/owl#equivalentClass",
+            "http://www.w3.org/ns/sosa/Actuation",
+            "http://www.w3.org/ns/sosa/Observation",
+            "http://www.w3.org/ns/sosa/Result",
+            "http://www.w3.org/ns/sosa/Sampling",
+            "https://www.commoncoreontologies.org/ont00000958",
+            "https://www.commoncoreontologies.org/ont00001816"
+          ],
+          "target_category": "mixed_bfo_cco",
+          "product_dispositions": {
+            "integrated": {
+              "status": "emitted_unchanged"
+            },
+            "alignment_core": {
+              "status": "not_applicable",
+              "reason_code": "TARGET_SPECIFIC"
+            },
+            "strict_bfo_mapping": {
+              "status": "deferred",
+              "reason_code": "NO_APPROVED_TRANSFORMATION_RULE"
+            },
+            "bfo_projection": {
+              "status": "deferred",
+              "reason_code": "NO_APPROVED_TRANSFORMATION_RULE"
+            },
+            "cco_extension": {
+              "status": "emitted_unchanged"
+            }
+          }
+        }
+      ],
+      "row_product_dispositions": null
+    },
+    {
+      "row_id": "urn:uuid:b1421726-3675-4b2a-9824-150e108157e4",
+      "location": {
+        "worksheet": "Sheet1",
+        "row": 34
+      },
+      "subject": {
+        "lexical": "ssn:Property",
+        "iri": "http://www.w3.org/ns/ssn/Property"
+      },
+      "predicate": {
+        "lexical": "owl:equivalentClass",
+        "iri": "http://www.w3.org/2002/07/owl#equivalentClass"
+      },
+      "authoritative_target_lexical": "(bfo:SpecificallyDependentContinuant or bfo:ProcessProfile)",
+      "canonical_row_expression": {
+        "canonicalization": "coms-row-expression-v1",
+        "mapping_type": "class_mapping",
+        "predicate_iri": "http://www.w3.org/2002/07/owl#equivalentClass",
+        "subject_iri": "http://www.w3.org/ns/ssn/Property",
+        "target": "ObjectUnionOf(<http://purl.obolibrary.org/obo/BFO_0000020> <http://purl.obolibrary.org/obo/BFO_0000144>)"
+      },
+      "source_expression_sha256": "8a3ad12c4c9f7269f431573e4b69efb66aff9d6b3e276799a27271efc7b98269",
+      "mapping_type": "class_mapping",
+      "coverage_classification": "class_mapping",
+      "reasoning": "",
+      "authoritative_axioms": [
+        {
+          "axiom_id": "sha256:e97401fddd65d2c240938d965cb3ecb82f52b396f7fbdc7ccee0de7edf3ff74b",
+          "canonical_expression": "EquivalentClasses(<http://www.w3.org/ns/ssn/Property> ObjectUnionOf(<http://purl.obolibrary.org/obo/BFO_0000020> <http://purl.obolibrary.org/obo/BFO_0000144>))",
+          "referenced_iris": [
+            "http://purl.obolibrary.org/obo/BFO_0000020",
+            "http://purl.obolibrary.org/obo/BFO_0000144",
+            "http://www.w3.org/2002/07/owl#equivalentClass",
+            "http://www.w3.org/ns/ssn/Property"
+          ],
+          "target_category": "bfo_bearing",
+          "product_dispositions": {
+            "integrated": {
+              "status": "emitted_unchanged"
+            },
+            "alignment_core": {
+              "status": "not_applicable",
+              "reason_code": "TARGET_SPECIFIC"
+            },
+            "strict_bfo_mapping": {
+              "status": "emitted_unchanged"
+            },
+            "bfo_projection": {
+              "status": "provided_through_import"
+            },
+            "cco_extension": {
+              "status": "provided_through_import"
+            }
+          }
+        }
+      ],
+      "row_product_dispositions": null
+    },
+    {
+      "row_id": "urn:uuid:b15038bf-7e69-4e62-9cdd-50edb029d88b",
+      "location": {
+        "worksheet": "Sheet1",
+        "row": 14
+      },
+      "subject": {
+        "lexical": "ssn-system:Condition",
+        "iri": "http://www.w3.org/ns/ssn/systems/Condition"
+      },
+      "predicate": {
+        "lexical": "rdfs:subClassOf",
+        "iri": "http://www.w3.org/2000/01/rdf-schema#subClassOf"
+      },
+      "authoritative_target_lexical": "(bfo:SpecificallyDependentContinuant or bfo:ProcessProfile) and (cco:condition_described_by some cco:PerformanceSpecification)",
+      "canonical_row_expression": {
+        "canonicalization": "coms-row-expression-v1",
+        "mapping_type": "class_mapping",
+        "predicate_iri": "http://www.w3.org/2000/01/rdf-schema#subClassOf",
+        "subject_iri": "http://www.w3.org/ns/ssn/systems/Condition",
+        "target": "ObjectIntersectionOf(ObjectSomeValuesFrom(<https://www.commoncoreontologies.org/ont00001884> <https://www.commoncoreontologies.org/ont00000127>) ObjectUnionOf(<http://purl.obolibrary.org/obo/BFO_0000020> <http://purl.obolibrary.org/obo/BFO_0000144>))"
+      },
+      "source_expression_sha256": "746a007b72a00ce5517e19770d2beceee5740b3b346b2e70d329f9ac95cc7778",
+      "mapping_type": "class_mapping",
+      "coverage_classification": "class_mapping",
+      "reasoning": "",
+      "authoritative_axioms": [
+        {
+          "axiom_id": "sha256:3555605bb2df608876e70c42ec20fa13f80abde4df1a61953beef445621384e2",
+          "canonical_expression": "SubClassOf(<http://www.w3.org/ns/ssn/systems/Condition> ObjectIntersectionOf(ObjectSomeValuesFrom(<https://www.commoncoreontologies.org/ont00001884> <https://www.commoncoreontologies.org/ont00000127>) ObjectUnionOf(<http://purl.obolibrary.org/obo/BFO_0000020> <http://purl.obolibrary.org/obo/BFO_0000144>)))",
+          "referenced_iris": [
+            "http://purl.obolibrary.org/obo/BFO_0000020",
+            "http://purl.obolibrary.org/obo/BFO_0000144",
+            "http://www.w3.org/2000/01/rdf-schema#subClassOf",
+            "http://www.w3.org/ns/ssn/systems/Condition",
+            "https://www.commoncoreontologies.org/ont00000127",
+            "https://www.commoncoreontologies.org/ont00001884"
+          ],
+          "target_category": "mixed_bfo_cco",
+          "product_dispositions": {
+            "integrated": {
+              "status": "emitted_unchanged"
+            },
+            "alignment_core": {
+              "status": "not_applicable",
+              "reason_code": "TARGET_SPECIFIC"
+            },
+            "strict_bfo_mapping": {
+              "status": "deferred",
+              "reason_code": "NO_APPROVED_TRANSFORMATION_RULE"
+            },
+            "bfo_projection": {
+              "status": "deferred",
+              "reason_code": "NO_APPROVED_TRANSFORMATION_RULE"
+            },
+            "cco_extension": {
+              "status": "emitted_unchanged"
+            }
+          }
+        }
+      ],
+      "row_product_dispositions": null
+    },
+    {
+      "row_id": "urn:uuid:b16f1d3a-3d10-4b75-9f12-2331e6c46d74",
+      "location": {
+        "worksheet": "Sheet2",
+        "row": 6
+      },
+      "subject": {
+        "lexical": "sosa:hasFeatureOfInterest",
+        "iri": "http://www.w3.org/ns/sosa/hasFeatureOfInterest"
+      },
+      "predicate": {
+        "lexical": "rdfs:domain",
+        "iri": "http://www.w3.org/2000/01/rdf-schema#domain"
+      },
+      "authoritative_target_lexical": "(sosa:Observation or sosa:Actuation or sosa:Sampling)",
+      "canonical_row_expression": {
+        "canonicalization": "coms-row-expression-v1",
+        "mapping_type": "domain",
+        "predicate_iri": "http://www.w3.org/2000/01/rdf-schema#domain",
+        "subject_iri": "http://www.w3.org/ns/sosa/hasFeatureOfInterest",
+        "target": "ObjectUnionOf(<http://www.w3.org/ns/sosa/Actuation> <http://www.w3.org/ns/sosa/Observation> <http://www.w3.org/ns/sosa/Sampling>)"
+      },
+      "source_expression_sha256": "44f8e256510d7aeee357d89e95dd987adb9c07fa43bc2b70e7fccb95348783e9",
+      "mapping_type": "domain",
+      "coverage_classification": "property_typing",
+      "reasoning": "",
+      "authoritative_axioms": [
+        {
+          "axiom_id": "sha256:2d8f0bb889aed23463bdc12f71eb087cf980f269d7283687d266c012c25c4f52",
+          "canonical_expression": "ObjectPropertyDomain(<http://www.w3.org/ns/sosa/hasFeatureOfInterest> ObjectUnionOf(<http://www.w3.org/ns/sosa/Actuation> <http://www.w3.org/ns/sosa/Observation> <http://www.w3.org/ns/sosa/Sampling>))",
+          "referenced_iris": [
+            "http://www.w3.org/2000/01/rdf-schema#domain",
+            "http://www.w3.org/ns/sosa/Actuation",
+            "http://www.w3.org/ns/sosa/Observation",
+            "http://www.w3.org/ns/sosa/Sampling",
+            "http://www.w3.org/ns/sosa/hasFeatureOfInterest"
+          ],
+          "target_category": "target_neutral",
+          "product_dispositions": {
+            "integrated": {
+              "status": "emitted_unchanged"
+            },
+            "alignment_core": {
+              "status": "emitted_unchanged"
+            },
+            "strict_bfo_mapping": {
+              "status": "provided_through_import"
+            },
+            "bfo_projection": {
+              "status": "provided_transitively"
+            },
+            "cco_extension": {
+              "status": "provided_transitively"
+            }
+          }
+        }
+      ],
+      "row_product_dispositions": null
+    },
+    {
+      "row_id": "urn:uuid:b4508c03-1b79-4f53-b525-d5db6d80c7cb",
+      "location": {
+        "worksheet": "Sheet1",
+        "row": 9
+      },
+      "subject": {
+        "lexical": "sosa:Platform",
+        "iri": "http://www.w3.org/ns/sosa/Platform"
+      },
+      "predicate": {
+        "lexical": "owl:equivalentClass",
+        "iri": "http://www.w3.org/2002/07/owl#equivalentClass"
+      },
+      "authoritative_target_lexical": "bfo:MaterialEntity and (sosa:hosts some ssn:System)",
+      "canonical_row_expression": {
+        "canonicalization": "coms-row-expression-v1",
+        "mapping_type": "class_mapping",
+        "predicate_iri": "http://www.w3.org/2002/07/owl#equivalentClass",
+        "subject_iri": "http://www.w3.org/ns/sosa/Platform",
+        "target": "ObjectIntersectionOf(<http://purl.obolibrary.org/obo/BFO_0000040> ObjectSomeValuesFrom(<http://www.w3.org/ns/sosa/hosts> <http://www.w3.org/ns/ssn/System>))"
+      },
+      "source_expression_sha256": "f195b5ed35e9d8e0ce1ff5345c0b5516fd9b946a6e74523cf4228306cf30cd87",
+      "mapping_type": "class_mapping",
+      "coverage_classification": "class_mapping",
+      "reasoning": "",
+      "authoritative_axioms": [
+        {
+          "axiom_id": "sha256:480ce3257f6b1baaaacee7b06ce730cdf63a7dd14c16b4a1bedc09597a5d96ef",
+          "canonical_expression": "EquivalentClasses(<http://www.w3.org/ns/sosa/Platform> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/BFO_0000040> ObjectSomeValuesFrom(<http://www.w3.org/ns/sosa/hosts> <http://www.w3.org/ns/ssn/System>)))",
+          "referenced_iris": [
+            "http://purl.obolibrary.org/obo/BFO_0000040",
+            "http://www.w3.org/2002/07/owl#equivalentClass",
+            "http://www.w3.org/ns/sosa/Platform",
+            "http://www.w3.org/ns/sosa/hosts",
+            "http://www.w3.org/ns/ssn/System"
+          ],
+          "target_category": "bfo_bearing",
+          "product_dispositions": {
+            "integrated": {
+              "status": "emitted_unchanged"
+            },
+            "alignment_core": {
+              "status": "not_applicable",
+              "reason_code": "TARGET_SPECIFIC"
+            },
+            "strict_bfo_mapping": {
+              "status": "emitted_unchanged"
+            },
+            "bfo_projection": {
+              "status": "provided_through_import"
+            },
+            "cco_extension": {
+              "status": "provided_through_import"
+            }
+          }
+        }
+      ],
+      "row_product_dispositions": null
+    },
+    {
+      "row_id": "urn:uuid:b4fc5247-7d44-4619-9d0b-8466f45218bf",
+      "location": {
+        "worksheet": "Sheet2",
+        "row": 25
+      },
+      "subject": {
+        "lexical": "sosa:isResultOf",
+        "iri": "http://www.w3.org/ns/sosa/isResultOf"
+      },
+      "predicate": {
+        "lexical": "rdfs:subPropertyOf",
+        "iri": "http://www.w3.org/2000/01/rdf-schema#subPropertyOf"
+      },
+      "authoritative_target_lexical": "cco:is_output_of",
+      "canonical_row_expression": {
+        "canonicalization": "coms-row-expression-v1",
+        "mapping_type": "object_property_mapping",
+        "predicate_iri": "http://www.w3.org/2000/01/rdf-schema#subPropertyOf",
+        "subject_iri": "http://www.w3.org/ns/sosa/isResultOf",
+        "target": "<https://www.commoncoreontologies.org/ont00001816>"
+      },
+      "source_expression_sha256": "8cc6fd22aa625f9d4f67a84514bdc12f4f6e94d12fc2c6242257a272d530e24d",
+      "mapping_type": "object_property_mapping",
+      "coverage_classification": "relation_mapping",
+      "reasoning": "",
+      "authoritative_axioms": [
+        {
+          "axiom_id": "sha256:68c7f27ba59dc05cef448bf3a158a51385a53a955f45a16d5b5de3025fd50149",
+          "canonical_expression": "SubObjectPropertyOf(<http://www.w3.org/ns/sosa/isResultOf> <https://www.commoncoreontologies.org/ont00001816>)",
+          "referenced_iris": [
+            "http://www.w3.org/2000/01/rdf-schema#subPropertyOf",
+            "http://www.w3.org/ns/sosa/isResultOf",
+            "https://www.commoncoreontologies.org/ont00001816"
+          ],
+          "target_category": "cco_bearing",
+          "product_dispositions": {
+            "integrated": {
+              "status": "emitted_unchanged"
+            },
+            "alignment_core": {
+              "status": "not_applicable",
+              "reason_code": "TARGET_SPECIFIC"
+            },
+            "strict_bfo_mapping": {
+              "status": "deferred",
+              "reason_code": "NO_APPROVED_TRANSFORMATION_RULE"
+            },
+            "bfo_projection": {
+              "status": "deferred",
+              "reason_code": "NO_APPROVED_TRANSFORMATION_RULE"
+            },
+            "cco_extension": {
+              "status": "emitted_unchanged"
+            }
+          }
+        }
+      ],
+      "row_product_dispositions": null
+    },
+    {
+      "row_id": "urn:uuid:b5a532fc-5dea-4a47-9323-0a78a849c078",
+      "location": {
+        "worksheet": "Sheet2",
+        "row": 9
+      },
+      "subject": {
+        "lexical": "sosa:isFeatureOfInterestOf",
+        "iri": "http://www.w3.org/ns/sosa/isFeatureOfInterestOf"
+      },
+      "predicate": {
+        "lexical": "rdfs:domain",
+        "iri": "http://www.w3.org/2000/01/rdf-schema#domain"
+      },
+      "authoritative_target_lexical": "sosa:FeatureOfInterest",
+      "canonical_row_expression": {
+        "canonicalization": "coms-row-expression-v1",
+        "mapping_type": "domain",
+        "predicate_iri": "http://www.w3.org/2000/01/rdf-schema#domain",
+        "subject_iri": "http://www.w3.org/ns/sosa/isFeatureOfInterestOf",
+        "target": "<http://www.w3.org/ns/sosa/FeatureOfInterest>"
+      },
+      "source_expression_sha256": "2d4010ce8244b3060af20e418fc7866cd9b40b3beddd905cc90d12b9586b3015",
+      "mapping_type": "domain",
+      "coverage_classification": "property_typing",
+      "reasoning": "",
+      "authoritative_axioms": [
+        {
+          "axiom_id": "sha256:5da19db0676db0eb0397d4708cf751f9c90a3a732165b769534e0d9300777cc6",
+          "canonical_expression": "ObjectPropertyDomain(<http://www.w3.org/ns/sosa/isFeatureOfInterestOf> <http://www.w3.org/ns/sosa/FeatureOfInterest>)",
+          "referenced_iris": [
+            "http://www.w3.org/2000/01/rdf-schema#domain",
+            "http://www.w3.org/ns/sosa/FeatureOfInterest",
+            "http://www.w3.org/ns/sosa/isFeatureOfInterestOf"
+          ],
+          "target_category": "target_neutral",
+          "product_dispositions": {
+            "integrated": {
+              "status": "emitted_unchanged"
+            },
+            "alignment_core": {
+              "status": "emitted_unchanged"
+            },
+            "strict_bfo_mapping": {
+              "status": "provided_through_import"
+            },
+            "bfo_projection": {
+              "status": "provided_transitively"
+            },
+            "cco_extension": {
+              "status": "provided_transitively"
+            }
+          }
+        }
+      ],
+      "row_product_dispositions": null
+    },
+    {
+      "row_id": "urn:uuid:b7873da3-fc78-4a2a-92e1-ef83efb6d600",
+      "location": {
+        "worksheet": "Sheet2",
+        "row": 61
+      },
+      "subject": {
+        "lexical": "ssn:isProxyFor",
+        "iri": "http://www.w3.org/ns/ssn/isProxyFor"
+      },
+      "predicate": {
+        "lexical": "rdfs:range",
+        "iri": "http://www.w3.org/2000/01/rdf-schema#range"
+      },
+      "authoritative_target_lexical": "ssn:Property",
+      "canonical_row_expression": {
+        "canonicalization": "coms-row-expression-v1",
+        "mapping_type": "range",
+        "predicate_iri": "http://www.w3.org/2000/01/rdf-schema#range",
+        "subject_iri": "http://www.w3.org/ns/ssn/isProxyFor",
+        "target": "<http://www.w3.org/ns/ssn/Property>"
+      },
+      "source_expression_sha256": "7867920787556af6ea7cdcfd036b466545cf68a1724655dad17b1288b19f62d8",
+      "mapping_type": "range",
+      "coverage_classification": "property_typing",
+      "reasoning": "",
+      "authoritative_axioms": [
+        {
+          "axiom_id": "sha256:09ba32215644cf2d55cfe5855539839e3bd68f014c110cd1f562426ee660134b",
+          "canonical_expression": "ObjectPropertyRange(<http://www.w3.org/ns/ssn/isProxyFor> <http://www.w3.org/ns/ssn/Property>)",
+          "referenced_iris": [
+            "http://www.w3.org/2000/01/rdf-schema#range",
+            "http://www.w3.org/ns/ssn/Property",
+            "http://www.w3.org/ns/ssn/isProxyFor"
+          ],
+          "target_category": "target_neutral",
+          "product_dispositions": {
+            "integrated": {
+              "status": "emitted_unchanged"
+            },
+            "alignment_core": {
+              "status": "emitted_unchanged"
+            },
+            "strict_bfo_mapping": {
+              "status": "provided_through_import"
+            },
+            "bfo_projection": {
+              "status": "provided_transitively"
+            },
+            "cco_extension": {
+              "status": "provided_transitively"
+            }
+          }
+        }
+      ],
+      "row_product_dispositions": null
+    },
+    {
+      "row_id": "urn:uuid:b891bb2b-0093-49ff-aa86-2a68a732686d",
+      "location": {
+        "worksheet": "Sheet1",
+        "row": 25
+      },
+      "subject": {
+        "lexical": "ssn-system:ResponseTime",
+        "iri": "http://www.w3.org/ns/ssn/systems/ResponseTime"
+      },
+      "predicate": {
+        "lexical": "rdfs:subClassOf",
+        "iri": "http://www.w3.org/2000/01/rdf-schema#subClassOf"
+      },
+      "authoritative_target_lexical": "bfo:Function and bfo:has_realization some (cco:PlannedAct and (cco:has_process_part some cco:Cause) and (cco:has_process_part some cco:Effect) and (bfo:occupies_temporal_region some (bfo:TemporalRegion and cco:prescribed_by some cco:ArtifactFunctionSpecification)))",
+      "canonical_row_expression": {
+        "canonicalization": "coms-row-expression-v1",
+        "mapping_type": "class_mapping",
+        "predicate_iri": "http://www.w3.org/2000/01/rdf-schema#subClassOf",
+        "subject_iri": "http://www.w3.org/ns/ssn/systems/ResponseTime",
+        "target": "ObjectIntersectionOf(<http://purl.obolibrary.org/obo/BFO_0000034> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000054> ObjectIntersectionOf(<https://www.commoncoreontologies.org/ont00000228> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000199> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/BFO_0000008> ObjectSomeValuesFrom(<https://www.commoncoreontologies.org/ont00001920> <https://www.commoncoreontologies.org/ont00000118>))) ObjectSomeValuesFrom(<https://www.commoncoreontologies.org/ont00001777> <https://www.commoncoreontologies.org/ont00000660>) ObjectSomeValuesFrom(<https://www.commoncoreontologies.org/ont00001777> <https://www.commoncoreontologies.org/ont00000978>))))"
+      },
+      "source_expression_sha256": "a9e7ce56c2b944844816d554305009c49ee6336bb243832e6bd5725ecad196b8",
+      "mapping_type": "class_mapping",
+      "coverage_classification": "class_mapping",
+      "reasoning": "",
+      "authoritative_axioms": [
+        {
+          "axiom_id": "sha256:d7147bf65fde2651641479cec361657f97e01137ad2b760e37061eae25cbe368",
+          "canonical_expression": "SubClassOf(<http://www.w3.org/ns/ssn/systems/ResponseTime> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/BFO_0000034> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000054> ObjectIntersectionOf(<https://www.commoncoreontologies.org/ont00000228> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000199> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/BFO_0000008> ObjectSomeValuesFrom(<https://www.commoncoreontologies.org/ont00001920> <https://www.commoncoreontologies.org/ont00000118>))) ObjectSomeValuesFrom(<https://www.commoncoreontologies.org/ont00001777> <https://www.commoncoreontologies.org/ont00000660>) ObjectSomeValuesFrom(<https://www.commoncoreontologies.org/ont00001777> <https://www.commoncoreontologies.org/ont00000978>)))))",
+          "referenced_iris": [
+            "http://purl.obolibrary.org/obo/BFO_0000008",
+            "http://purl.obolibrary.org/obo/BFO_0000034",
+            "http://purl.obolibrary.org/obo/BFO_0000054",
+            "http://purl.obolibrary.org/obo/BFO_0000199",
+            "http://www.w3.org/2000/01/rdf-schema#subClassOf",
+            "http://www.w3.org/ns/ssn/systems/ResponseTime",
+            "https://www.commoncoreontologies.org/ont00000118",
+            "https://www.commoncoreontologies.org/ont00000228",
+            "https://www.commoncoreontologies.org/ont00000660",
+            "https://www.commoncoreontologies.org/ont00000978",
+            "https://www.commoncoreontologies.org/ont00001777",
+            "https://www.commoncoreontologies.org/ont00001920"
+          ],
+          "target_category": "mixed_bfo_cco",
+          "product_dispositions": {
+            "integrated": {
+              "status": "emitted_unchanged"
+            },
+            "alignment_core": {
+              "status": "not_applicable",
+              "reason_code": "TARGET_SPECIFIC"
+            },
+            "strict_bfo_mapping": {
+              "status": "deferred",
+              "reason_code": "NO_APPROVED_TRANSFORMATION_RULE"
+            },
+            "bfo_projection": {
+              "status": "deferred",
+              "reason_code": "NO_APPROVED_TRANSFORMATION_RULE"
+            },
+            "cco_extension": {
+              "status": "emitted_unchanged"
+            }
+          }
+        }
+      ],
+      "row_product_dispositions": null
+    },
+    {
+      "row_id": "urn:uuid:bc709fe5-c239-494c-9b88-c14e5a8fc79e",
+      "location": {
+        "worksheet": "Sheet1",
+        "row": 3
+      },
+      "subject": {
+        "lexical": "sampling:SampleRelationship",
+        "iri": "http://www.w3.org/ns/sosa/sampling/SampleRelationship"
+      },
+      "predicate": {
+        "lexical": "rdfs:subClassOf",
+        "iri": "http://www.w3.org/2000/01/rdf-schema#subClassOf"
+      },
+      "authoritative_target_lexical": "cco:InformationContentEntity",
+      "canonical_row_expression": {
+        "canonicalization": "coms-row-expression-v1",
+        "mapping_type": "class_mapping",
+        "predicate_iri": "http://www.w3.org/2000/01/rdf-schema#subClassOf",
+        "subject_iri": "http://www.w3.org/ns/sosa/sampling/SampleRelationship",
+        "target": "<https://www.commoncoreontologies.org/ont00000958>"
+      },
+      "source_expression_sha256": "a478be4c1764cbfca52c521cad2d4bb904985e678540a3be8c726c5fe285719c",
+      "mapping_type": "class_mapping",
+      "coverage_classification": "class_mapping",
+      "reasoning": "",
+      "authoritative_axioms": [
+        {
+          "axiom_id": "sha256:7a526678ca98bd78c27db8abd67cc309ea9841c11fa1b6845fe62ade62f3556c",
+          "canonical_expression": "SubClassOf(<http://www.w3.org/ns/sosa/sampling/SampleRelationship> <https://www.commoncoreontologies.org/ont00000958>)",
+          "referenced_iris": [
+            "http://www.w3.org/2000/01/rdf-schema#subClassOf",
+            "http://www.w3.org/ns/sosa/sampling/SampleRelationship",
+            "https://www.commoncoreontologies.org/ont00000958"
+          ],
+          "target_category": "cco_bearing",
+          "product_dispositions": {
+            "integrated": {
+              "status": "emitted_unchanged"
+            },
+            "alignment_core": {
+              "status": "not_applicable",
+              "reason_code": "TARGET_SPECIFIC"
+            },
+            "strict_bfo_mapping": {
+              "status": "deferred",
+              "reason_code": "NO_APPROVED_TRANSFORMATION_RULE"
+            },
+            "bfo_projection": {
+              "status": "deferred",
+              "reason_code": "NO_APPROVED_TRANSFORMATION_RULE"
+            },
+            "cco_extension": {
+              "status": "emitted_unchanged"
+            }
+          }
+        }
+      ],
+      "row_product_dispositions": null
+    },
+    {
+      "row_id": "urn:uuid:bd5a2014-f338-49b8-b7ef-27f5b933d93b",
+      "location": {
+        "worksheet": "Sheet2",
+        "row": 42
+      },
+      "subject": {
+        "lexical": "ssn-system:hasSurvivalRange",
+        "iri": "http://www.w3.org/ns/ssn/systems/hasSurvivalRange"
+      },
+      "predicate": {
+        "lexical": "rdfs:range",
+        "iri": "http://www.w3.org/2000/01/rdf-schema#range"
+      },
+      "authoritative_target_lexical": "ssn-system:SurvivalRange",
+      "canonical_row_expression": {
+        "canonicalization": "coms-row-expression-v1",
+        "mapping_type": "range",
+        "predicate_iri": "http://www.w3.org/2000/01/rdf-schema#range",
+        "subject_iri": "http://www.w3.org/ns/ssn/systems/hasSurvivalRange",
+        "target": "<http://www.w3.org/ns/ssn/systems/SurvivalRange>"
+      },
+      "source_expression_sha256": "8f903cd362769ba3fa14c03661dd8a7cdcb1d02f5285469e3ccf6acb83e56b99",
+      "mapping_type": "range",
+      "coverage_classification": "property_typing",
+      "reasoning": "",
+      "authoritative_axioms": [
+        {
+          "axiom_id": "sha256:332f337d02fa3315c8d21c1ff70a9a182696adf032799e50a6f2bd623ecda746",
+          "canonical_expression": "ObjectPropertyRange(<http://www.w3.org/ns/ssn/systems/hasSurvivalRange> <http://www.w3.org/ns/ssn/systems/SurvivalRange>)",
+          "referenced_iris": [
+            "http://www.w3.org/2000/01/rdf-schema#range",
+            "http://www.w3.org/ns/ssn/systems/SurvivalRange",
+            "http://www.w3.org/ns/ssn/systems/hasSurvivalRange"
+          ],
+          "target_category": "target_neutral",
+          "product_dispositions": {
+            "integrated": {
+              "status": "emitted_unchanged"
+            },
+            "alignment_core": {
+              "status": "emitted_unchanged"
+            },
+            "strict_bfo_mapping": {
+              "status": "provided_through_import"
+            },
+            "bfo_projection": {
+              "status": "provided_transitively"
+            },
+            "cco_extension": {
+              "status": "provided_transitively"
+            }
+          }
+        }
+      ],
+      "row_product_dispositions": null
+    },
+    {
+      "row_id": "urn:uuid:c0a94c70-33c7-41ac-8906-49ad2efe48b5",
+      "location": {
+        "worksheet": "Sheet2",
+        "row": 47
+      },
+      "subject": {
+        "lexical": "ssn:deployedSystem",
+        "iri": "http://www.w3.org/ns/ssn/deployedSystem"
+      },
+      "predicate": {
+        "lexical": "rdfs:subPropertyOf",
+        "iri": "http://www.w3.org/2000/01/rdf-schema#subPropertyOf"
+      },
+      "authoritative_target_lexical": "bfo:has_participant",
+      "canonical_row_expression": {
+        "canonicalization": "coms-row-expression-v1",
+        "mapping_type": "object_property_mapping",
+        "predicate_iri": "http://www.w3.org/2000/01/rdf-schema#subPropertyOf",
+        "subject_iri": "http://www.w3.org/ns/ssn/deployedSystem",
+        "target": "<http://purl.obolibrary.org/obo/BFO_0000057>"
+      },
+      "source_expression_sha256": "20ec8ef778e6da66caf7bb1904db3c3a13a2527e0a935404ab2444fc9b3d0385",
+      "mapping_type": "object_property_mapping",
+      "coverage_classification": "relation_mapping",
+      "reasoning": "",
+      "authoritative_axioms": [
+        {
+          "axiom_id": "sha256:3e6d4c8e6ae7f32b3fde12f2e976c4c91ea66a0893e45ae7a3bb7ddf974dafba",
+          "canonical_expression": "SubObjectPropertyOf(<http://www.w3.org/ns/ssn/deployedSystem> <http://purl.obolibrary.org/obo/BFO_0000057>)",
+          "referenced_iris": [
+            "http://purl.obolibrary.org/obo/BFO_0000057",
+            "http://www.w3.org/2000/01/rdf-schema#subPropertyOf",
+            "http://www.w3.org/ns/ssn/deployedSystem"
+          ],
+          "target_category": "bfo_bearing",
+          "product_dispositions": {
+            "integrated": {
+              "status": "emitted_unchanged"
+            },
+            "alignment_core": {
+              "status": "not_applicable",
+              "reason_code": "TARGET_SPECIFIC"
+            },
+            "strict_bfo_mapping": {
+              "status": "emitted_unchanged"
+            },
+            "bfo_projection": {
+              "status": "provided_through_import"
+            },
+            "cco_extension": {
+              "status": "provided_through_import"
+            }
+          }
+        }
+      ],
+      "row_product_dispositions": null
+    },
+    {
+      "row_id": "urn:uuid:c15208c5-847f-4de3-a456-4037142ca542",
+      "location": {
+        "worksheet": "Sheet1",
+        "row": 44
+      },
+      "subject": {
+        "lexical": "ssn-system:SurvivalRange",
+        "iri": "http://www.w3.org/ns/ssn/systems/SurvivalRange"
+      },
+      "predicate": {
+        "lexical": "rdfs:subClassOf",
+        "iri": "http://www.w3.org/2000/01/rdf-schema#subClassOf"
+      },
+      "authoritative_target_lexical": "bfo:Function and (bfo:has_realization some (bfo:Process and (cco:caused_by some (bfo:Process and (bfo:realizes some (cco:Affordance and (cco:prescribed_by some cco:ArtifactDesign)))))))",
+      "canonical_row_expression": {
+        "canonicalization": "coms-row-expression-v1",
+        "mapping_type": "class_mapping",
+        "predicate_iri": "http://www.w3.org/2000/01/rdf-schema#subClassOf",
+        "subject_iri": "http://www.w3.org/ns/ssn/systems/SurvivalRange",
+        "target": "ObjectIntersectionOf(<http://purl.obolibrary.org/obo/BFO_0000034> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000054> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/BFO_0000015> ObjectSomeValuesFrom(<https://www.commoncoreontologies.org/ont00001819> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/BFO_0000015> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000055> ObjectIntersectionOf(<https://www.commoncoreontologies.org/ont00000177> ObjectSomeValuesFrom(<https://www.commoncoreontologies.org/ont00001920> <https://www.commoncoreontologies.org/ont00000319>))))))))"
+      },
+      "source_expression_sha256": "b5f25fb0bcf748c3be3006227cf4f1f3b71b1307094704afefdd37c7d371386f",
+      "mapping_type": "class_mapping",
+      "coverage_classification": "class_mapping",
+      "reasoning": "",
+      "authoritative_axioms": [
+        {
+          "axiom_id": "sha256:e941d1a04c368c1f5129efef4a5d369aae978e8850e6eecfab01bc9244eca46a",
+          "canonical_expression": "SubClassOf(<http://www.w3.org/ns/ssn/systems/SurvivalRange> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/BFO_0000034> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000054> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/BFO_0000015> ObjectSomeValuesFrom(<https://www.commoncoreontologies.org/ont00001819> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/BFO_0000015> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000055> ObjectIntersectionOf(<https://www.commoncoreontologies.org/ont00000177> ObjectSomeValuesFrom(<https://www.commoncoreontologies.org/ont00001920> <https://www.commoncoreontologies.org/ont00000319>)))))))))",
+          "referenced_iris": [
+            "http://purl.obolibrary.org/obo/BFO_0000015",
+            "http://purl.obolibrary.org/obo/BFO_0000034",
+            "http://purl.obolibrary.org/obo/BFO_0000054",
+            "http://purl.obolibrary.org/obo/BFO_0000055",
+            "http://www.w3.org/2000/01/rdf-schema#subClassOf",
+            "http://www.w3.org/ns/ssn/systems/SurvivalRange",
+            "https://www.commoncoreontologies.org/ont00000177",
+            "https://www.commoncoreontologies.org/ont00000319",
+            "https://www.commoncoreontologies.org/ont00001819",
+            "https://www.commoncoreontologies.org/ont00001920"
+          ],
+          "target_category": "mixed_bfo_cco",
+          "product_dispositions": {
+            "integrated": {
+              "status": "emitted_unchanged"
+            },
+            "alignment_core": {
+              "status": "not_applicable",
+              "reason_code": "TARGET_SPECIFIC"
+            },
+            "strict_bfo_mapping": {
+              "status": "deferred",
+              "reason_code": "NO_APPROVED_TRANSFORMATION_RULE"
+            },
+            "bfo_projection": {
+              "status": "deferred",
+              "reason_code": "NO_APPROVED_TRANSFORMATION_RULE"
+            },
+            "cco_extension": {
+              "status": "emitted_unchanged"
+            }
+          }
+        }
+      ],
+      "row_product_dispositions": null
+    },
+    {
+      "row_id": "urn:uuid:c912bc86-4ac6-4200-8606-7fda6005542f",
+      "location": {
+        "worksheet": "Sheet1",
+        "row": 29
+      },
+      "subject": {
+        "lexical": "ssn-system:SystemCapability",
+        "iri": "http://www.w3.org/ns/ssn/systems/SystemCapability"
+      },
+      "predicate": {
+        "lexical": "rdfs:subClassOf",
+        "iri": "http://www.w3.org/2000/01/rdf-schema#subClassOf"
+      },
+      "authoritative_target_lexical": "(bfo:SpecificallyDependentContinuant or bfo:ProcessProfile) and (cco:condition_described_by some cco:PerformanceSpecification)",
+      "canonical_row_expression": {
+        "canonicalization": "coms-row-expression-v1",
+        "mapping_type": "class_mapping",
+        "predicate_iri": "http://www.w3.org/2000/01/rdf-schema#subClassOf",
+        "subject_iri": "http://www.w3.org/ns/ssn/systems/SystemCapability",
+        "target": "ObjectIntersectionOf(ObjectSomeValuesFrom(<https://www.commoncoreontologies.org/ont00001884> <https://www.commoncoreontologies.org/ont00000127>) ObjectUnionOf(<http://purl.obolibrary.org/obo/BFO_0000020> <http://purl.obolibrary.org/obo/BFO_0000144>))"
+      },
+      "source_expression_sha256": "5db7fb7b07d43ae858f318823c2f64e43407419625e58ece12f9dfb3f83224f5",
+      "mapping_type": "class_mapping",
+      "coverage_classification": "class_mapping",
+      "reasoning": "",
+      "authoritative_axioms": [
+        {
+          "axiom_id": "sha256:765b6d8892fe2096feba40fd405da8b82eb8e3ea275470c3970146781ba79ecc",
+          "canonical_expression": "SubClassOf(<http://www.w3.org/ns/ssn/systems/SystemCapability> ObjectIntersectionOf(ObjectSomeValuesFrom(<https://www.commoncoreontologies.org/ont00001884> <https://www.commoncoreontologies.org/ont00000127>) ObjectUnionOf(<http://purl.obolibrary.org/obo/BFO_0000020> <http://purl.obolibrary.org/obo/BFO_0000144>)))",
+          "referenced_iris": [
+            "http://purl.obolibrary.org/obo/BFO_0000020",
+            "http://purl.obolibrary.org/obo/BFO_0000144",
+            "http://www.w3.org/2000/01/rdf-schema#subClassOf",
+            "http://www.w3.org/ns/ssn/systems/SystemCapability",
+            "https://www.commoncoreontologies.org/ont00000127",
+            "https://www.commoncoreontologies.org/ont00001884"
+          ],
+          "target_category": "mixed_bfo_cco",
+          "product_dispositions": {
+            "integrated": {
+              "status": "emitted_unchanged"
+            },
+            "alignment_core": {
+              "status": "not_applicable",
+              "reason_code": "TARGET_SPECIFIC"
+            },
+            "strict_bfo_mapping": {
+              "status": "deferred",
+              "reason_code": "NO_APPROVED_TRANSFORMATION_RULE"
+            },
+            "bfo_projection": {
+              "status": "deferred",
+              "reason_code": "NO_APPROVED_TRANSFORMATION_RULE"
+            },
+            "cco_extension": {
+              "status": "emitted_unchanged"
+            }
+          }
+        }
+      ],
+      "row_product_dispositions": null
+    },
+    {
+      "row_id": "urn:uuid:cbbba7df-22ee-4393-b4fd-46019697192a",
+      "location": {
+        "worksheet": "Sheet2",
+        "row": 8
+      },
+      "subject": {
+        "lexical": "sosa:hasResult",
+        "iri": "http://www.w3.org/ns/sosa/hasResult"
+      },
+      "predicate": {
+        "lexical": "rdfs:subPropertyOf",
+        "iri": "http://www.w3.org/2000/01/rdf-schema#subPropertyOf"
+      },
+      "authoritative_target_lexical": "cco:has_output",
+      "canonical_row_expression": {
+        "canonicalization": "coms-row-expression-v1",
+        "mapping_type": "object_property_mapping",
+        "predicate_iri": "http://www.w3.org/2000/01/rdf-schema#subPropertyOf",
+        "subject_iri": "http://www.w3.org/ns/sosa/hasResult",
+        "target": "<https://www.commoncoreontologies.org/ont00001986>"
+      },
+      "source_expression_sha256": "47d35665f53fc5d1fb29148f7d1184f38162d47477c0929e2a90b53aba86bcf0",
+      "mapping_type": "object_property_mapping",
+      "coverage_classification": "relation_mapping",
+      "reasoning": "",
+      "authoritative_axioms": [
+        {
+          "axiom_id": "sha256:ea0c502c7fe789b98b0bbe26002ac0b18790b13a24580a0e31e06a9891f717ec",
+          "canonical_expression": "SubObjectPropertyOf(<http://www.w3.org/ns/sosa/hasResult> <https://www.commoncoreontologies.org/ont00001986>)",
+          "referenced_iris": [
+            "http://www.w3.org/2000/01/rdf-schema#subPropertyOf",
+            "http://www.w3.org/ns/sosa/hasResult",
+            "https://www.commoncoreontologies.org/ont00001986"
+          ],
+          "target_category": "cco_bearing",
+          "product_dispositions": {
+            "integrated": {
+              "status": "emitted_unchanged"
+            },
+            "alignment_core": {
+              "status": "not_applicable",
+              "reason_code": "TARGET_SPECIFIC"
+            },
+            "strict_bfo_mapping": {
+              "status": "deferred",
+              "reason_code": "NO_APPROVED_TRANSFORMATION_RULE"
+            },
+            "bfo_projection": {
+              "status": "deferred",
+              "reason_code": "NO_APPROVED_TRANSFORMATION_RULE"
+            },
+            "cco_extension": {
+              "status": "emitted_unchanged"
+            }
+          }
+        }
+      ],
+      "row_product_dispositions": null
+    },
+    {
+      "row_id": "urn:uuid:d180e765-d4d1-4578-a33a-6e96308e01db",
+      "location": {
+        "worksheet": "Sheet1",
+        "row": 43
+      },
+      "subject": {
+        "lexical": "ssn-system:MeasurementRange",
+        "iri": "http://www.w3.org/ns/ssn/systems/MeasurementRange"
+      },
+      "predicate": {
+        "lexical": "rdfs:subClassOf",
+        "iri": "http://www.w3.org/2000/01/rdf-schema#subClassOf"
+      },
+      "authoritative_target_lexical": "bfo:Function and (bfo:has_realization some (sosa:Observation and (cco:caused_by some (ssn:Stimulus and (cco:prescribed_by some cco:ArtifactFunctionSpecification)))))",
+      "canonical_row_expression": {
+        "canonicalization": "coms-row-expression-v1",
+        "mapping_type": "class_mapping",
+        "predicate_iri": "http://www.w3.org/2000/01/rdf-schema#subClassOf",
+        "subject_iri": "http://www.w3.org/ns/ssn/systems/MeasurementRange",
+        "target": "ObjectIntersectionOf(<http://purl.obolibrary.org/obo/BFO_0000034> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000054> ObjectIntersectionOf(<http://www.w3.org/ns/sosa/Observation> ObjectSomeValuesFrom(<https://www.commoncoreontologies.org/ont00001819> ObjectIntersectionOf(<http://www.w3.org/ns/ssn/Stimulus> ObjectSomeValuesFrom(<https://www.commoncoreontologies.org/ont00001920> <https://www.commoncoreontologies.org/ont00000118>))))))"
+      },
+      "source_expression_sha256": "9b387c1657e3dbe917196955793476da0f730ef73ba29d0687f7111b5521b43e",
+      "mapping_type": "class_mapping",
+      "coverage_classification": "class_mapping",
+      "reasoning": "",
+      "authoritative_axioms": [
+        {
+          "axiom_id": "sha256:89dc07e0f0e0a2117964d686c2a88b7da77cb761bba5c3cb74b6b6521502cf11",
+          "canonical_expression": "SubClassOf(<http://www.w3.org/ns/ssn/systems/MeasurementRange> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/BFO_0000034> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000054> ObjectIntersectionOf(<http://www.w3.org/ns/sosa/Observation> ObjectSomeValuesFrom(<https://www.commoncoreontologies.org/ont00001819> ObjectIntersectionOf(<http://www.w3.org/ns/ssn/Stimulus> ObjectSomeValuesFrom(<https://www.commoncoreontologies.org/ont00001920> <https://www.commoncoreontologies.org/ont00000118>)))))))",
+          "referenced_iris": [
+            "http://purl.obolibrary.org/obo/BFO_0000034",
+            "http://purl.obolibrary.org/obo/BFO_0000054",
+            "http://www.w3.org/2000/01/rdf-schema#subClassOf",
+            "http://www.w3.org/ns/sosa/Observation",
+            "http://www.w3.org/ns/ssn/Stimulus",
+            "http://www.w3.org/ns/ssn/systems/MeasurementRange",
+            "https://www.commoncoreontologies.org/ont00000118",
+            "https://www.commoncoreontologies.org/ont00001819",
+            "https://www.commoncoreontologies.org/ont00001920"
+          ],
+          "target_category": "mixed_bfo_cco",
+          "product_dispositions": {
+            "integrated": {
+              "status": "emitted_unchanged"
+            },
+            "alignment_core": {
+              "status": "not_applicable",
+              "reason_code": "TARGET_SPECIFIC"
+            },
+            "strict_bfo_mapping": {
+              "status": "deferred",
+              "reason_code": "NO_APPROVED_TRANSFORMATION_RULE"
+            },
+            "bfo_projection": {
+              "status": "deferred",
+              "reason_code": "NO_APPROVED_TRANSFORMATION_RULE"
+            },
+            "cco_extension": {
+              "status": "emitted_unchanged"
+            }
+          }
+        }
+      ],
+      "row_product_dispositions": null
+    },
+    {
+      "row_id": "urn:uuid:d5712b64-a526-4112-ba23-520ec8dc5066",
+      "location": {
+        "worksheet": "Sheet2",
+        "row": 21
+      },
+      "subject": {
+        "lexical": "sosa:isObservedBy",
+        "iri": "http://www.w3.org/ns/sosa/isObservedBy"
+      },
+      "predicate": {
+        "lexical": "rdfs:domain",
+        "iri": "http://www.w3.org/2000/01/rdf-schema#domain"
+      },
+      "authoritative_target_lexical": "sosa:ObservableProperty",
+      "canonical_row_expression": {
+        "canonicalization": "coms-row-expression-v1",
+        "mapping_type": "domain",
+        "predicate_iri": "http://www.w3.org/2000/01/rdf-schema#domain",
+        "subject_iri": "http://www.w3.org/ns/sosa/isObservedBy",
+        "target": "<http://www.w3.org/ns/sosa/ObservableProperty>"
+      },
+      "source_expression_sha256": "b5fb7b4571c02926a0bd3b107ad08a64ac20970554266fc15dfbf40d1ac6396c",
+      "mapping_type": "domain",
+      "coverage_classification": "property_typing",
+      "reasoning": "",
+      "authoritative_axioms": [
+        {
+          "axiom_id": "sha256:574e85973353c07195e8e6ae6dc3a813c8baecb2b0a19a268084ff8e404f606c",
+          "canonical_expression": "ObjectPropertyDomain(<http://www.w3.org/ns/sosa/isObservedBy> <http://www.w3.org/ns/sosa/ObservableProperty>)",
+          "referenced_iris": [
+            "http://www.w3.org/2000/01/rdf-schema#domain",
+            "http://www.w3.org/ns/sosa/ObservableProperty",
+            "http://www.w3.org/ns/sosa/isObservedBy"
+          ],
+          "target_category": "target_neutral",
+          "product_dispositions": {
+            "integrated": {
+              "status": "emitted_unchanged"
+            },
+            "alignment_core": {
+              "status": "emitted_unchanged"
+            },
+            "strict_bfo_mapping": {
+              "status": "provided_through_import"
+            },
+            "bfo_projection": {
+              "status": "provided_transitively"
+            },
+            "cco_extension": {
+              "status": "provided_transitively"
+            }
+          }
+        }
+      ],
+      "row_product_dispositions": null
+    },
+    {
+      "row_id": "urn:uuid:d88535da-ab7c-409c-b928-a9b0760b4607",
+      "location": {
+        "worksheet": "Sheet1",
+        "row": 39
+      },
+      "subject": {
+        "lexical": "sosa:Procedure",
+        "iri": "http://www.w3.org/ns/sosa/Procedure"
+      },
+      "predicate": {
+        "lexical": "rdfs:subClassOf",
+        "iri": "http://www.w3.org/2000/01/rdf-schema#subClassOf"
+      },
+      "authoritative_target_lexical": "cco:DirectiveInformationContentEntity and (cco:prescribes some bfo:Process)",
+      "canonical_row_expression": {
+        "canonicalization": "coms-row-expression-v1",
+        "mapping_type": "class_mapping",
+        "predicate_iri": "http://www.w3.org/2000/01/rdf-schema#subClassOf",
+        "subject_iri": "http://www.w3.org/ns/sosa/Procedure",
+        "target": "ObjectIntersectionOf(<https://www.commoncoreontologies.org/ont00000965> ObjectSomeValuesFrom(<https://www.commoncoreontologies.org/ont00001942> <http://purl.obolibrary.org/obo/BFO_0000015>))"
+      },
+      "source_expression_sha256": "e027eeb617a4a930a80560c624b56160074a365d62d331d067b2eafdcd974b25",
+      "mapping_type": "class_mapping",
+      "coverage_classification": "class_mapping",
+      "reasoning": "",
+      "authoritative_axioms": [
+        {
+          "axiom_id": "sha256:d0db111747f3564ec1005c04b04a804ebaf5476f273ae2675826b889dfeda719",
+          "canonical_expression": "SubClassOf(<http://www.w3.org/ns/sosa/Procedure> ObjectIntersectionOf(<https://www.commoncoreontologies.org/ont00000965> ObjectSomeValuesFrom(<https://www.commoncoreontologies.org/ont00001942> <http://purl.obolibrary.org/obo/BFO_0000015>)))",
+          "referenced_iris": [
+            "http://purl.obolibrary.org/obo/BFO_0000015",
+            "http://www.w3.org/2000/01/rdf-schema#subClassOf",
+            "http://www.w3.org/ns/sosa/Procedure",
+            "https://www.commoncoreontologies.org/ont00000965",
+            "https://www.commoncoreontologies.org/ont00001942"
+          ],
+          "target_category": "mixed_bfo_cco",
+          "product_dispositions": {
+            "integrated": {
+              "status": "emitted_unchanged"
+            },
+            "alignment_core": {
+              "status": "not_applicable",
+              "reason_code": "TARGET_SPECIFIC"
+            },
+            "strict_bfo_mapping": {
+              "status": "deferred",
+              "reason_code": "NO_APPROVED_TRANSFORMATION_RULE"
+            },
+            "bfo_projection": {
+              "status": "deferred",
+              "reason_code": "NO_APPROVED_TRANSFORMATION_RULE"
+            },
+            "cco_extension": {
+              "status": "emitted_unchanged"
+            }
+          }
+        }
+      ],
+      "row_product_dispositions": null
+    },
+    {
+      "row_id": "urn:uuid:d8b4d0f0-d8d4-4f22-ae7c-2bbdebcdd51f",
+      "location": {
+        "worksheet": "Sheet1",
+        "row": 42
+      },
+      "subject": {
+        "lexical": "ssn-system:BatteryLifetime",
+        "iri": "http://www.w3.org/ns/ssn/systems/BatteryLifetime"
+      },
+      "predicate": {
+        "lexical": "rdfs:subClassOf",
+        "iri": "http://www.w3.org/2000/01/rdf-schema#subClassOf"
+      },
+      "authoritative_target_lexical": "bfo:Function and (bfo:has_realization some (cco:StasisOfArtifactOperationality and (bfo:has_occurrent_part some cco:Power) and (cco:caused_by some (bfo:Process and (bfo:realizes some (cco:Affordance and (cco:prescribed_by some cco:ArtifactDesign)))))))",
+      "canonical_row_expression": {
+        "canonicalization": "coms-row-expression-v1",
+        "mapping_type": "class_mapping",
+        "predicate_iri": "http://www.w3.org/2000/01/rdf-schema#subClassOf",
+        "subject_iri": "http://www.w3.org/ns/ssn/systems/BatteryLifetime",
+        "target": "ObjectIntersectionOf(<http://purl.obolibrary.org/obo/BFO_0000034> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000054> ObjectIntersectionOf(<https://www.commoncoreontologies.org/ont00001213> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000117> <https://www.commoncoreontologies.org/ont00000503>) ObjectSomeValuesFrom(<https://www.commoncoreontologies.org/ont00001819> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/BFO_0000015> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000055> ObjectIntersectionOf(<https://www.commoncoreontologies.org/ont00000177> ObjectSomeValuesFrom(<https://www.commoncoreontologies.org/ont00001920> <https://www.commoncoreontologies.org/ont00000319>))))))))"
+      },
+      "source_expression_sha256": "d7f46e445d34eb318bb7b400732670f57783a8ec8931b255c21275c5240e0589",
+      "mapping_type": "class_mapping",
+      "coverage_classification": "class_mapping",
+      "reasoning": "",
+      "authoritative_axioms": [
+        {
+          "axiom_id": "sha256:dcf3f04234e744a132f942e4d0ce6fe2bb71420cf0c3de60b8163d8b6d9ffe4a",
+          "canonical_expression": "SubClassOf(<http://www.w3.org/ns/ssn/systems/BatteryLifetime> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/BFO_0000034> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000054> ObjectIntersectionOf(<https://www.commoncoreontologies.org/ont00001213> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000117> <https://www.commoncoreontologies.org/ont00000503>) ObjectSomeValuesFrom(<https://www.commoncoreontologies.org/ont00001819> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/BFO_0000015> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000055> ObjectIntersectionOf(<https://www.commoncoreontologies.org/ont00000177> ObjectSomeValuesFrom(<https://www.commoncoreontologies.org/ont00001920> <https://www.commoncoreontologies.org/ont00000319>)))))))))",
+          "referenced_iris": [
+            "http://purl.obolibrary.org/obo/BFO_0000015",
+            "http://purl.obolibrary.org/obo/BFO_0000034",
+            "http://purl.obolibrary.org/obo/BFO_0000054",
+            "http://purl.obolibrary.org/obo/BFO_0000055",
+            "http://purl.obolibrary.org/obo/BFO_0000117",
+            "http://www.w3.org/2000/01/rdf-schema#subClassOf",
+            "http://www.w3.org/ns/ssn/systems/BatteryLifetime",
+            "https://www.commoncoreontologies.org/ont00000177",
+            "https://www.commoncoreontologies.org/ont00000319",
+            "https://www.commoncoreontologies.org/ont00000503",
+            "https://www.commoncoreontologies.org/ont00001213",
+            "https://www.commoncoreontologies.org/ont00001819",
+            "https://www.commoncoreontologies.org/ont00001920"
+          ],
+          "target_category": "mixed_bfo_cco",
+          "product_dispositions": {
+            "integrated": {
+              "status": "emitted_unchanged"
+            },
+            "alignment_core": {
+              "status": "not_applicable",
+              "reason_code": "TARGET_SPECIFIC"
+            },
+            "strict_bfo_mapping": {
+              "status": "deferred",
+              "reason_code": "NO_APPROVED_TRANSFORMATION_RULE"
+            },
+            "bfo_projection": {
+              "status": "deferred",
+              "reason_code": "NO_APPROVED_TRANSFORMATION_RULE"
+            },
+            "cco_extension": {
+              "status": "emitted_unchanged"
+            }
+          }
+        }
+      ],
+      "row_product_dispositions": null
+    },
+    {
+      "row_id": "urn:uuid:d8f45381-cd95-4251-ae69-803a033a8f49",
+      "location": {
+        "worksheet": "Sheet2",
+        "row": 45
+      },
+      "subject": {
+        "lexical": "ssn-system:hasSystemProperty",
+        "iri": "http://www.w3.org/ns/ssn/systems/hasSystemProperty"
+      },
+      "predicate": {
+        "lexical": "rdfs:subPropertyOf",
+        "iri": "http://www.w3.org/2000/01/rdf-schema#subPropertyOf"
+      },
+      "authoritative_target_lexical": "bfo:specifically_depended_on_by",
+      "canonical_row_expression": {
+        "canonicalization": "coms-row-expression-v1",
+        "mapping_type": "object_property_mapping",
+        "predicate_iri": "http://www.w3.org/2000/01/rdf-schema#subPropertyOf",
+        "subject_iri": "http://www.w3.org/ns/ssn/systems/hasSystemProperty",
+        "target": "<http://purl.obolibrary.org/obo/BFO_0000194>"
+      },
+      "source_expression_sha256": "64f48f9c624c6fd33d8135e498d7eafc52a8624ac2ae90f9bfa6735bb1ff7a0c",
+      "mapping_type": "object_property_mapping",
+      "coverage_classification": "relation_mapping",
+      "reasoning": "",
+      "authoritative_axioms": [
+        {
+          "axiom_id": "sha256:9df2ac96dda81289facb4e871c73c208fa2ae4fc7f33cfd9bc293c8e50b0439c",
+          "canonical_expression": "SubObjectPropertyOf(<http://www.w3.org/ns/ssn/systems/hasSystemProperty> <http://purl.obolibrary.org/obo/BFO_0000194>)",
+          "referenced_iris": [
+            "http://purl.obolibrary.org/obo/BFO_0000194",
+            "http://www.w3.org/2000/01/rdf-schema#subPropertyOf",
+            "http://www.w3.org/ns/ssn/systems/hasSystemProperty"
+          ],
+          "target_category": "bfo_bearing",
+          "product_dispositions": {
+            "integrated": {
+              "status": "emitted_unchanged"
+            },
+            "alignment_core": {
+              "status": "not_applicable",
+              "reason_code": "TARGET_SPECIFIC"
+            },
+            "strict_bfo_mapping": {
+              "status": "emitted_unchanged"
+            },
+            "bfo_projection": {
+              "status": "provided_through_import"
+            },
+            "cco_extension": {
+              "status": "provided_through_import"
+            }
+          }
+        }
+      ],
+      "row_product_dispositions": null
+    },
+    {
+      "row_id": "urn:uuid:d973063c-f3a7-4a0b-ab0f-e0ee1fb9eeaa",
+      "location": {
+        "worksheet": "Sheet1",
+        "row": 8
+      },
+      "subject": {
+        "lexical": "sosa:Observation",
+        "iri": "http://www.w3.org/ns/sosa/Observation"
+      },
+      "predicate": {
+        "lexical": "rdfs:subClassOf",
+        "iri": "http://www.w3.org/2000/01/rdf-schema#subClassOf"
+      },
+      "authoritative_target_lexical": "cco:PlannedAct and (cco:has_process_part some (cco:ActOfMeasuring and cco:ActOfObservation))",
+      "canonical_row_expression": {
+        "canonicalization": "coms-row-expression-v1",
+        "mapping_type": "class_mapping",
+        "predicate_iri": "http://www.w3.org/2000/01/rdf-schema#subClassOf",
+        "subject_iri": "http://www.w3.org/ns/sosa/Observation",
+        "target": "ObjectIntersectionOf(<https://www.commoncoreontologies.org/ont00000228> ObjectSomeValuesFrom(<https://www.commoncoreontologies.org/ont00001777> ObjectIntersectionOf(<https://www.commoncoreontologies.org/ont00000037> <https://www.commoncoreontologies.org/ont00000345>)))"
+      },
+      "source_expression_sha256": "1513a648a3ec448a29813759c8249cc034de2b23eba821b8c0b852b9385d8e22",
+      "mapping_type": "class_mapping",
+      "coverage_classification": "class_mapping",
+      "reasoning": "",
+      "authoritative_axioms": [
+        {
+          "axiom_id": "sha256:6f6ff88affdc1afbc57c833c7eae38117a3ec8d54b7ac28931e83474e938c6c5",
+          "canonical_expression": "SubClassOf(<http://www.w3.org/ns/sosa/Observation> ObjectIntersectionOf(<https://www.commoncoreontologies.org/ont00000228> ObjectSomeValuesFrom(<https://www.commoncoreontologies.org/ont00001777> ObjectIntersectionOf(<https://www.commoncoreontologies.org/ont00000037> <https://www.commoncoreontologies.org/ont00000345>))))",
+          "referenced_iris": [
+            "http://www.w3.org/2000/01/rdf-schema#subClassOf",
+            "http://www.w3.org/ns/sosa/Observation",
+            "https://www.commoncoreontologies.org/ont00000037",
+            "https://www.commoncoreontologies.org/ont00000228",
+            "https://www.commoncoreontologies.org/ont00000345",
+            "https://www.commoncoreontologies.org/ont00001777"
+          ],
+          "target_category": "cco_bearing",
+          "product_dispositions": {
+            "integrated": {
+              "status": "emitted_unchanged"
+            },
+            "alignment_core": {
+              "status": "not_applicable",
+              "reason_code": "TARGET_SPECIFIC"
+            },
+            "strict_bfo_mapping": {
+              "status": "deferred",
+              "reason_code": "NO_APPROVED_TRANSFORMATION_RULE"
+            },
+            "bfo_projection": {
+              "status": "deferred",
+              "reason_code": "NO_APPROVED_TRANSFORMATION_RULE"
+            },
+            "cco_extension": {
+              "status": "emitted_unchanged"
+            }
+          }
+        }
+      ],
+      "row_product_dispositions": null
+    },
+    {
+      "row_id": "urn:uuid:dbdcee3f-bbdf-4a35-b92e-a14dd26e6239",
+      "location": {
+        "worksheet": "Sheet1",
+        "row": 22
+      },
+      "subject": {
+        "lexical": "ssn-system:OperatingRange",
+        "iri": "http://www.w3.org/ns/ssn/systems/OperatingRange"
+      },
+      "predicate": {
+        "lexical": "rdfs:subClassOf",
+        "iri": "http://www.w3.org/2000/01/rdf-schema#subClassOf"
+      },
+      "authoritative_target_lexical": "(bfo:SpecificallyDependentContinuant or bfo:ProcessProfile) and cco:prescribed_by some cco:ArtifactDesign",
+      "canonical_row_expression": {
+        "canonicalization": "coms-row-expression-v1",
+        "mapping_type": "class_mapping",
+        "predicate_iri": "http://www.w3.org/2000/01/rdf-schema#subClassOf",
+        "subject_iri": "http://www.w3.org/ns/ssn/systems/OperatingRange",
+        "target": "ObjectIntersectionOf(ObjectSomeValuesFrom(<https://www.commoncoreontologies.org/ont00001920> <https://www.commoncoreontologies.org/ont00000319>) ObjectUnionOf(<http://purl.obolibrary.org/obo/BFO_0000020> <http://purl.obolibrary.org/obo/BFO_0000144>))"
+      },
+      "source_expression_sha256": "d88340717fd4e5dfd5bd070a7cbc9d1a465e93a91e0284805d7cae23becd6e37",
+      "mapping_type": "class_mapping",
+      "coverage_classification": "class_mapping",
+      "reasoning": "",
+      "authoritative_axioms": [
+        {
+          "axiom_id": "sha256:a7156d6ebbd83de2547dbd7e11a2c103e9fd8cc8be71a59c57656e86df5a715f",
+          "canonical_expression": "SubClassOf(<http://www.w3.org/ns/ssn/systems/OperatingRange> ObjectIntersectionOf(ObjectSomeValuesFrom(<https://www.commoncoreontologies.org/ont00001920> <https://www.commoncoreontologies.org/ont00000319>) ObjectUnionOf(<http://purl.obolibrary.org/obo/BFO_0000020> <http://purl.obolibrary.org/obo/BFO_0000144>)))",
+          "referenced_iris": [
+            "http://purl.obolibrary.org/obo/BFO_0000020",
+            "http://purl.obolibrary.org/obo/BFO_0000144",
+            "http://www.w3.org/2000/01/rdf-schema#subClassOf",
+            "http://www.w3.org/ns/ssn/systems/OperatingRange",
+            "https://www.commoncoreontologies.org/ont00000319",
+            "https://www.commoncoreontologies.org/ont00001920"
+          ],
+          "target_category": "mixed_bfo_cco",
+          "product_dispositions": {
+            "integrated": {
+              "status": "emitted_unchanged"
+            },
+            "alignment_core": {
+              "status": "not_applicable",
+              "reason_code": "TARGET_SPECIFIC"
+            },
+            "strict_bfo_mapping": {
+              "status": "deferred",
+              "reason_code": "NO_APPROVED_TRANSFORMATION_RULE"
+            },
+            "bfo_projection": {
+              "status": "deferred",
+              "reason_code": "NO_APPROVED_TRANSFORMATION_RULE"
+            },
+            "cco_extension": {
+              "status": "emitted_unchanged"
+            }
+          }
+        }
+      ],
+      "row_product_dispositions": null
+    },
+    {
+      "row_id": "urn:uuid:e15cfee1-3c8e-4519-bce0-ec62729fd2fd",
+      "location": {
+        "worksheet": "Sheet2",
+        "row": 10
+      },
+      "subject": {
+        "lexical": "sosa:isFeatureOfInterestOf",
+        "iri": "http://www.w3.org/ns/sosa/isFeatureOfInterestOf"
+      },
+      "predicate": {
+        "lexical": "rdfs:range",
+        "iri": "http://www.w3.org/2000/01/rdf-schema#range"
+      },
+      "authoritative_target_lexical": "(sosa:Observation or sosa:Actuation or sosa:Sampling)",
+      "canonical_row_expression": {
+        "canonicalization": "coms-row-expression-v1",
+        "mapping_type": "range",
+        "predicate_iri": "http://www.w3.org/2000/01/rdf-schema#range",
+        "subject_iri": "http://www.w3.org/ns/sosa/isFeatureOfInterestOf",
+        "target": "ObjectUnionOf(<http://www.w3.org/ns/sosa/Actuation> <http://www.w3.org/ns/sosa/Observation> <http://www.w3.org/ns/sosa/Sampling>)"
+      },
+      "source_expression_sha256": "a5bc720f89ba6680e3bd74be03ecbf006f3b9a83477a0bd8d47b5ed07310ba20",
+      "mapping_type": "range",
+      "coverage_classification": "property_typing",
+      "reasoning": "",
+      "authoritative_axioms": [
+        {
+          "axiom_id": "sha256:046c9120e36b99488082b91da7f607659195e4d0af549e456e88766fe7643f9a",
+          "canonical_expression": "ObjectPropertyRange(<http://www.w3.org/ns/sosa/isFeatureOfInterestOf> ObjectUnionOf(<http://www.w3.org/ns/sosa/Actuation> <http://www.w3.org/ns/sosa/Observation> <http://www.w3.org/ns/sosa/Sampling>))",
+          "referenced_iris": [
+            "http://www.w3.org/2000/01/rdf-schema#range",
+            "http://www.w3.org/ns/sosa/Actuation",
+            "http://www.w3.org/ns/sosa/Observation",
+            "http://www.w3.org/ns/sosa/Sampling",
+            "http://www.w3.org/ns/sosa/isFeatureOfInterestOf"
+          ],
+          "target_category": "target_neutral",
+          "product_dispositions": {
+            "integrated": {
+              "status": "emitted_unchanged"
+            },
+            "alignment_core": {
+              "status": "emitted_unchanged"
+            },
+            "strict_bfo_mapping": {
+              "status": "provided_through_import"
+            },
+            "bfo_projection": {
+              "status": "provided_transitively"
+            },
+            "cco_extension": {
+              "status": "provided_transitively"
+            }
+          }
+        }
+      ],
+      "row_product_dispositions": null
+    },
+    {
+      "row_id": "urn:uuid:e2d7f509-a5ee-477a-9660-f608b518ea3f",
+      "location": {
+        "worksheet": "Sheet2",
+        "row": 35
+      },
+      "subject": {
+        "lexical": "sosa:madeObservation",
+        "iri": "http://www.w3.org/ns/sosa/madeObservation"
+      },
+      "predicate": {
+        "lexical": "rdfs:range",
+        "iri": "http://www.w3.org/2000/01/rdf-schema#range"
+      },
+      "authoritative_target_lexical": "sosa:Observation",
+      "canonical_row_expression": {
+        "canonicalization": "coms-row-expression-v1",
+        "mapping_type": "range",
+        "predicate_iri": "http://www.w3.org/2000/01/rdf-schema#range",
+        "subject_iri": "http://www.w3.org/ns/sosa/madeObservation",
+        "target": "<http://www.w3.org/ns/sosa/Observation>"
+      },
+      "source_expression_sha256": "3d997d4556ac3e64fa0a6e59241e8a8ba623b0db767a9d934b46351ee4a1296a",
+      "mapping_type": "range",
+      "coverage_classification": "property_typing",
+      "reasoning": "",
+      "authoritative_axioms": [
+        {
+          "axiom_id": "sha256:dca940a9ecdfa31a693dffaa7b880ac797fb94b80580f7dc3b292f1220960009",
+          "canonical_expression": "ObjectPropertyRange(<http://www.w3.org/ns/sosa/madeObservation> <http://www.w3.org/ns/sosa/Observation>)",
+          "referenced_iris": [
+            "http://www.w3.org/2000/01/rdf-schema#range",
+            "http://www.w3.org/ns/sosa/Observation",
+            "http://www.w3.org/ns/sosa/madeObservation"
+          ],
+          "target_category": "target_neutral",
+          "product_dispositions": {
+            "integrated": {
+              "status": "emitted_unchanged"
+            },
+            "alignment_core": {
+              "status": "emitted_unchanged"
+            },
+            "strict_bfo_mapping": {
+              "status": "provided_through_import"
+            },
+            "bfo_projection": {
+              "status": "provided_transitively"
+            },
+            "cco_extension": {
+              "status": "provided_transitively"
+            }
+          }
+        }
+      ],
+      "row_product_dispositions": null
+    },
+    {
+      "row_id": "urn:uuid:e866de80-683d-4138-a713-be9646d37148",
+      "location": {
+        "worksheet": "Sheet2",
+        "row": 19
+      },
+      "subject": {
+        "lexical": "sosa:isHostedBy",
+        "iri": "http://www.w3.org/ns/sosa/isHostedBy"
+      },
+      "predicate": {
+        "lexical": "owl:propertyChainAxiom",
+        "iri": "http://www.w3.org/2002/07/owl#propertyChainAxiom"
+      },
+      "authoritative_target_lexical": "bfo:participates_in o bfo:realizes o bfo:inheres_in",
+      "canonical_row_expression": {
+        "canonicalization": "coms-row-expression-v1",
+        "mapping_type": "property_chain",
+        "predicate_iri": "http://www.w3.org/2002/07/owl#propertyChainAxiom",
+        "subject_iri": "http://www.w3.org/ns/sosa/isHostedBy",
+        "target": "ObjectPropertyChain(<http://purl.obolibrary.org/obo/BFO_0000056> <http://purl.obolibrary.org/obo/BFO_0000055> <http://purl.obolibrary.org/obo/BFO_0000197>)"
+      },
+      "source_expression_sha256": "5029139adaefa0e642d4a632424227c407448858c17b4c5f82acd80e9a7469dc",
+      "mapping_type": "property_chain",
+      "coverage_classification": "property_chain",
+      "reasoning": "",
+      "authoritative_axioms": [
+        {
+          "axiom_id": "sha256:47859e2cfd5df437d1f55c83560793ab22f035de9b829ccdedcc4d3118cc4f3e",
+          "canonical_expression": "SubObjectPropertyOf(ObjectPropertyChain(<http://purl.obolibrary.org/obo/BFO_0000056> <http://purl.obolibrary.org/obo/BFO_0000055> <http://purl.obolibrary.org/obo/BFO_0000197>) <http://www.w3.org/ns/sosa/isHostedBy>)",
+          "referenced_iris": [
+            "http://purl.obolibrary.org/obo/BFO_0000055",
+            "http://purl.obolibrary.org/obo/BFO_0000056",
+            "http://purl.obolibrary.org/obo/BFO_0000197",
+            "http://www.w3.org/2002/07/owl#propertyChainAxiom",
+            "http://www.w3.org/ns/sosa/isHostedBy"
+          ],
+          "target_category": "bfo_bearing",
+          "product_dispositions": {
+            "integrated": {
+              "status": "emitted_unchanged"
+            },
+            "alignment_core": {
+              "status": "not_applicable",
+              "reason_code": "TARGET_SPECIFIC"
+            },
+            "strict_bfo_mapping": {
+              "status": "emitted_unchanged"
+            },
+            "bfo_projection": {
+              "status": "provided_through_import"
+            },
+            "cco_extension": {
+              "status": "provided_through_import"
+            }
+          }
+        }
+      ],
+      "row_product_dispositions": null
+    },
+    {
+      "row_id": "urn:uuid:ebf4115f-fe96-4959-89a4-98c3a6031cff",
+      "location": {
+        "worksheet": "Sheet2",
+        "row": 60
+      },
+      "subject": {
+        "lexical": "ssn:isProxyFor",
+        "iri": "http://www.w3.org/ns/ssn/isProxyFor"
+      },
+      "predicate": {
+        "lexical": "rdfs:domain",
+        "iri": "http://www.w3.org/2000/01/rdf-schema#domain"
+      },
+      "authoritative_target_lexical": "ssn:Stimulus",
+      "canonical_row_expression": {
+        "canonicalization": "coms-row-expression-v1",
+        "mapping_type": "domain",
+        "predicate_iri": "http://www.w3.org/2000/01/rdf-schema#domain",
+        "subject_iri": "http://www.w3.org/ns/ssn/isProxyFor",
+        "target": "<http://www.w3.org/ns/ssn/Stimulus>"
+      },
+      "source_expression_sha256": "9c5471a4e0cc97d3cade0a1c2a22af533fd573d9365bc7fee476b1ecf216ce75",
+      "mapping_type": "domain",
+      "coverage_classification": "property_typing",
+      "reasoning": "",
+      "authoritative_axioms": [
+        {
+          "axiom_id": "sha256:f67fc6019bda0c4d47e8eb2a71f56bc92fc3d5eb49c9e2b4a82b38615046ae91",
+          "canonical_expression": "ObjectPropertyDomain(<http://www.w3.org/ns/ssn/isProxyFor> <http://www.w3.org/ns/ssn/Stimulus>)",
+          "referenced_iris": [
+            "http://www.w3.org/2000/01/rdf-schema#domain",
+            "http://www.w3.org/ns/ssn/Stimulus",
+            "http://www.w3.org/ns/ssn/isProxyFor"
+          ],
+          "target_category": "target_neutral",
+          "product_dispositions": {
+            "integrated": {
+              "status": "emitted_unchanged"
+            },
+            "alignment_core": {
+              "status": "emitted_unchanged"
+            },
+            "strict_bfo_mapping": {
+              "status": "provided_through_import"
+            },
+            "bfo_projection": {
+              "status": "provided_transitively"
+            },
+            "cco_extension": {
+              "status": "provided_transitively"
+            }
+          }
+        }
+      ],
+      "row_product_dispositions": null
+    },
+    {
+      "row_id": "urn:uuid:ee7f2f05-bc8e-4477-bb58-0f40e6da81d0",
+      "location": {
+        "worksheet": "Sheet1",
+        "row": 37
+      },
+      "subject": {
+        "lexical": "sosa:Actuator",
+        "iri": "http://www.w3.org/ns/sosa/Actuator"
+      },
+      "predicate": {
+        "lexical": "rdfs:subClassOf",
+        "iri": "http://www.w3.org/2000/01/rdf-schema#subClassOf"
+      },
+      "authoritative_target_lexical": "bfo:MaterialEntity and (bfo:bearer_of some (bfo:RealizableEntity and (bfo:has_realization some sosa:Actuation))) and (cco:agent_in some sosa:Actuation)",
+      "canonical_row_expression": {
+        "canonicalization": "coms-row-expression-v1",
+        "mapping_type": "class_mapping",
+        "predicate_iri": "http://www.w3.org/2000/01/rdf-schema#subClassOf",
+        "subject_iri": "http://www.w3.org/ns/sosa/Actuator",
+        "target": "ObjectIntersectionOf(<http://purl.obolibrary.org/obo/BFO_0000040> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000196> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/BFO_0000017> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000054> <http://www.w3.org/ns/sosa/Actuation>))) ObjectSomeValuesFrom(<https://www.commoncoreontologies.org/ont00001787> <http://www.w3.org/ns/sosa/Actuation>))"
+      },
+      "source_expression_sha256": "2cebc1769b4adbf1594ebdbe7afc3c7ed0fd16bde2c0994b9ff6952bd9d72402",
+      "mapping_type": "class_mapping",
+      "coverage_classification": "class_mapping",
+      "reasoning": "",
+      "authoritative_axioms": [
+        {
+          "axiom_id": "sha256:21d7cb7ddce4687296139d1e503435b53404810ecba690267188a7a6082659b0",
+          "canonical_expression": "SubClassOf(<http://www.w3.org/ns/sosa/Actuator> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/BFO_0000040> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000196> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/BFO_0000017> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000054> <http://www.w3.org/ns/sosa/Actuation>))) ObjectSomeValuesFrom(<https://www.commoncoreontologies.org/ont00001787> <http://www.w3.org/ns/sosa/Actuation>)))",
+          "referenced_iris": [
+            "http://purl.obolibrary.org/obo/BFO_0000017",
+            "http://purl.obolibrary.org/obo/BFO_0000040",
+            "http://purl.obolibrary.org/obo/BFO_0000054",
+            "http://purl.obolibrary.org/obo/BFO_0000196",
+            "http://www.w3.org/2000/01/rdf-schema#subClassOf",
+            "http://www.w3.org/ns/sosa/Actuation",
+            "http://www.w3.org/ns/sosa/Actuator",
+            "https://www.commoncoreontologies.org/ont00001787"
+          ],
+          "target_category": "mixed_bfo_cco",
+          "product_dispositions": {
+            "integrated": {
+              "status": "emitted_unchanged"
+            },
+            "alignment_core": {
+              "status": "not_applicable",
+              "reason_code": "TARGET_SPECIFIC"
+            },
+            "strict_bfo_mapping": {
+              "status": "deferred",
+              "reason_code": "NO_APPROVED_TRANSFORMATION_RULE"
+            },
+            "bfo_projection": {
+              "status": "deferred",
+              "reason_code": "NO_APPROVED_TRANSFORMATION_RULE"
+            },
+            "cco_extension": {
+              "status": "emitted_unchanged"
+            }
+          }
+        }
+      ],
+      "row_product_dispositions": null
+    },
+    {
+      "row_id": "urn:uuid:f0fbd0af-655a-46c8-bda9-1c2adb24a10a",
+      "location": {
+        "worksheet": "Sheet2",
+        "row": 40
+      },
+      "subject": {
+        "lexical": "ssn-system:hasSurvivalProperty",
+        "iri": "http://www.w3.org/ns/ssn/systems/hasSurvivalProperty"
+      },
+      "predicate": {
+        "lexical": "rdfs:subPropertyOf",
+        "iri": "http://www.w3.org/2000/01/rdf-schema#subPropertyOf"
+      },
+      "authoritative_target_lexical": "bfo:specifically_depended_on_by",
+      "canonical_row_expression": {
+        "canonicalization": "coms-row-expression-v1",
+        "mapping_type": "object_property_mapping",
+        "predicate_iri": "http://www.w3.org/2000/01/rdf-schema#subPropertyOf",
+        "subject_iri": "http://www.w3.org/ns/ssn/systems/hasSurvivalProperty",
+        "target": "<http://purl.obolibrary.org/obo/BFO_0000194>"
+      },
+      "source_expression_sha256": "eb56d5239f3725bd2e8d6ae2c02cc7aa60d9237a2c93d701d514291d47744918",
+      "mapping_type": "object_property_mapping",
+      "coverage_classification": "relation_mapping",
+      "reasoning": "",
+      "authoritative_axioms": [
+        {
+          "axiom_id": "sha256:b87f9b4fe09c1df974c9c698e4501efaab8762b8a376aa207f83810b6f2ae7dd",
+          "canonical_expression": "SubObjectPropertyOf(<http://www.w3.org/ns/ssn/systems/hasSurvivalProperty> <http://purl.obolibrary.org/obo/BFO_0000194>)",
+          "referenced_iris": [
+            "http://purl.obolibrary.org/obo/BFO_0000194",
+            "http://www.w3.org/2000/01/rdf-schema#subPropertyOf",
+            "http://www.w3.org/ns/ssn/systems/hasSurvivalProperty"
+          ],
+          "target_category": "bfo_bearing",
+          "product_dispositions": {
+            "integrated": {
+              "status": "emitted_unchanged"
+            },
+            "alignment_core": {
+              "status": "not_applicable",
+              "reason_code": "TARGET_SPECIFIC"
+            },
+            "strict_bfo_mapping": {
+              "status": "emitted_unchanged"
+            },
+            "bfo_projection": {
+              "status": "provided_through_import"
+            },
+            "cco_extension": {
+              "status": "provided_through_import"
+            }
+          }
+        }
+      ],
+      "row_product_dispositions": null
+    },
+    {
+      "row_id": "urn:uuid:f293250d-b1e8-4467-8b7d-a94fb2b9b705",
+      "location": {
+        "worksheet": "Sheet2",
+        "row": 3
+      },
+      "subject": {
+        "lexical": "sampling:natureOfRelationship",
+        "iri": "http://www.w3.org/ns/sosa/sampling/natureOfRelationship"
+      },
+      "predicate": {
+        "lexical": "rdfs:subPropertyOf",
+        "iri": "http://www.w3.org/2000/01/rdf-schema#subPropertyOf"
+      },
+      "authoritative_target_lexical": "cco:is_about",
+      "canonical_row_expression": {
+        "canonicalization": "coms-row-expression-v1",
+        "mapping_type": "object_property_mapping",
+        "predicate_iri": "http://www.w3.org/2000/01/rdf-schema#subPropertyOf",
+        "subject_iri": "http://www.w3.org/ns/sosa/sampling/natureOfRelationship",
+        "target": "<https://www.commoncoreontologies.org/ont00001808>"
+      },
+      "source_expression_sha256": "d6aed3db731e2dbec987a7eff38297d409d36240f10f920663c9eb82154ee4d2",
+      "mapping_type": "object_property_mapping",
+      "coverage_classification": "relation_mapping",
+      "reasoning": "",
+      "authoritative_axioms": [
+        {
+          "axiom_id": "sha256:a5469930af6f93dca4bf66f337827b214ff9f4fb940d04f569b4142b69a68154",
+          "canonical_expression": "SubObjectPropertyOf(<http://www.w3.org/ns/sosa/sampling/natureOfRelationship> <https://www.commoncoreontologies.org/ont00001808>)",
+          "referenced_iris": [
+            "http://www.w3.org/2000/01/rdf-schema#subPropertyOf",
+            "http://www.w3.org/ns/sosa/sampling/natureOfRelationship",
+            "https://www.commoncoreontologies.org/ont00001808"
+          ],
+          "target_category": "cco_bearing",
+          "product_dispositions": {
+            "integrated": {
+              "status": "emitted_unchanged"
+            },
+            "alignment_core": {
+              "status": "not_applicable",
+              "reason_code": "TARGET_SPECIFIC"
+            },
+            "strict_bfo_mapping": {
+              "status": "deferred",
+              "reason_code": "NO_APPROVED_TRANSFORMATION_RULE"
+            },
+            "bfo_projection": {
+              "status": "deferred",
+              "reason_code": "NO_APPROVED_TRANSFORMATION_RULE"
+            },
+            "cco_extension": {
+              "status": "emitted_unchanged"
+            }
+          }
+        }
+      ],
+      "row_product_dispositions": null
+    },
+    {
+      "row_id": "urn:uuid:f475ef3c-12f0-4925-ad21-419ebd96406b",
+      "location": {
+        "worksheet": "Sheet1",
+        "row": 2
+      },
+      "subject": {
+        "lexical": "sampling:RelationshipNature",
+        "iri": "http://www.w3.org/ns/sosa/sampling/RelationshipNature"
+      },
+      "predicate": {
+        "lexical": "rdfs:subClassOf",
+        "iri": "http://www.w3.org/2000/01/rdf-schema#subClassOf"
+      },
+      "authoritative_target_lexical": "cco:InformationContentEntity",
+      "canonical_row_expression": {
+        "canonicalization": "coms-row-expression-v1",
+        "mapping_type": "class_mapping",
+        "predicate_iri": "http://www.w3.org/2000/01/rdf-schema#subClassOf",
+        "subject_iri": "http://www.w3.org/ns/sosa/sampling/RelationshipNature",
+        "target": "<https://www.commoncoreontologies.org/ont00000958>"
+      },
+      "source_expression_sha256": "b00d4da20ac7bbeccd0bc92eaeccb1207d290accaa1401a96565e0c919fe0f13",
+      "mapping_type": "class_mapping",
+      "coverage_classification": "class_mapping",
+      "reasoning": "",
+      "authoritative_axioms": [
+        {
+          "axiom_id": "sha256:3c778acf36c7687a0a2d38929a849455d40ab77d001b6aa8b8c4586e890d7997",
+          "canonical_expression": "SubClassOf(<http://www.w3.org/ns/sosa/sampling/RelationshipNature> <https://www.commoncoreontologies.org/ont00000958>)",
+          "referenced_iris": [
+            "http://www.w3.org/2000/01/rdf-schema#subClassOf",
+            "http://www.w3.org/ns/sosa/sampling/RelationshipNature",
+            "https://www.commoncoreontologies.org/ont00000958"
+          ],
+          "target_category": "cco_bearing",
+          "product_dispositions": {
+            "integrated": {
+              "status": "emitted_unchanged"
+            },
+            "alignment_core": {
+              "status": "not_applicable",
+              "reason_code": "TARGET_SPECIFIC"
+            },
+            "strict_bfo_mapping": {
+              "status": "deferred",
+              "reason_code": "NO_APPROVED_TRANSFORMATION_RULE"
+            },
+            "bfo_projection": {
+              "status": "deferred",
+              "reason_code": "NO_APPROVED_TRANSFORMATION_RULE"
+            },
+            "cco_extension": {
+              "status": "emitted_unchanged"
+            }
+          }
+        }
+      ],
+      "row_product_dispositions": null
+    },
+    {
+      "row_id": "urn:uuid:f7b8b133-2846-4627-9f8d-1ba39c13b9d1",
+      "location": {
+        "worksheet": "Sheet2",
+        "row": 36
+      },
+      "subject": {
+        "lexical": "sosa:observedProperty",
+        "iri": "http://www.w3.org/ns/sosa/observedProperty"
+      },
+      "predicate": {
+        "lexical": "rdfs:subPropertyOf",
+        "iri": "http://www.w3.org/2000/01/rdf-schema#subPropertyOf"
+      },
+      "authoritative_target_lexical": "cco:has_input",
+      "canonical_row_expression": {
+        "canonicalization": "coms-row-expression-v1",
+        "mapping_type": "object_property_mapping",
+        "predicate_iri": "http://www.w3.org/2000/01/rdf-schema#subPropertyOf",
+        "subject_iri": "http://www.w3.org/ns/sosa/observedProperty",
+        "target": "<https://www.commoncoreontologies.org/ont00001921>"
+      },
+      "source_expression_sha256": "b445637d9f4cfc26ab88b990deee554a701a683195b88bf4ccb2d481e55993da",
+      "mapping_type": "object_property_mapping",
+      "coverage_classification": "relation_mapping",
+      "reasoning": "",
+      "authoritative_axioms": [
+        {
+          "axiom_id": "sha256:3319996395ff5c961d89ef64b955bd227c90bbd762a5184a40e39ef307ea54a8",
+          "canonical_expression": "SubObjectPropertyOf(<http://www.w3.org/ns/sosa/observedProperty> <https://www.commoncoreontologies.org/ont00001921>)",
+          "referenced_iris": [
+            "http://www.w3.org/2000/01/rdf-schema#subPropertyOf",
+            "http://www.w3.org/ns/sosa/observedProperty",
+            "https://www.commoncoreontologies.org/ont00001921"
+          ],
+          "target_category": "cco_bearing",
+          "product_dispositions": {
+            "integrated": {
+              "status": "emitted_unchanged"
+            },
+            "alignment_core": {
+              "status": "not_applicable",
+              "reason_code": "TARGET_SPECIFIC"
+            },
+            "strict_bfo_mapping": {
+              "status": "deferred",
+              "reason_code": "NO_APPROVED_TRANSFORMATION_RULE"
+            },
+            "bfo_projection": {
+              "status": "deferred",
+              "reason_code": "NO_APPROVED_TRANSFORMATION_RULE"
+            },
+            "cco_extension": {
+              "status": "emitted_unchanged"
+            }
+          }
+        }
+      ],
+      "row_product_dispositions": null
+    }
+  ]
+}

--- a/tests/test_generate_mapping_from_coms.py
+++ b/tests/test_generate_mapping_from_coms.py
@@ -3,10 +3,12 @@
 
 from __future__ import annotations
 
+import json
 import sys
 import tempfile
 import unittest
 from pathlib import Path
+from types import SimpleNamespace
 from unittest import mock
 
 import openpyxl
@@ -20,6 +22,8 @@ sys.path.insert(0, str(REPO_ROOT / "tools"))
 import check_coms_mapping as checker  # noqa: E402
 import coms_row_identity as identity  # noqa: E402
 import generate_mapping_from_coms as coms  # noqa: E402
+import product_dispositions as dispositions  # noqa: E402
+from publication_metadata import load_metadata  # noqa: E402
 
 
 SUBJECT = "sosa:hasFeatureOfInterest"
@@ -98,9 +102,10 @@ class ComsDomainRangeTests(unittest.TestCase):
         for fragment in expected_fragments:
             self.assertIn(fragment, message)
 
-    def run_generator(self, workbook_path: Path) -> tuple[int, Path, Path]:
+    def run_generator(self, workbook_path: Path) -> tuple[int, Path, Path, Path]:
         output_path = self.root / "candidate-output.ttl"
         report_path = self.root / "generation-report.md"
+        disposition_path = self.root / "product-dispositions.json"
         return_code = coms.main(
             [
                 "--input",
@@ -109,6 +114,8 @@ class ComsDomainRangeTests(unittest.TestCase):
                 str(output_path),
                 "--report",
                 str(report_path),
+                "--disposition-report",
+                str(disposition_path),
                 "--coverage-report",
                 str(self.root / "coverage.md"),
                 "--diff-report",
@@ -117,7 +124,7 @@ class ComsDomainRangeTests(unittest.TestCase):
                 str(self.root / "reasoner"),
             ]
         )
-        return return_code, output_path, report_path
+        return return_code, output_path, report_path, disposition_path
 
     def assert_generator_main_failure(
         self,
@@ -125,14 +132,60 @@ class ComsDomainRangeTests(unittest.TestCase):
         *expected_fragments: str,
     ) -> None:
         before = workbook_path.read_bytes()
-        return_code, output_path, report_path = self.run_generator(workbook_path)
+        return_code, output_path, report_path, disposition_path = self.run_generator(workbook_path)
         self.assertEqual(return_code, 1)
         self.assertFalse(output_path.exists())
+        self.assertFalse(disposition_path.exists())
         self.assertTrue(report_path.is_file())
         report = report_path.read_text(encoding="utf-8")
         self.assertIn("| overall status | FAIL |", report)
         for fragment in expected_fragments:
             self.assertIn(fragment, report)
+        self.assertEqual(workbook_path.read_bytes(), before)
+
+    def test_disposition_failure_prevents_ontology_generation(self) -> None:
+        workbook_path = self.synthetic_workbook(
+            [(SUBJECT, "rdfs:domain", "sosa:Observation")]
+        )
+        failure = dispositions.ProductDispositionError(
+            [
+                dispositions.ValidationIssue(
+                    code="TARGET_CATEGORY_MISMATCH",
+                    row_id=self.row_id_for(1),
+                    message="synthetic disposition failure",
+                )
+            ]
+        )
+        before = workbook_path.read_bytes()
+        with mock.patch.object(coms, "build_disposition_document", side_effect=failure):
+            return_code, output_path, report_path, disposition_path = self.run_generator(
+                workbook_path
+            )
+        self.assertEqual(return_code, 1)
+        self.assertFalse(output_path.exists())
+        self.assertFalse(disposition_path.exists())
+        report = report_path.read_text(encoding="utf-8")
+        self.assertIn("TARGET_CATEGORY_MISMATCH", report)
+        self.assertIn("| overall status | FAIL |", report)
+        self.assertEqual(workbook_path.read_bytes(), before)
+
+    def test_disposition_generation_succeeds_without_mutating_workbook(self) -> None:
+        workbook_path = self.synthetic_workbook(
+            [(SUBJECT, "rdfs:domain", "sosa:Observation")]
+        )
+        before = workbook_path.read_bytes()
+        workbook_rows, stats = coms.read_workbook(workbook_path)
+        processed = coms.validate_and_process_rows(workbook_rows, coms.Resolver(), stats)
+        path = self.root / "dispositions.json"
+        document, row_inputs = coms.build_and_write_disposition_report(
+            processed,
+            path,
+            dispositions.RequiredInputHashes(*["0" * 64] * 5),
+        )
+        self.assertEqual(document.summary.governed_row_count, 1)
+        self.assertEqual(document.summary.authoritative_axiom_count, 1)
+        self.assertEqual(document.summary.target_neutral_axiom_count, 1)
+        self.assertEqual(len(row_inputs), 1)
         self.assertEqual(workbook_path.read_bytes(), before)
 
     def governed_row(
@@ -645,6 +698,7 @@ class ComsGenerationReportTests(unittest.TestCase):
         *,
         stats: coms.WorkbookStats | None = None,
         identity_audits: list[identity.CanonicalRowAudit] | None = None,
+        disposition_document: dispositions.DispositionDocument | None = None,
     ) -> str:
         path = self.root / f"{name}.md"
         coms.write_generation_report(
@@ -665,6 +719,11 @@ class ComsGenerationReportTests(unittest.TestCase):
             identity_module_sha256="identity-module-hash",
             generation_timestamp="2026-01-01T00:00:00+00:00",
             candidate_sha256="candidate-hash",
+            disposition_document=disposition_document,
+            disposition_path=Path("reports/coms-product-dispositions.json"),
+            disposition_sha256="disposition-hash",
+            disposition_module_sha256="disposition-module-hash",
+            publication_metadata_sha256="publication-metadata-hash",
         )
         return path.read_text(encoding="utf-8")
 
@@ -715,6 +774,27 @@ class ComsGenerationReportTests(unittest.TestCase):
             "/opt/robot",
             stats=stats,
             identity_audits=[audit],
+            disposition_document=dispositions.build_disposition_document(
+                [
+                    dispositions.DispositionRowInput(
+                        row_id=row.row_id,
+                        location=row.location,
+                        subject_lexical=SUBJECT,
+                        predicate_lexical="rdfs:domain",
+                        authoritative_target_lexical="sosa:Observation",
+                        canonical_row=audit.expression,
+                        source_expression_sha256=audit.source_expression_sha256,
+                        mapping_type="domain",
+                        reasoning="",
+                        authoritative_axioms=tuple(
+                            dispositions.axiom_input_from_canonical_row(axiom, row)
+                            for axiom in audit.authoritative_axioms
+                        ),
+                    )
+                ],
+                load_metadata(REPO_ROOT / "config/publication-metadata.toml"),
+                dispositions.RequiredInputHashes(*["0" * 64] * 5),
+            ),
         )
 
         self.assertIn("Governed RowID header: `coms:RowID`", report)
@@ -732,6 +812,9 @@ class ComsGenerationReportTests(unittest.TestCase):
         self.assertIn(audit.source_expression_sha256, report)
         self.assertIn(audit.authoritative_axioms[0].canonical_axiom, report)
         self.assertIn("_(blank)_", report)
+        self.assertIn("## Product Dispositions", report)
+        self.assertIn("Target-neutral axioms: 1", report)
+        self.assertIn("Disposition reconciliation and canonical serialization: PASS", report)
 
 
 class ComsAuthorityMigrationTests(unittest.TestCase):
@@ -746,6 +829,7 @@ class ComsAuthorityMigrationTests(unittest.TestCase):
             "generation_report": self.root / "reports/coms-generation-validation.md",
             "coverage_report": self.root / "reports/coms-source-term-coverage.md",
             "diff_report": self.root / "reports/coms-vs-pre-coms-legacy-diff.md",
+            "disposition_report": self.root / "reports/coms-product-dispositions.json",
         }
 
     @staticmethod
@@ -758,6 +842,10 @@ class ComsAuthorityMigrationTests(unittest.TestCase):
         self.assertEqual(
             checker.MAINTAINED_OUTPUTS["diff_report"],
             REPO_ROOT / "reports/coms-vs-pre-coms-legacy-diff.md",
+        )
+        self.assertEqual(
+            checker.MAINTAINED_OUTPUTS["disposition_report"],
+            REPO_ROOT / "reports/coms-product-dispositions.json",
         )
 
     def test_legacy_ontology_is_the_comparison_baseline(self) -> None:
@@ -786,22 +874,48 @@ class ComsAuthorityMigrationTests(unittest.TestCase):
         for name, path in outputs.items():
             self.write(path, f"maintained-{name}\n")
         candidate_hash = checker.sha256_file(outputs["candidate"])
+        disposition_hash = checker.sha256_file(outputs["disposition_report"])
+        disposition_module_hash = checker.sha256_file(checker.DISPOSITION_MODULE)
+        publication_metadata_hash = checker.sha256_file(checker.PUBLICATION_METADATA)
         self.write(
             outputs["generation_report"],
             "\n".join(
                 [
                     "| workbook SHA-256 | `workbook-hash` |",
                     "| generator SHA-256 | `generator-hash` |",
+                    f"| product-disposition module SHA-256 | `{disposition_module_hash}` |",
+                    f"| publication metadata SHA-256 | `{publication_metadata_hash}` |",
                     "| generation timestamp (UTC) | `2026-01-01T00:00:00+00:00` |",
                     "| maintained ontology path | `SSN2BFO.ttl` |",
                     f"| generated ontology SHA-256 | `{candidate_hash}` |",
+                    "| maintained product-disposition path | `reports/coms-product-dispositions.json` |",
+                    f"| product-disposition JSON SHA-256 | `{disposition_hash}` |",
                 ]
+            ),
+        )
+
+        fake_disposition = SimpleNamespace(
+            input_hashes=SimpleNamespace(
+                workbook_sha256="workbook-hash",
+                generator_sha256="generator-hash",
+                row_identity_module_sha256=checker.sha256_file(checker.ROW_IDENTITY_MODULE),
+                disposition_module_sha256=disposition_module_hash,
+                publication_metadata_sha256=publication_metadata_hash,
+            ),
+            product_order=tuple(
+                product.key for product in load_metadata(checker.PUBLICATION_METADATA).products
             ),
         )
 
         with (
             mock.patch.object(checker, "REPO_ROOT", self.root),
             mock.patch.object(checker, "MAINTAINED_OUTPUTS", outputs),
+            mock.patch.object(checker, "load_disposition_document", return_value=fake_disposition),
+            mock.patch.object(
+                checker,
+                "serialize_disposition_document",
+                return_value=outputs["disposition_report"].read_bytes(),
+            ),
         ):
             self.assertEqual(checker.freshness_errors("workbook-hash", "generator-hash"), [])
             self.write(outputs["candidate"], "changed root ontology\n")
@@ -844,6 +958,169 @@ class ComsAuthorityMigrationTests(unittest.TestCase):
             self.assertEqual(checker.main([]), 0)
 
         self.assertEqual(outputs["candidate"].read_text(encoding="utf-8"), "new-candidate\n")
+
+    def test_check_only_preserves_all_five_outputs_and_workbook(self) -> None:
+        outputs = self.maintained_outputs()
+        workbook = self.root / "mappings/SSN2BFO-COMS.xlsx"
+        self.write(workbook, "workbook-bytes\n")
+        for name, path in outputs.items():
+            self.write(path, f"maintained-{name}\n")
+        protected = [workbook, *outputs.values()]
+        before = {
+            path: (path.read_bytes(), path.stat().st_mtime_ns)
+            for path in protected
+        }
+        files_before = {
+            path.relative_to(self.root)
+            for path in self.root.rglob("*")
+            if path.is_file()
+        }
+        cache_dir = self.root / ".cache/coms"
+
+        def fake_run_generator(paths: dict[str, Path], _log: list[str]) -> None:
+            for name in outputs:
+                self.write(paths[name], f"temporary-{name}\n")
+            self.write(paths["summary"], "{}\n")
+
+        with (
+            mock.patch.object(checker, "REPO_ROOT", self.root),
+            mock.patch.object(checker, "WORKBOOK", workbook),
+            mock.patch.object(checker, "CACHE_DIR", cache_dir),
+            mock.patch.object(checker, "LAST_SUCCESS", cache_dir / "last-success.json"),
+            mock.patch.object(checker, "LAST_FAILURE", cache_dir / "last-failure.log"),
+            mock.patch.object(checker, "MAINTAINED_OUTPUTS", outputs),
+            mock.patch.object(checker, "verify_workbook", return_value="workbook-hash"),
+            mock.patch.object(checker, "compile_generator", return_value="generator-hash"),
+            mock.patch.object(checker, "freshness_errors", return_value=[]),
+            mock.patch.object(checker, "run_generator", side_effect=fake_run_generator),
+            mock.patch.object(checker, "validate_temporary_outputs", return_value={}),
+            mock.patch.object(checker, "git_diff_check"),
+            mock.patch.object(checker, "output_differences", return_value=[]),
+            mock.patch.object(checker, "record_success"),
+            mock.patch.object(checker, "write_failure_log"),
+        ):
+            self.assertEqual(checker.main(["--check-only"]), 0)
+
+        for path, expected in before.items():
+            self.assertEqual((path.read_bytes(), path.stat().st_mtime_ns), expected)
+        files_after = {
+            path.relative_to(self.root)
+            for path in self.root.rglob("*")
+            if path.is_file()
+        }
+        self.assertEqual(files_after, files_before)
+
+    def test_rollback_removes_new_disposition_when_it_was_initially_absent(self) -> None:
+        outputs = self.maintained_outputs()
+        existing = {
+            name: path
+            for name, path in outputs.items()
+            if name != "disposition_report"
+        }
+        for name, path in existing.items():
+            self.write(path, f"old-{name}\n")
+        before = {
+            path: (path.read_bytes(), path.stat().st_mtime_ns)
+            for path in existing.values()
+        }
+        cache_dir = self.root / ".cache/coms"
+        transaction_dirs: list[Path] = []
+
+        def fake_run_generator(paths: dict[str, Path], _log: list[str]) -> None:
+            transaction_dirs.append(paths["candidate"].parents[1])
+            for name in outputs:
+                self.write(paths[name], f"new-{name}\n")
+            self.write(paths["summary"], "{}\n")
+
+        diff_checks = 0
+
+        def fail_post_update(_log: list[str], _label: str) -> None:
+            nonlocal diff_checks
+            diff_checks += 1
+            if diff_checks == 2:
+                raise checker.CheckFailure("post-update failure")
+
+        with (
+            mock.patch.object(checker, "REPO_ROOT", self.root),
+            mock.patch.object(checker, "CACHE_DIR", cache_dir),
+            mock.patch.object(checker, "LAST_SUCCESS", cache_dir / "last-success.json"),
+            mock.patch.object(checker, "LAST_FAILURE", cache_dir / "last-failure.log"),
+            mock.patch.object(checker, "MAINTAINED_OUTPUTS", outputs),
+            mock.patch.object(checker, "verify_workbook", return_value="workbook-hash"),
+            mock.patch.object(checker, "compile_generator", return_value="generator-hash"),
+            mock.patch.object(checker, "freshness_errors", return_value=["stale"]),
+            mock.patch.object(checker, "run_generator", side_effect=fake_run_generator),
+            mock.patch.object(checker, "validate_temporary_outputs", return_value={}),
+            mock.patch.object(checker, "git_diff_check", side_effect=fail_post_update),
+            mock.patch.object(checker, "output_differences", return_value=list(outputs)),
+            mock.patch.object(checker, "record_success"),
+            mock.patch.object(checker, "write_failure_log"),
+        ):
+            self.assertEqual(checker.main([]), 1)
+
+        self.assertEqual(diff_checks, 2)
+        for path, expected in before.items():
+            self.assertEqual((path.read_bytes(), path.stat().st_mtime_ns), expected)
+        self.assertFalse(outputs["disposition_report"].exists())
+        self.assertEqual(len(transaction_dirs), 1)
+        self.assertFalse(transaction_dirs[0].exists())
+
+    def test_written_malformed_disposition_fails_before_replacement(self) -> None:
+        outputs = self.maintained_outputs()
+        for name, path in outputs.items():
+            self.write(path, f"old-{name}\n")
+        before = {path: path.read_bytes() for path in outputs.values()}
+        cache_dir = self.root / ".cache/coms"
+        transaction_dirs: list[Path] = []
+        observed_candidates: list[bytes] = []
+
+        def fake_run_generator(paths: dict[str, Path], _log: list[str]) -> None:
+            transaction_dirs.append(paths["candidate"].parents[1])
+            for name in outputs:
+                self.write(paths[name], f"temporary-{name}\n")
+            self.write(
+                paths["disposition_report"],
+                json.dumps({"schema_version": 1}, indent=2) + "\n",
+            )
+            self.write(
+                paths["summary"],
+                json.dumps(
+                    {
+                        "status": "PASS",
+                        "workbook_sha256": "workbook-hash",
+                        "generator_sha256": "generator-hash",
+                    }
+                )
+                + "\n",
+            )
+
+        production_loader = checker.load_disposition_document
+
+        def observe_load(path: Path):
+            observed_candidates.append(path.read_bytes())
+            return production_loader(path)
+
+        with (
+            mock.patch.object(checker, "REPO_ROOT", self.root),
+            mock.patch.object(checker, "CACHE_DIR", cache_dir),
+            mock.patch.object(checker, "LAST_SUCCESS", cache_dir / "last-success.json"),
+            mock.patch.object(checker, "LAST_FAILURE", cache_dir / "last-failure.log"),
+            mock.patch.object(checker, "MAINTAINED_OUTPUTS", outputs),
+            mock.patch.object(checker, "verify_workbook", return_value="workbook-hash"),
+            mock.patch.object(checker, "compile_generator", return_value="generator-hash"),
+            mock.patch.object(checker, "freshness_errors", return_value=["stale"]),
+            mock.patch.object(checker, "run_generator", side_effect=fake_run_generator),
+            mock.patch.object(checker, "load_disposition_document", side_effect=observe_load),
+            mock.patch.object(checker, "write_failure_log"),
+        ):
+            self.assertEqual(checker.main([]), 1)
+
+        self.assertEqual(len(observed_candidates), 1)
+        self.assertIn(b'"schema_version": 1', observed_candidates[0])
+        for path, expected in before.items():
+            self.assertEqual(path.read_bytes(), expected)
+        self.assertEqual(len(transaction_dirs), 1)
+        self.assertFalse(transaction_dirs[0].exists())
 
     def test_atomic_replacement_rolls_back_root_on_post_update_failure(self) -> None:
         outputs = self.maintained_outputs()

--- a/tests/test_product_dispositions.py
+++ b/tests/test_product_dispositions.py
@@ -1,0 +1,683 @@
+#!/usr/bin/env python3
+"""Focused tests for generated COMS per-product disposition evidence."""
+
+from __future__ import annotations
+
+import json
+import sys
+import tempfile
+import unittest
+from dataclasses import replace
+from pathlib import Path
+from unittest import mock
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT / "tools"))
+
+import coms_row_identity as identity  # noqa: E402
+import generate_mapping_from_coms as generator  # noqa: E402
+import product_dispositions as dispositions  # noqa: E402
+from publication_metadata import load_metadata  # noqa: E402
+
+
+ROW_A = "urn:uuid:11111111-1111-4111-8111-111111111111"
+ROW_B = "urn:uuid:22222222-2222-4222-8222-222222222222"
+SOSA_OBSERVATION = "http://www.w3.org/ns/sosa/Observation"
+SOSA_FEATURE = "http://www.w3.org/ns/sosa/FeatureOfInterest"
+SOSA_HAS_FEATURE = "http://www.w3.org/ns/sosa/hasFeatureOfInterest"
+BFO_ENTITY = "http://purl.obolibrary.org/obo/BFO_0000001"
+CCO_ENTITY = "https://www.commoncoreontologies.org/ont00000958"
+RDFS_SUBCLASS = "http://www.w3.org/2000/01/rdf-schema#subClassOf"
+RDFS_SUBPROPERTY = "http://www.w3.org/2000/01/rdf-schema#subPropertyOf"
+RDFS_DOMAIN = "http://www.w3.org/2000/01/rdf-schema#domain"
+OWL_CHAIN = "http://www.w3.org/2002/07/owl#propertyChainAxiom"
+
+
+def hashes(seed: str = "0") -> dispositions.RequiredInputHashes:
+    return dispositions.RequiredInputHashes(*[(seed * 64)[:64]] * 5)
+
+
+def named(iri: str) -> identity.ExpressionNode:
+    return identity.ExpressionNode(kind="named", iri=iri)
+
+
+def row_input(
+    target: identity.ExpressionNode = identity.ExpressionNode(kind="named", iri=SOSA_FEATURE),
+    *,
+    row_id: str = ROW_A,
+    location: identity.RowLocation = identity.RowLocation("Synthetic", 2),
+    reasoning: str = "",
+    subject: str = SOSA_OBSERVATION,
+    predicate: str = RDFS_SUBCLASS,
+    predicate_lexical: str = "rdfs:subClassOf",
+    mapping_type: str = "class_mapping",
+    target_lexical: str = "sosa:FeatureOfInterest",
+) -> dispositions.DispositionRowInput:
+    canonical = identity.CanonicalRowInput(
+        row_id=row_id,
+        location=location,
+        subject_iri=subject,
+        predicate_iri=predicate,
+        mapping_type=mapping_type,
+        reasoning=reasoning,
+        expression=target,
+    )
+    audit = identity.build_row_audit(canonical)
+    return dispositions.DispositionRowInput(
+        row_id=row_id,
+        location=location,
+        subject_lexical="sosa:Observation",
+        predicate_lexical=predicate_lexical,
+        authoritative_target_lexical=target_lexical,
+        canonical_row=audit.expression,
+        source_expression_sha256=audit.source_expression_sha256,
+        mapping_type=mapping_type,
+        reasoning=reasoning,
+        authoritative_axioms=tuple(
+            dispositions.axiom_input_from_canonical_row(axiom, canonical)
+            for axiom in audit.authoritative_axioms
+        ),
+    )
+
+
+def zero_row() -> dispositions.DispositionRowInput:
+    canonical = identity.CanonicalRowInput(
+        row_id=ROW_A,
+        location=identity.RowLocation("Synthetic", 2),
+        subject_iri=SOSA_OBSERVATION,
+        predicate_iri=None,
+        mapping_type="explicit_blank",
+    )
+    audit = identity.build_row_audit(canonical)
+    return dispositions.DispositionRowInput(
+        row_id=ROW_A,
+        location=canonical.location,
+        subject_lexical="sosa:Observation",
+        predicate_lexical=None,
+        authoritative_target_lexical=None,
+        canonical_row=audit.expression,
+        source_expression_sha256=audit.source_expression_sha256,
+        mapping_type="explicit_blank",
+        reasoning="",
+        authoritative_axioms=(),
+    )
+
+
+def object_property_row_input() -> dispositions.DispositionRowInput:
+    canonical = identity.CanonicalRowInput(
+        row_id=ROW_A,
+        location=identity.RowLocation("Synthetic", 2),
+        subject_iri=SOSA_HAS_FEATURE,
+        predicate_iri=RDFS_SUBPROPERTY,
+        mapping_type="object_property_mapping",
+        target_property_iri="http://purl.obolibrary.org/obo/BFO_0000056",
+    )
+    audit = identity.build_row_audit(canonical)
+    return dispositions.DispositionRowInput(
+        row_id=ROW_A,
+        location=canonical.location,
+        subject_lexical="sosa:hasFeatureOfInterest",
+        predicate_lexical="rdfs:subPropertyOf",
+        authoritative_target_lexical="bfo:participates_in",
+        canonical_row=audit.expression,
+        source_expression_sha256=audit.source_expression_sha256,
+        mapping_type="object_property_mapping",
+        reasoning="",
+        authoritative_axioms=tuple(
+            dispositions.axiom_input_from_canonical_row(axiom, canonical)
+            for axiom in audit.authoritative_axioms
+        ),
+    )
+
+
+def domain_row_input() -> dispositions.DispositionRowInput:
+    return replace(
+        row_input(
+            subject=SOSA_HAS_FEATURE,
+            predicate=RDFS_DOMAIN,
+            predicate_lexical="rdfs:domain",
+            mapping_type="domain",
+        ),
+        subject_lexical="sosa:hasFeatureOfInterest",
+    )
+
+
+def multi_axiom_row_input() -> dispositions.DispositionRowInput:
+    source = row_input()
+    expression = (
+        "SubClassOf(<http://www.w3.org/ns/sosa/Observation> "
+        "<http://www.w3.org/ns/sosa/Actuation>)"
+    )
+    second = dispositions.DispositionAxiomInput(
+        identity.AuthoritativeAxiomIdentity(
+            canonical_axiom=expression,
+            sha256=dispositions.sha256_text(expression),
+        ),
+        SOSA_OBSERVATION,
+        RDFS_SUBCLASS,
+        ("http://www.w3.org/ns/sosa/Actuation",),
+    )
+    return replace(
+        source,
+        authoritative_axioms=(*source.authoritative_axioms, second),
+    )
+
+
+class ProductDispositionTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.metadata = load_metadata(REPO_ROOT / "config/publication-metadata.toml")
+        cls.product_order = tuple(product.key for product in cls.metadata.products)
+
+    def build(self, *rows: dispositions.DispositionRowInput) -> dispositions.DispositionDocument:
+        return dispositions.build_disposition_document(rows, self.metadata, hashes())
+
+    def assert_codes(self, issues, *codes: str) -> None:
+        actual = {value.code for value in issues}
+        for code in codes:
+            self.assertIn(code, actual)
+
+    def assert_noncanonical_file(
+        self,
+        document: dispositions.DispositionDocument,
+        row_inputs: list[dispositions.DispositionRowInput],
+        mutate,
+    ) -> None:
+        raw = dispositions.disposition_document_object(document)
+        mutate(raw)
+        with tempfile.TemporaryDirectory(prefix="disposition-order-") as temp:
+            path = Path(temp) / "dispositions.json"
+            path.write_text(
+                json.dumps(raw, ensure_ascii=False, indent=2) + "\n",
+                encoding="utf-8",
+            )
+            loaded, issues = dispositions.validate_disposition_file(
+                path,
+                row_inputs,
+                self.metadata,
+                hashes(),
+            )
+            self.assert_codes(issues, "NONCANONICAL_SERIALIZATION")
+            self.assertEqual(
+                dispositions.validate_disposition_document(
+                    loaded,
+                    row_inputs,
+                    self.metadata,
+                    hashes(),
+                ),
+                (),
+            )
+            self.assertEqual(
+                dispositions.serialize_disposition_document(loaded),
+                dispositions.serialize_disposition_document(document),
+            )
+
+    def current_document(self) -> dispositions.DispositionDocument:
+        rows, stats = generator.read_workbook(REPO_ROOT / "mappings/SSN2BFO-COMS.xlsx")
+        processed = generator.validate_and_process_rows(rows, generator.Resolver(), stats)
+        inputs = [generator.disposition_input_for_processed_row(row) for row in processed]
+        return dispositions.build_disposition_document(inputs, self.metadata, hashes())
+
+    def test_current_workbook_totals_and_product_order(self) -> None:
+        document = self.current_document()
+        summary = document.summary
+        self.assertEqual(document.product_order, self.product_order)
+        self.assertEqual(summary.governed_row_count, 105)
+        self.assertEqual(summary.unique_row_id_count, 105)
+        self.assertEqual(summary.authoritative_axiom_count, 105)
+        self.assertEqual(summary.unique_authoritative_axiom_count, 105)
+        self.assertEqual(summary.zero_axiom_row_count, 0)
+        self.assertEqual(
+            (
+                summary.target_neutral_axiom_count,
+                summary.bfo_bearing_axiom_count,
+                summary.cco_bearing_axiom_count,
+                summary.mixed_bfo_cco_axiom_count,
+            ),
+            (29, 19, 25, 32),
+        )
+        self.assertEqual(
+            (
+                summary.class_mapping_row_count,
+                summary.relation_mapping_row_count,
+                summary.property_chain_row_count,
+                summary.property_typing_row_count,
+            ),
+            (44, 25, 5, 31),
+        )
+        self.assertTrue(all(len(row.authoritative_axioms) == 1 for row in document.rows))
+
+    def test_exact_disposition_matrix(self) -> None:
+        expected = {
+            "target_neutral": (
+                ("integrated", "emitted_unchanged", None),
+                ("alignment_core", "emitted_unchanged", None),
+                ("strict_bfo_mapping", "provided_through_import", None),
+                ("bfo_projection", "provided_transitively", None),
+                ("cco_extension", "provided_transitively", None),
+            ),
+            "bfo_bearing": (
+                ("integrated", "emitted_unchanged", None),
+                ("alignment_core", "not_applicable", "TARGET_SPECIFIC"),
+                ("strict_bfo_mapping", "emitted_unchanged", None),
+                ("bfo_projection", "provided_through_import", None),
+                ("cco_extension", "provided_through_import", None),
+            ),
+            "cco_bearing": (
+                ("integrated", "emitted_unchanged", None),
+                ("alignment_core", "not_applicable", "TARGET_SPECIFIC"),
+                ("strict_bfo_mapping", "deferred", "NO_APPROVED_TRANSFORMATION_RULE"),
+                ("bfo_projection", "deferred", "NO_APPROVED_TRANSFORMATION_RULE"),
+                ("cco_extension", "emitted_unchanged", None),
+            ),
+            "mixed_bfo_cco": (
+                ("integrated", "emitted_unchanged", None),
+                ("alignment_core", "not_applicable", "TARGET_SPECIFIC"),
+                ("strict_bfo_mapping", "deferred", "NO_APPROVED_TRANSFORMATION_RULE"),
+                ("bfo_projection", "deferred", "NO_APPROVED_TRANSFORMATION_RULE"),
+                ("cco_extension", "emitted_unchanged", None),
+            ),
+        }
+        for category, required in expected.items():
+            with self.subTest(category=category):
+                values = dispositions.derive_product_dispositions(category, self.product_order)
+                self.assertEqual(
+                    tuple((key, value.status, value.reason_code) for key, value in values),
+                    required,
+                )
+
+    def test_target_categories_and_nested_traversal(self) -> None:
+        expressions = {
+            "target_neutral": identity.ExpressionNode(
+                kind="union", children=(named(SOSA_OBSERVATION), named(SOSA_FEATURE))
+            ),
+            "bfo_bearing": named(BFO_ENTITY),
+            "cco_bearing": named(CCO_ENTITY),
+            "mixed_bfo_cco": identity.ExpressionNode(
+                kind="intersection",
+                children=(
+                    named(BFO_ENTITY),
+                    identity.ExpressionNode(
+                        kind="some",
+                        property_iri="https://www.commoncoreontologies.org/ont00001808",
+                        filler=named(SOSA_FEATURE),
+                    ),
+                ),
+            ),
+        }
+        for expected, expression in expressions.items():
+            with self.subTest(expected=expected):
+                axiom = row_input(expression).authoritative_axioms[0]
+                self.assertEqual(dispositions.classify_target_category(axiom), expected)
+                references = dispositions.referenced_iris(axiom)
+                self.assertEqual(references, tuple(sorted(set(references))))
+
+    def test_property_chain_member_traversal_and_coverage(self) -> None:
+        canonical = identity.CanonicalRowInput(
+            row_id=ROW_A,
+            location=identity.RowLocation("Synthetic", 2),
+            subject_iri=SOSA_HAS_FEATURE,
+            predicate_iri=OWL_CHAIN,
+            mapping_type="property_chain",
+            property_chain=(
+                "http://www.w3.org/ns/sosa/madeBySensor",
+                "https://www.commoncoreontologies.org/ont00001808",
+            ),
+        )
+        audit = identity.build_row_audit(canonical)
+        axiom = dispositions.axiom_input_from_canonical_row(audit.authoritative_axioms[0], canonical)
+        self.assertEqual(dispositions.classify_target_category(axiom), "cco_bearing")
+        self.assertIn("https://www.commoncoreontologies.org/ont00001808", dispositions.referenced_iris(axiom))
+        self.assertEqual(dispositions.coverage_classification("property_chain"), "property_chain")
+
+    def test_coverage_classification(self) -> None:
+        expected = {
+            "class_mapping": "class_mapping",
+            "object_property_mapping": "relation_mapping",
+            "property_chain": "property_chain",
+            "domain": "property_typing",
+            "range": "property_typing",
+            "explicit_blank": "explicitly_unmapped",
+        }
+        for mapping_type, coverage in expected.items():
+            with self.subTest(mapping_type=mapping_type):
+                self.assertEqual(dispositions.coverage_classification(mapping_type), coverage)
+
+    def test_domain_and_range_are_property_typing(self) -> None:
+        for mapping_type, predicate, lexical in (
+            ("domain", RDFS_DOMAIN, "rdfs:domain"),
+            ("range", "http://www.w3.org/2000/01/rdf-schema#range", "rdfs:range"),
+        ):
+            with self.subTest(mapping_type=mapping_type):
+                document = self.build(
+                    row_input(
+                        subject=SOSA_HAS_FEATURE,
+                        predicate=predicate,
+                        predicate_lexical=lexical,
+                        mapping_type=mapping_type,
+                    )
+                )
+                self.assertEqual(document.rows[0].coverage_classification, "property_typing")
+
+    def test_unexpected_subject_predicate_and_target_fail(self) -> None:
+        cases = (
+            replace(row_input(), canonical_row=replace(row_input().canonical_row, subject_iri="https://example.org/Subject")),
+            replace(
+                row_input(),
+                authoritative_axioms=(
+                    replace(row_input().authoritative_axioms[0], predicate_iri="https://example.org/predicate"),
+                ),
+            ),
+            row_input(named("https://example.org/ThirdParty")),
+        )
+        for value in cases:
+            with self.subTest(value=value):
+                with self.assertRaises(dispositions.ProductDispositionError) as caught:
+                    self.build(value)
+                self.assert_codes(caught.exception.issues, "UNEXPECTED_TARGET_VOCABULARY")
+
+    def test_zero_one_and_multiple_axiom_schema_support(self) -> None:
+        zero = self.build(zero_row()).rows[0]
+        self.assertEqual(zero.authoritative_axioms, ())
+        self.assertIsNotNone(zero.row_product_dispositions)
+        self.assertTrue(
+            all(
+                value == dispositions.ProductDisposition(
+                    "deferred", "EXPLICITLY_UNMAPPED_SOURCE_ROW"
+                )
+                for _, value in zero.row_product_dispositions or ()
+            )
+        )
+        one_input = row_input()
+        one = self.build(one_input).rows[0]
+        second_identity = identity.AuthoritativeAxiomIdentity(
+            canonical_axiom="SubClassOf(<http://www.w3.org/ns/sosa/Observation> <http://www.w3.org/ns/sosa/Actuation>)",
+            sha256=dispositions.sha256_text(
+                "SubClassOf(<http://www.w3.org/ns/sosa/Observation> <http://www.w3.org/ns/sosa/Actuation>)"
+            ),
+        )
+        second = dispositions.DispositionAxiomInput(
+            second_identity,
+            SOSA_OBSERVATION,
+            RDFS_SUBCLASS,
+            ("http://www.w3.org/ns/sosa/Actuation",),
+        )
+        multiple = self.build(
+            replace(one_input, authoritative_axioms=(*one_input.authoritative_axioms, second))
+        ).rows[0]
+        self.assertEqual(len(one.authoritative_axioms), 1)
+        self.assertEqual(len(multiple.authoritative_axioms), 2)
+
+    def test_incomplete_zero_axiom_row_rejected(self) -> None:
+        with self.assertRaises(dispositions.ProductDispositionError) as caught:
+            self.build(replace(zero_row(), predicate_lexical="rdfs:subClassOf"))
+        self.assert_codes(caught.exception.issues, "INCOMPLETE_ZERO_AXIOM_ROW")
+
+    def test_reasoning_changes_bytes_not_expression_hash(self) -> None:
+        first = self.build(row_input(reasoning="first"))
+        second = self.build(row_input(reasoning="second"))
+        self.assertEqual(
+            first.rows[0].source_expression_sha256,
+            second.rows[0].source_expression_sha256,
+        )
+        self.assertNotEqual(
+            dispositions.serialize_disposition_document(first),
+            dispositions.serialize_disposition_document(second),
+        )
+
+    def test_serialization_is_deterministic_and_input_order_independent(self) -> None:
+        first = row_input(row_id=ROW_A, location=identity.RowLocation("Synthetic", 2))
+        second = row_input(
+            named("http://www.w3.org/ns/sosa/Actuation"),
+            row_id=ROW_B,
+            location=identity.RowLocation("Synthetic", 3),
+            target_lexical="sosa:Actuation",
+        )
+        forward = self.build(first, second)
+        reverse = self.build(second, first)
+        self.assertEqual(
+            dispositions.serialize_disposition_document(forward),
+            dispositions.serialize_disposition_document(reverse),
+        )
+        self.assertEqual(tuple(row.row_id for row in forward.rows), (ROW_A, ROW_B))
+
+    def test_file_validation_rejects_noncanonical_collection_order(self) -> None:
+        first = row_input(row_id=ROW_A, location=identity.RowLocation("Synthetic", 2))
+        second = row_input(
+            named("http://www.w3.org/ns/sosa/Actuation"),
+            row_id=ROW_B,
+            location=identity.RowLocation("Synthetic", 3),
+            target_lexical="sosa:Actuation",
+        )
+
+        def reverse_rows(raw) -> None:
+            raw["rows"].reverse()
+
+        def reverse_axioms(raw) -> None:
+            raw["rows"][0]["authoritative_axioms"].reverse()
+
+        def reverse_references(raw) -> None:
+            raw["rows"][0]["authoritative_axioms"][0]["referenced_iris"].reverse()
+
+        def reverse_axiom_dispositions(raw) -> None:
+            current = raw["rows"][0]["authoritative_axioms"][0]["product_dispositions"]
+            raw["rows"][0]["authoritative_axioms"][0]["product_dispositions"] = dict(
+                reversed(tuple(current.items()))
+            )
+
+        def reverse_row_dispositions(raw) -> None:
+            current = raw["rows"][0]["row_product_dispositions"]
+            raw["rows"][0]["row_product_dispositions"] = dict(
+                reversed(tuple(current.items()))
+            )
+
+        cases = (
+            ("rows", [first, second], reverse_rows),
+            ("axioms", [multi_axiom_row_input()], reverse_axioms),
+            ("references", [first], reverse_references),
+            ("axiom dispositions", [first], reverse_axiom_dispositions),
+            ("row dispositions", [zero_row()], reverse_row_dispositions),
+        )
+        for label, inputs, mutate in cases:
+            with self.subTest(label=label):
+                self.assert_noncanonical_file(self.build(*inputs), inputs, mutate)
+
+    def test_worksheet_names_are_nfc_normalized(self) -> None:
+        decomposed = "Cafe\u0301"
+        composed = "Caf\u00e9"
+        source = replace(
+            row_input(),
+            location=identity.RowLocation(decomposed, 7),
+        )
+        document = self.build(source)
+        self.assertEqual(source.location.worksheet, decomposed)
+        self.assertEqual(document.rows[0].location, identity.RowLocation(composed, 7))
+        self.assertEqual(
+            self.build(row_input()).rows[0].location.worksheet,
+            "Synthetic",
+        )
+
+        def decompose_worksheet(raw) -> None:
+            raw["rows"][0]["location"]["worksheet"] = decomposed
+
+        self.assert_noncanonical_file(document, [source], decompose_worksheet)
+
+    def test_mapping_type_must_match_canonical_expression(self) -> None:
+        cases = (
+            (replace(row_input(), mapping_type="domain"), "domain", "class_mapping"),
+            (
+                replace(object_property_row_input(), mapping_type="range"),
+                "range",
+                "object_property_mapping",
+            ),
+        )
+        for source, supplied, canonical in cases:
+            with self.subTest(supplied=supplied, canonical=canonical):
+                with (
+                    mock.patch.object(
+                        dispositions,
+                        "coverage_classification",
+                        side_effect=AssertionError(
+                            "coverage classification must not run after a mapping-type mismatch"
+                        ),
+                    ) as coverage,
+                    self.assertRaises(dispositions.ProductDispositionError) as caught,
+                ):
+                    self.build(source)
+                coverage.assert_not_called()
+                self.assertEqual(len(caught.exception.issues), 1)
+                mismatch = next(
+                    value
+                    for value in caught.exception.issues
+                    if value.code == "ROW_EXPRESSION_MISMATCH"
+                    and value.field == "mapping_type"
+                )
+                self.assertEqual(mismatch.row_id, ROW_A)
+                self.assertIn("Synthetic!2", mismatch.message)
+                self.assertIn(repr(supplied), mismatch.message)
+                self.assertIn(repr(canonical), mismatch.message)
+
+    def test_matching_mapping_types_derive_coverage(self) -> None:
+        cases = (
+            (row_input(), "class_mapping"),
+            (domain_row_input(), "property_typing"),
+        )
+        for source, expected in cases:
+            with (
+                self.subTest(mapping_type=source.mapping_type),
+                mock.patch.object(
+                    dispositions,
+                    "coverage_classification",
+                    wraps=dispositions.coverage_classification,
+                ) as coverage,
+            ):
+                document = self.build(source)
+                coverage.assert_called_once_with(source.mapping_type)
+                self.assertEqual(document.rows[0].coverage_classification, expected)
+
+    def test_round_trip_and_noncanonical_serialization(self) -> None:
+        document = self.build(row_input())
+        with tempfile.TemporaryDirectory(prefix="disposition-json-") as temp:
+            path = Path(temp) / "dispositions.json"
+            canonical = dispositions.serialize_disposition_document(document)
+            path.write_bytes(canonical)
+            loaded, issues = dispositions.validate_disposition_file(
+                path, [row_input()], self.metadata, hashes()
+            )
+            self.assertEqual(issues, ())
+            self.assertEqual(dispositions.serialize_disposition_document(loaded), canonical)
+            path.write_text(json.dumps(dispositions.disposition_document_object(document)), encoding="utf-8")
+            _, issues = dispositions.validate_disposition_file(
+                path, [row_input()], self.metadata, hashes()
+            )
+            self.assert_codes(issues, "NONCANONICAL_SERIALIZATION")
+
+    def test_identity_and_row_reconciliation_failures(self) -> None:
+        source = row_input()
+        document = self.build(source)
+        actual = document.rows[0]
+        mutations = (
+            (replace(document, rows=(replace(actual, row_id=ROW_B),)), "MISSING_DISPOSITION_ROW"),
+            (replace(document, rows=(replace(actual, location=identity.RowLocation("Other", 99)),)), "ROW_LOCATION_MISMATCH"),
+            (replace(document, rows=(replace(actual, canonical_row_expression=replace(actual.canonical_row_expression, target="<changed>")),)), "ROW_EXPRESSION_MISMATCH"),
+            (replace(document, rows=(replace(actual, source_expression_sha256="f" * 64),)), "EXPRESSION_HASH_MISMATCH"),
+        )
+        for changed, code in mutations:
+            with self.subTest(code=code):
+                self.assert_codes(
+                    dispositions.validate_disposition_document(changed, [source], self.metadata, hashes()),
+                    code,
+                )
+
+    def test_axiom_reconciliation_category_and_references(self) -> None:
+        source = row_input()
+        document = self.build(source)
+        row = document.rows[0]
+        axiom = row.authoritative_axioms[0]
+        mutations = (
+            (replace(axiom, axiom_id="sha256:" + "f" * 64), "MISSING_AUTHORITATIVE_AXIOM"),
+            (replace(axiom, canonical_expression=axiom.canonical_expression + " "), "AXIOM_ID_MISMATCH"),
+            (replace(axiom, referenced_iris=(*axiom.referenced_iris, "https://example.org/x")), "REFERENCED_IRI_MISMATCH"),
+            (replace(axiom, target_category="cco_bearing"), "TARGET_CATEGORY_MISMATCH"),
+            (replace(axiom, target_category="unknown"), "UNKNOWN_TARGET_CATEGORY"),
+        )
+        for changed_axiom, code in mutations:
+            changed = replace(document, rows=(replace(row, authoritative_axioms=(changed_axiom,)),))
+            with self.subTest(code=code):
+                self.assert_codes(
+                    dispositions.validate_disposition_document(changed, [source], self.metadata, hashes()),
+                    code,
+                )
+
+    def test_product_status_and_reason_validation(self) -> None:
+        source = row_input(named(CCO_ENTITY))
+        document = self.build(source)
+        row = document.rows[0]
+        axiom = row.authoritative_axioms[0]
+        values = list(axiom.product_dispositions)
+        mutations = (
+            (tuple(values[:-1]), "MISSING_PRODUCT_DISPOSITION"),
+            ((*values, ("extra", dispositions.ProductDisposition("deferred", "NO_APPROVED_TRANSFORMATION_RULE"))), "UNKNOWN_PRODUCT"),
+            (tuple((key, dispositions.ProductDisposition("unknown")) if key == "integrated" else (key, value) for key, value in values), "UNKNOWN_DISPOSITION_STATUS"),
+            (tuple((key, dispositions.ProductDisposition("deferred")) if key == "strict_bfo_mapping" else (key, value) for key, value in values), "MISSING_REASON_CODE"),
+            (tuple((key, dispositions.ProductDisposition("emitted_unchanged", "TARGET_SPECIFIC")) if key == "integrated" else (key, value) for key, value in values), "PROHIBITED_REASON_CODE"),
+            (tuple((key, dispositions.ProductDisposition("deferred", "TARGET_SPECIFIC")) if key == "strict_bfo_mapping" else (key, value) for key, value in values), "INVALID_REASON_CODE"),
+        )
+        for changed_values, code in mutations:
+            changed_axiom = replace(axiom, product_dispositions=tuple(changed_values))
+            changed = replace(document, rows=(replace(row, authoritative_axioms=(changed_axiom,)),))
+            with self.subTest(code=code):
+                self.assert_codes(
+                    dispositions.validate_disposition_document(changed, [source], self.metadata, hashes()),
+                    code,
+                )
+
+    def test_summary_product_order_and_stale_hashes(self) -> None:
+        source = row_input()
+        document = self.build(source)
+        changed_summary = replace(document.summary, governed_row_count=2)
+        self.assert_codes(
+            dispositions.validate_disposition_document(
+                replace(document, summary=changed_summary), [source], self.metadata, hashes()
+            ),
+            "SUMMARY_MISMATCH",
+        )
+        self.assert_codes(
+            dispositions.validate_disposition_document(
+                replace(document, product_order=tuple(reversed(document.product_order))),
+                [source],
+                self.metadata,
+                hashes(),
+            ),
+            "PRODUCT_ORDER_MISMATCH",
+        )
+        hash_codes = (
+            ("workbook_sha256", "STALE_WORKBOOK"),
+            ("generator_sha256", "STALE_GENERATOR"),
+            ("row_identity_module_sha256", "STALE_ROW_IDENTITY_MODULE"),
+            ("disposition_module_sha256", "STALE_DISPOSITION_MODULE"),
+            ("publication_metadata_sha256", "STALE_PUBLICATION_METADATA"),
+        )
+        for field, code in hash_codes:
+            changed_hashes = replace(document.input_hashes, **{field: "f" * 64})
+            with self.subTest(field=field):
+                self.assert_codes(
+                    dispositions.validate_disposition_document(
+                        replace(document, input_hashes=changed_hashes),
+                        [source],
+                        self.metadata,
+                        hashes(),
+                    ),
+                    code,
+                )
+
+    def test_future_modular_ttl_files_are_not_required(self) -> None:
+        for product in self.metadata.products:
+            if product.key != "integrated":
+                self.assertFalse((REPO_ROOT / product.path).is_file())
+        self.assertEqual(self.build(row_input()).summary.governed_row_count, 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/check_coms_mapping.py
+++ b/tools/check_coms_mapping.py
@@ -23,6 +23,13 @@ import traceback
 from datetime import datetime, timezone
 from pathlib import Path
 
+from product_dispositions import (
+    ProductDispositionError,
+    load_disposition_document,
+    serialize_disposition_document,
+)
+from publication_metadata import PublicationMetadataError, load_metadata
+
 try:
     import openpyxl
 except ModuleNotFoundError:  # pragma: no cover - runtime dependency guard
@@ -37,6 +44,10 @@ except ModuleNotFoundError:  # pragma: no cover - runtime dependency guard
 REPO_ROOT = Path(__file__).resolve().parents[1]
 WORKBOOK = REPO_ROOT / "mappings/SSN2BFO-COMS.xlsx"
 GENERATOR = REPO_ROOT / "tools/generate_mapping_from_coms.py"
+ROW_IDENTITY_MODULE = REPO_ROOT / "tools/coms_row_identity.py"
+DISPOSITION_MODULE = REPO_ROOT / "tools/product_dispositions.py"
+PUBLICATION_METADATA = REPO_ROOT / "config/publication-metadata.toml"
+PUBLICATION_METADATA_MODULE = REPO_ROOT / "tools/publication_metadata.py"
 CACHE_DIR = REPO_ROOT / ".cache/coms"
 LAST_SUCCESS = CACHE_DIR / "last-success.json"
 LAST_FAILURE = CACHE_DIR / "last-failure.log"
@@ -46,6 +57,7 @@ MAINTAINED_OUTPUTS = {
     "generation_report": REPO_ROOT / "reports/coms-generation-validation.md",
     "coverage_report": REPO_ROOT / "reports/coms-source-term-coverage.md",
     "diff_report": REPO_ROOT / "reports/coms-vs-pre-coms-legacy-diff.md",
+    "disposition_report": REPO_ROOT / "reports/coms-product-dispositions.json",
 }
 
 METADATA_LABELS = {
@@ -54,6 +66,10 @@ METADATA_LABELS = {
     "generation timestamp (UTC)": "generation_timestamp",
     "maintained ontology path": "maintained_output_path",
     "generated ontology SHA-256": "generated_candidate_sha256",
+    "product-disposition module SHA-256": "disposition_module_sha256",
+    "publication metadata SHA-256": "publication_metadata_sha256",
+    "maintained product-disposition path": "disposition_report_path",
+    "product-disposition JSON SHA-256": "disposition_report_sha256",
 }
 
 
@@ -108,7 +124,8 @@ def verify_workbook(log: list[str]) -> str:
 def compile_generator(log: list[str]) -> str:
     emit("[2/11] Compiling COMS generator", log)
     try:
-        py_compile.compile(str(GENERATOR), doraise=True)
+        for path in (GENERATOR, ROW_IDENTITY_MODULE, DISPOSITION_MODULE, PUBLICATION_METADATA_MODULE):
+            py_compile.compile(str(path), doraise=True)
     except py_compile.PyCompileError as exc:
         raise CheckFailure(f"generator compile failed: {exc.msg}") from exc
     generator_hash = sha256_file(GENERATOR)
@@ -143,6 +160,7 @@ def transaction_paths(transaction_dir: Path) -> dict[str, Path]:
         "generation_report": transaction_dir / "reports/coms-generation-validation.md",
         "coverage_report": transaction_dir / "reports/coms-source-term-coverage.md",
         "diff_report": transaction_dir / "reports/coms-vs-pre-coms-legacy-diff.md",
+        "disposition_report": transaction_dir / "reports/coms-product-dispositions.json",
         "summary": transaction_dir / "summary.json",
         "hermit": transaction_dir / "hermit",
     }
@@ -159,6 +177,8 @@ def run_generator(paths: dict[str, Path], log: list[str]) -> None:
         str(paths["candidate"]),
         "--report",
         str(paths["generation_report"]),
+        "--disposition-report",
+        str(paths["disposition_report"]),
         "--coverage-report",
         str(paths["coverage_report"]),
         "--diff-report",
@@ -169,6 +189,8 @@ def run_generator(paths: dict[str, Path], log: list[str]) -> None:
         relative(WORKBOOK),
         "--report-output-path",
         relative(MAINTAINED_OUTPUTS["candidate"]),
+        "--report-disposition-path",
+        relative(MAINTAINED_OUTPUTS["disposition_report"]),
         "--summary-json",
         str(paths["summary"]),
     ]
@@ -208,6 +230,42 @@ def validate_temporary_outputs(
         raise CheckFailure("generator summary workbook hash does not match the checked input")
     if summary.get("generator_sha256") != generator_hash:
         raise CheckFailure("generator summary generator hash does not match the compiled generator")
+
+    try:
+        disposition = load_disposition_document(paths["disposition_report"])
+        publication_metadata = load_metadata(PUBLICATION_METADATA)
+    except (ProductDispositionError, PublicationMetadataError) as exc:
+        raise CheckFailure(f"product-disposition validation failed: {exc}") from exc
+    if paths["disposition_report"].read_bytes() != serialize_disposition_document(disposition):
+        raise CheckFailure("product-disposition JSON is not canonically serialized")
+    expected_disposition_hashes = {
+        "workbook_sha256": workbook_hash,
+        "generator_sha256": generator_hash,
+        "row_identity_module_sha256": sha256_file(ROW_IDENTITY_MODULE),
+        "disposition_module_sha256": sha256_file(DISPOSITION_MODULE),
+        "publication_metadata_sha256": sha256_file(PUBLICATION_METADATA),
+    }
+    for field, expected in expected_disposition_hashes.items():
+        if getattr(disposition.input_hashes, field) != expected:
+            raise CheckFailure(f"temporary product-disposition {field} mismatch")
+    expected_products = tuple(product.key for product in publication_metadata.products)
+    if disposition.product_order != expected_products:
+        raise CheckFailure("temporary product-disposition product order mismatch")
+    disposition_hash = sha256_file(paths["disposition_report"])
+    if summary.get("product_disposition_report_sha256") != disposition_hash:
+        raise CheckFailure("product-disposition hash does not match generator summary")
+    disposition_summary = summary.get("product_dispositions")
+    if not isinstance(disposition_summary, dict):
+        raise CheckFailure("generator summary is missing product-disposition results")
+    for field in disposition.summary.__dataclass_fields__:
+        if disposition_summary.get(field) != getattr(disposition.summary, field):
+            raise CheckFailure(f"product-disposition summary mismatch for {field}")
+    emit(
+        "Product dispositions: PASS "
+        f"({disposition.summary.governed_row_count} rows; "
+        f"{disposition.summary.authoritative_axiom_count} axioms)",
+        log,
+    )
 
     emit("[5/11] Confirming maintained SPARQL source-term coverage checks ran", log)
     coverage = summary.get("source_term_coverage")
@@ -264,6 +322,10 @@ def validate_temporary_outputs(
         "generator_sha256": generator_hash,
         "maintained_output_path": relative(MAINTAINED_OUTPUTS["candidate"]),
         "generated_candidate_sha256": candidate_hash,
+        "disposition_module_sha256": sha256_file(DISPOSITION_MODULE),
+        "publication_metadata_sha256": sha256_file(PUBLICATION_METADATA),
+        "disposition_report_path": relative(MAINTAINED_OUTPUTS["disposition_report"]),
+        "disposition_report_sha256": disposition_hash,
     }
     for key, expected in expected_metadata.items():
         if metadata.get(key) != expected:
@@ -313,11 +375,43 @@ def freshness_errors(workbook_hash: str, generator_hash: str) -> list[str]:
         errors.append("workbook hash differs from the generated report")
     if metadata.get("generator_sha256") != generator_hash:
         errors.append("generator hash differs from the generated report")
+    disposition_module_hash = sha256_file(DISPOSITION_MODULE)
+    publication_metadata_hash = sha256_file(PUBLICATION_METADATA)
+    if metadata.get("disposition_module_sha256") != disposition_module_hash:
+        errors.append("product-disposition module hash differs from the generated report")
+    if metadata.get("publication_metadata_sha256") != publication_metadata_hash:
+        errors.append("publication metadata hash differs from the generated report")
     if metadata.get("maintained_output_path") != relative(MAINTAINED_OUTPUTS["candidate"]):
         errors.append("maintained ontology path differs from the generated report")
     candidate_hash = sha256_file(MAINTAINED_OUTPUTS["candidate"])
     if metadata.get("generated_candidate_sha256") != candidate_hash:
         errors.append("generated candidate hash differs from the generated report")
+    disposition_path = MAINTAINED_OUTPUTS["disposition_report"]
+    disposition_hash = sha256_file(disposition_path)
+    if metadata.get("disposition_report_path") != relative(disposition_path):
+        errors.append("maintained product-disposition path differs from the generated report")
+    if metadata.get("disposition_report_sha256") != disposition_hash:
+        errors.append("product-disposition hash differs from the generated report")
+    try:
+        disposition = load_disposition_document(disposition_path)
+        publication_metadata = load_metadata(PUBLICATION_METADATA)
+    except (ProductDispositionError, PublicationMetadataError) as exc:
+        errors.append(f"product-disposition document is invalid: {exc}")
+    else:
+        if disposition_path.read_bytes() != serialize_disposition_document(disposition):
+            errors.append("product-disposition document is not canonically serialized")
+        expected_hashes = {
+            "workbook_sha256": workbook_hash,
+            "generator_sha256": generator_hash,
+            "row_identity_module_sha256": sha256_file(ROW_IDENTITY_MODULE),
+            "disposition_module_sha256": disposition_module_hash,
+            "publication_metadata_sha256": publication_metadata_hash,
+        }
+        for field, expected in expected_hashes.items():
+            if getattr(disposition.input_hashes, field) != expected:
+                errors.append(f"product-disposition {field} is stale")
+        if disposition.product_order != tuple(product.key for product in publication_metadata.products):
+            errors.append("product-disposition product order differs from publication metadata")
     return errors
 
 
@@ -333,7 +427,7 @@ def normalized_generation_report(path: Path) -> str:
 
 def output_differences(paths: dict[str, Path]) -> list[str]:
     differences: list[str] = []
-    for name in ("candidate", "coverage_report", "diff_report"):
+    for name in ("candidate", "coverage_report", "diff_report", "disposition_report"):
         current = MAINTAINED_OUTPUTS[name]
         if not current.is_file() or current.read_bytes() != paths[name].read_bytes():
             differences.append(name)
@@ -405,6 +499,9 @@ def record_success(summary: dict[str, object], workbook_hash: str, generator_has
         "workbook_sha256": workbook_hash,
         "generator_sha256": generator_hash,
         "generated_candidate_sha256": summary.get("generated_candidate_sha256"),
+        "product_disposition_report_path": summary.get("product_disposition_report_path"),
+        "product_disposition_report_sha256": summary.get("product_disposition_report_sha256"),
+        "product_dispositions": summary.get("product_dispositions"),
         "timestamp": utc_now(),
         "generated_ontology_triple_count": summary.get("generated_ontology_triple_count"),
         "candidate_closure_triple_count": summary.get("candidate_closure_triple_count"),

--- a/tools/generate_mapping_from_coms.py
+++ b/tools/generate_mapping_from_coms.py
@@ -31,6 +31,17 @@ from coms_row_identity import (
     validate_unique_authoritative_axioms,
     validate_unique_row_ids,
 )
+from product_dispositions import (
+    DispositionDocument,
+    DispositionRowInput,
+    ProductDispositionError,
+    RequiredInputHashes,
+    axiom_input_from_canonical_row,
+    build_disposition_document,
+    serialize_disposition_document,
+    validate_disposition_file,
+)
+from publication_metadata import PublicationMetadataError, load_metadata
 
 try:
     import openpyxl
@@ -48,6 +59,8 @@ except ModuleNotFoundError as exc:  # pragma: no cover - runtime dependency guar
 REPO_ROOT = Path(__file__).resolve().parents[1]
 LEGACY_ONTOLOGY = REPO_ROOT / "legacy/SSN2BFO-pre-COMS.ttl"
 IDENTITY_MODULE = REPO_ROOT / "tools/coms_row_identity.py"
+DISPOSITION_MODULE = REPO_ROOT / "tools/product_dispositions.py"
+PUBLICATION_METADATA = REPO_ROOT / "config/publication-metadata.toml"
 GENERATED_NOTICE = (
     "# GENERATED FILE: produced from mappings/SSN2BFO-COMS.xlsx; "
     "do not edit SSN2BFO.ttl directly."
@@ -899,6 +912,50 @@ def attach_canonical_identities(processed_rows: list[ProcessedRow]) -> tuple[Can
     return tuple(audits)
 
 
+def disposition_input_for_processed_row(item: ProcessedRow) -> DispositionRowInput:
+    if item.identity_audit is None:
+        raise GenerationError(f"{item.row.diagnostic_id}: identity audit is required for dispositions")
+    canonical_input = canonical_input_for_processed_row(item)
+    try:
+        axiom_inputs = tuple(
+            axiom_input_from_canonical_row(identity, canonical_input)
+            for identity in item.identity_audit.authoritative_axioms
+        )
+    except ProductDispositionError as exc:
+        raise GenerationError(str(exc)) from exc
+    return DispositionRowInput(
+        row_id=item.row.stable_row_id,
+        location=item.row.location,
+        subject_lexical=item.row.subject_text,
+        predicate_lexical=item.row.predicate_text or None,
+        authoritative_target_lexical=item.row.target_text or None,
+        canonical_row=item.identity_audit.expression,
+        source_expression_sha256=item.identity_audit.source_expression_sha256,
+        mapping_type=mapping_type_for_processed_row(item),
+        reasoning=item.row.reasoning_text,
+        authoritative_axioms=axiom_inputs,
+    )
+
+
+def build_and_write_disposition_report(
+    processed_rows: list[ProcessedRow],
+    path: Path,
+    input_hashes: RequiredInputHashes,
+) -> tuple[DispositionDocument, list[DispositionRowInput]]:
+    try:
+        metadata = load_metadata(PUBLICATION_METADATA)
+        row_inputs = [disposition_input_for_processed_row(item) for item in processed_rows]
+        document = build_disposition_document(row_inputs, metadata, input_hashes)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(serialize_disposition_document(document))
+        loaded, issues = validate_disposition_file(path, row_inputs, metadata, input_hashes)
+    except (ProductDispositionError, PublicationMetadataError) as exc:
+        raise GenerationError(str(exc)) from exc
+    if issues:
+        raise GenerationError(str(ProductDispositionError(issues)))
+    return loaded, row_inputs
+
+
 def validate_identity_audit_completeness(
     governed_rows: list[WorkbookRow],
     processed_rows: list[ProcessedRow],
@@ -1656,6 +1713,11 @@ def write_generation_report(
     identity_module_sha256: str,
     generation_timestamp: str,
     candidate_sha256: str,
+    disposition_document: DispositionDocument | None = None,
+    disposition_path: Path | None = None,
+    disposition_sha256: str = "unavailable",
+    disposition_module_sha256: str = "unavailable",
+    publication_metadata_sha256: str = "unavailable",
 ) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     error_lines = [f"- {error}" for error in errors] or ["- none"]
@@ -1679,9 +1741,13 @@ def write_generation_report(
         f"| workbook SHA-256 | `{workbook_sha256}` |",
         f"| generator SHA-256 | `{generator_sha256}` |",
         f"| row-identity module SHA-256 | `{identity_module_sha256}` |",
+        f"| product-disposition module SHA-256 | `{disposition_module_sha256}` |",
+        f"| publication metadata SHA-256 | `{publication_metadata_sha256}` |",
         f"| generation timestamp (UTC) | `{generation_timestamp}` |",
         f"| maintained ontology path | `{output_path}` |",
         f"| generated ontology SHA-256 | `{candidate_sha256}` |",
+        f"| maintained product-disposition path | `{disposition_path or 'unavailable'}` |",
+        f"| product-disposition JSON SHA-256 | `{disposition_sha256}` |",
         "",
         "## Workbook",
         "",
@@ -1740,6 +1806,31 @@ def write_generation_report(
             )
     else:
         lines.append("No label-to-IRI fallback resolutions were required.")
+
+    if disposition_document is None:
+        disposition_lines = [
+            "## Product Dispositions",
+            "",
+            "- Disposition generation: unavailable",
+        ]
+    else:
+        disposition_summary = disposition_document.summary
+        disposition_lines = [
+            "## Product Dispositions",
+            "",
+            f"- Path: `{disposition_path}`",
+            "- Schema version: `1`",
+            f"- Product order: {', '.join(f'`{key}`' for key in disposition_document.product_order)}",
+            f"- Governed rows: {disposition_summary.governed_row_count}",
+            f"- Canonical authoritative axioms: {disposition_summary.authoritative_axiom_count}",
+            f"- Zero-axiom rows: {disposition_summary.zero_axiom_row_count}",
+            f"- Target-neutral axioms: {disposition_summary.target_neutral_axiom_count}",
+            f"- BFO-bearing axioms: {disposition_summary.bfo_bearing_axiom_count}",
+            f"- CCO-bearing axioms: {disposition_summary.cco_bearing_axiom_count}",
+            f"- Mixed BFO/CCO axioms: {disposition_summary.mixed_bfo_cco_axiom_count}",
+            "- Disposition reconciliation and canonical serialization: PASS",
+            "- No lossless transformation or weakened projection is approved by this artifact.",
+        ]
 
     lines.extend(
         [
@@ -1800,8 +1891,13 @@ def write_generation_report(
                     ]
                 )
                 + " |"
-                for audit in sorted(identity_audits, key=lambda item: (item.location, item.row_id))
+                for audit in sorted(
+                    identity_audits,
+                    key=lambda item: (item.location, item.row_id),
+                )
             ],
+            "",
+            *disposition_lines,
             "",
             "## Generated Ontology",
             "",
@@ -1992,6 +2088,11 @@ def write_summary_json(
     comparison: ComparisonResult | None,
     errors: list[str],
     elapsed_seconds: float,
+    disposition_document: DispositionDocument | None = None,
+    disposition_path: Path | None = None,
+    disposition_sha256: str = "unavailable",
+    disposition_module_sha256: str = "unavailable",
+    publication_metadata_sha256: str = "unavailable",
 ) -> None:
     payload = {
         "status": "PASS" if not errors else "FAIL",
@@ -2000,8 +2101,12 @@ def write_summary_json(
         "workbook_sha256": workbook_sha256,
         "generator_sha256": generator_sha256,
         "row_identity_module_sha256": identity_module_sha256,
+        "product_disposition_module_sha256": disposition_module_sha256,
+        "publication_metadata_sha256": publication_metadata_sha256,
         "generation_timestamp": generation_timestamp,
         "generated_candidate_sha256": candidate_sha256,
+        "product_disposition_report_path": None if disposition_path is None else str(disposition_path),
+        "product_disposition_report_sha256": disposition_sha256,
         "worksheets_read": stats.worksheets_read,
         "active_axiom_rows": stats.active_axiom_rows,
         "mapped_rows": stats.mapped_rows,
@@ -2029,6 +2134,16 @@ def write_summary_json(
                 for axiom in audit.authoritative_axioms
             }
         ),
+        "product_dispositions": None
+        if disposition_document is None
+        else {
+            "schema_version": disposition_document.schema_version,
+            "product_order": list(disposition_document.product_order),
+            **{
+                field: getattr(disposition_document.summary, field)
+                for field in disposition_document.summary.__dataclass_fields__
+            },
+        },
         "generated_ontology_triple_count": None if hermit is None else hermit.generated_triple_count,
         "candidate_closure_triple_count": None if hermit is None else hermit.closure_triple_count,
         "hermit_return_code": None if hermit is None else hermit.return_code,
@@ -2081,6 +2196,11 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--output", required=True, help="Generated TTL output path.")
     parser.add_argument("--report", required=True, help="Generation validation report path.")
     parser.add_argument(
+        "--disposition-report",
+        required=True,
+        help="Generated COMS per-product disposition JSON path.",
+    )
+    parser.add_argument(
         "--coverage-report",
         default="reports/coms-source-term-coverage.md",
         help="Source-term coverage report path.",
@@ -2104,6 +2224,10 @@ def main(argv: list[str] | None = None) -> int:
         help="Generated ontology path displayed in reports. Defaults to the actual --output path.",
     )
     parser.add_argument(
+        "--report-disposition-path",
+        help="Disposition path displayed in reports. Defaults to the actual --disposition-report path.",
+    )
+    parser.add_argument(
         "--summary-json",
         help="Optional machine-readable generation summary path.",
     )
@@ -2113,10 +2237,12 @@ def main(argv: list[str] | None = None) -> int:
     input_path = REPO_ROOT / args.input if not Path(args.input).is_absolute() else Path(args.input)
     output_path = REPO_ROOT / args.output if not Path(args.output).is_absolute() else Path(args.output)
     report_path = REPO_ROOT / args.report if not Path(args.report).is_absolute() else Path(args.report)
+    disposition_report_path = REPO_ROOT / args.disposition_report if not Path(args.disposition_report).is_absolute() else Path(args.disposition_report)
     coverage_report_path = REPO_ROOT / args.coverage_report if not Path(args.coverage_report).is_absolute() else Path(args.coverage_report)
     diff_report_path = REPO_ROOT / args.diff_report if not Path(args.diff_report).is_absolute() else Path(args.diff_report)
     report_workbook_path = Path(args.report_workbook_path) if args.report_workbook_path else input_path
     report_output_path = Path(args.report_output_path) if args.report_output_path else output_path
+    report_disposition_path = Path(args.report_disposition_path) if args.report_disposition_path else disposition_report_path
     summary_json_path = None
     if args.summary_json:
         summary_json_path = REPO_ROOT / args.summary_json if not Path(args.summary_json).is_absolute() else Path(args.summary_json)
@@ -2124,7 +2250,10 @@ def main(argv: list[str] | None = None) -> int:
     workbook_sha256 = sha256_file(input_path) if input_path.is_file() else "unavailable"
     generator_sha256 = sha256_file(Path(__file__).resolve())
     identity_module_sha256 = sha256_file(IDENTITY_MODULE)
+    disposition_module_sha256 = sha256_file(DISPOSITION_MODULE)
+    publication_metadata_sha256 = sha256_file(PUBLICATION_METADATA)
     candidate_sha256 = "unavailable"
+    disposition_sha256 = "unavailable"
 
     stats = WorkbookStats()
     resolver = Resolver()
@@ -2134,6 +2263,7 @@ def main(argv: list[str] | None = None) -> int:
     comparison: ComparisonResult | None = None
     normalized_rows: list[NormalizedRow] = []
     identity_audits: list[CanonicalRowAudit] = []
+    disposition_document: DispositionDocument | None = None
 
     try:
         rows, stats = read_workbook(input_path)
@@ -2143,6 +2273,18 @@ def main(argv: list[str] | None = None) -> int:
             for item in processed
             if item.identity_audit is not None
         ]
+        disposition_document, _ = build_and_write_disposition_report(
+            processed,
+            disposition_report_path,
+            RequiredInputHashes(
+                workbook_sha256=workbook_sha256,
+                generator_sha256=generator_sha256,
+                row_identity_module_sha256=identity_module_sha256,
+                disposition_module_sha256=disposition_module_sha256,
+                publication_metadata_sha256=publication_metadata_sha256,
+            ),
+        )
+        disposition_sha256 = sha256_file(disposition_report_path)
         graph = generate_ontology(processed, output_path)
         normalized_rows = normalized_axiom_rows(processed, graph)
         coverage = build_coverage(processed, [], coverage_report_path)
@@ -2177,6 +2319,11 @@ def main(argv: list[str] | None = None) -> int:
         identity_module_sha256=identity_module_sha256,
         generation_timestamp=generation_timestamp,
         candidate_sha256=candidate_sha256,
+        disposition_document=disposition_document,
+        disposition_path=report_disposition_path,
+        disposition_sha256=disposition_sha256,
+        disposition_module_sha256=disposition_module_sha256,
+        publication_metadata_sha256=publication_metadata_sha256,
     )
     if summary_json_path is not None:
         write_summary_json(
@@ -2195,6 +2342,11 @@ def main(argv: list[str] | None = None) -> int:
             comparison=comparison,
             errors=errors,
             elapsed_seconds=elapsed,
+            disposition_document=disposition_document,
+            disposition_path=report_disposition_path,
+            disposition_sha256=disposition_sha256,
+            disposition_module_sha256=disposition_module_sha256,
+            publication_metadata_sha256=publication_metadata_sha256,
         )
 
     print(f"Wrote {report_path}")
@@ -2204,6 +2356,8 @@ def main(argv: list[str] | None = None) -> int:
         print(f"Wrote {coverage_report_path}")
     if diff_report_path.exists():
         print(f"Wrote {diff_report_path}")
+    if disposition_report_path.exists():
+        print(f"Wrote {disposition_report_path}")
     print(f"Worksheets read: {', '.join(stats.worksheets_read) or 'none'}")
     print(f"Mapped rows: {stats.mapped_rows}")
     print(f"Blank mapping rows: {stats.blank_mapping_rows}")
@@ -2220,6 +2374,12 @@ def main(argv: list[str] | None = None) -> int:
         "Canonical authoritative axioms: "
         f"{sum(len(audit.authoritative_axioms) for audit in identity_audits)}"
     )
+    if disposition_document is not None:
+        disposition_summary = disposition_document.summary
+        print(f"Disposition target-neutral axioms: {disposition_summary.target_neutral_axiom_count}")
+        print(f"Disposition BFO-bearing axioms: {disposition_summary.bfo_bearing_axiom_count}")
+        print(f"Disposition CCO-bearing axioms: {disposition_summary.cco_bearing_axiom_count}")
+        print(f"Disposition mixed BFO/CCO axioms: {disposition_summary.mixed_bfo_cco_axiom_count}")
     if hermit is not None:
         print(f"Generated triple count: {hermit.generated_triple_count}")
         print(f"Candidate closure triple count: {hermit.closure_triple_count}")

--- a/tools/product_dispositions.py
+++ b/tools/product_dispositions.py
@@ -1,0 +1,1279 @@
+#!/usr/bin/env python3
+"""Derive and validate deterministic COMS product-disposition evidence."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import unicodedata
+from collections import Counter
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable
+
+from coms_row_identity import (
+    CANONICALIZATION_VERSION,
+    AuthoritativeAxiomIdentity,
+    CanonicalRowExpression,
+    CanonicalRowInput,
+    ExpressionNode,
+    RowLocation,
+    canonical_row_json,
+    source_expression_sha256,
+)
+from publication_metadata import PublicationMetadata
+
+
+SCHEMA_VERSION = 1
+SHA256_RE = re.compile(r"[0-9a-f]{64}\Z")
+AXIOM_ID_RE = re.compile(r"sha256:([0-9a-f]{64})\Z")
+
+TARGET_CATEGORIES = (
+    "target_neutral",
+    "bfo_bearing",
+    "cco_bearing",
+    "mixed_bfo_cco",
+)
+MAPPING_TYPES = (
+    "class_mapping",
+    "object_property_mapping",
+    "property_chain",
+    "domain",
+    "range",
+    "explicit_blank",
+)
+COVERAGE_CLASSIFICATIONS = (
+    "class_mapping",
+    "relation_mapping",
+    "property_chain",
+    "property_typing",
+    "explicitly_unmapped",
+)
+DISPOSITION_STATUSES = (
+    "emitted_unchanged",
+    "provided_through_import",
+    "provided_transitively",
+    "not_applicable",
+    "deferred",
+)
+REASON_CODES = (
+    "TARGET_SPECIFIC",
+    "NO_APPROVED_TRANSFORMATION_RULE",
+    "EXPLICITLY_UNMAPPED_SOURCE_ROW",
+)
+
+SOURCE_NAMESPACES = (
+    "http://www.w3.org/ns/sosa/",
+    "http://www.w3.org/ns/sosa/sampling/",
+    "http://www.w3.org/ns/ssn/",
+    "http://www.w3.org/ns/ssn/systems/",
+)
+BFO_NAMESPACE = "http://purl.obolibrary.org/obo/BFO_"
+CCO_NAMESPACE = "https://www.commoncoreontologies.org/"
+STRUCTURAL_NAMESPACES = (
+    "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+    "http://www.w3.org/2000/01/rdf-schema#",
+    "http://www.w3.org/2002/07/owl#",
+)
+SUPPORTED_PREDICATE_IRIS = frozenset(
+    {
+        "http://www.w3.org/2000/01/rdf-schema#subClassOf",
+        "http://www.w3.org/2002/07/owl#equivalentClass",
+        "http://www.w3.org/2000/01/rdf-schema#subPropertyOf",
+        "http://www.w3.org/2002/07/owl#equivalentProperty",
+        "http://www.w3.org/2002/07/owl#propertyChainAxiom",
+        "http://www.w3.org/2000/01/rdf-schema#domain",
+        "http://www.w3.org/2000/01/rdf-schema#range",
+    }
+)
+POLICY_PRODUCTS = frozenset(
+    {
+        "integrated",
+        "alignment_core",
+        "strict_bfo_mapping",
+        "bfo_projection",
+        "cco_extension",
+    }
+)
+
+
+@dataclass(frozen=True)
+class ValidationIssue:
+    code: str
+    row_id: str = ""
+    axiom_id: str = ""
+    field: str = ""
+    message: str = ""
+
+
+class ProductDispositionError(ValueError):
+    """One or more expected disposition parsing or validation failures."""
+
+    def __init__(self, issues: Iterable[ValidationIssue]):
+        self.issues = sort_issues(issues)
+        super().__init__(" | ".join(format_issue(issue) for issue in self.issues))
+
+
+@dataclass(frozen=True)
+class ProductDisposition:
+    status: str
+    reason_code: str | None = None
+
+
+@dataclass(frozen=True)
+class RequiredInputHashes:
+    workbook_sha256: str
+    generator_sha256: str
+    row_identity_module_sha256: str
+    disposition_module_sha256: str
+    publication_metadata_sha256: str
+
+
+@dataclass(frozen=True)
+class DispositionAxiomInput:
+    identity: AuthoritativeAxiomIdentity
+    subject_iri: str
+    predicate_iri: str
+    target_iris: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class DispositionRowInput:
+    row_id: str
+    location: RowLocation
+    subject_lexical: str
+    predicate_lexical: str | None
+    authoritative_target_lexical: str | None
+    canonical_row: CanonicalRowExpression
+    source_expression_sha256: str
+    mapping_type: str
+    reasoning: str
+    authoritative_axioms: tuple[DispositionAxiomInput, ...]
+
+
+@dataclass(frozen=True)
+class EntityReference:
+    lexical: str
+    iri: str
+
+
+@dataclass(frozen=True)
+class DispositionAxiomRecord:
+    axiom_id: str
+    canonical_expression: str
+    referenced_iris: tuple[str, ...]
+    target_category: str
+    product_dispositions: tuple[tuple[str, ProductDisposition], ...]
+
+
+@dataclass(frozen=True)
+class DispositionRowRecord:
+    row_id: str
+    location: RowLocation
+    subject: EntityReference
+    predicate: EntityReference | None
+    authoritative_target_lexical: str | None
+    canonical_row_expression: CanonicalRowExpression
+    source_expression_sha256: str
+    mapping_type: str
+    coverage_classification: str
+    reasoning: str
+    authoritative_axioms: tuple[DispositionAxiomRecord, ...]
+    row_product_dispositions: tuple[tuple[str, ProductDisposition], ...] | None
+
+
+@dataclass(frozen=True)
+class DispositionSummary:
+    governed_row_count: int
+    unique_row_id_count: int
+    authoritative_axiom_count: int
+    unique_authoritative_axiom_count: int
+    zero_axiom_row_count: int
+    target_neutral_axiom_count: int
+    bfo_bearing_axiom_count: int
+    cco_bearing_axiom_count: int
+    mixed_bfo_cco_axiom_count: int
+    class_mapping_row_count: int
+    relation_mapping_row_count: int
+    property_chain_row_count: int
+    property_typing_row_count: int
+    explicitly_unmapped_row_count: int
+
+
+@dataclass(frozen=True)
+class DispositionDocument:
+    schema_version: int
+    canonicalization_version: str
+    input_hashes: RequiredInputHashes
+    product_order: tuple[str, ...]
+    summary: DispositionSummary
+    rows: tuple[DispositionRowRecord, ...]
+
+
+def issue(
+    code: str,
+    message: str,
+    *,
+    row_id: str = "",
+    axiom_id: str = "",
+    field: str = "",
+) -> ValidationIssue:
+    return ValidationIssue(code, row_id, axiom_id, field, message)
+
+
+def sort_issues(issues: Iterable[ValidationIssue]) -> tuple[ValidationIssue, ...]:
+    return tuple(
+        sorted(
+            issues,
+            key=lambda value: (
+                value.code,
+                value.row_id,
+                value.axiom_id,
+                value.field,
+                value.message,
+            ),
+        )
+    )
+
+
+def format_issue(value: ValidationIssue) -> str:
+    context = " ".join(
+        part
+        for part in (
+            value.row_id,
+            value.axiom_id,
+            value.field,
+        )
+        if part
+    )
+    return f"ERROR [{value.code}]" + (f" {context}" if context else "") + f": {value.message}"
+
+
+def nfc(value: str) -> str:
+    return unicodedata.normalize("NFC", value)
+
+
+def sha256_text(value: str) -> str:
+    return hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+
+def _is_namespace(value: str, namespaces: tuple[str, ...]) -> bool:
+    return any(value.startswith(namespace) for namespace in namespaces)
+
+
+def _expression_iris(node: ExpressionNode | None) -> tuple[str, ...]:
+    if node is None:
+        return ()
+    if node.kind == "named":
+        if node.iri is None:
+            raise ProductDispositionError(
+                [issue("ROW_EXPRESSION_MISMATCH", "named expression lacks an IRI")]
+            )
+        return (node.iri,)
+    if node.kind in {"intersection", "union"}:
+        return tuple(iri for child in node.children for iri in _expression_iris(child))
+    if node.kind == "some":
+        if node.property_iri is None or node.filler is None:
+            raise ProductDispositionError(
+                [issue("ROW_EXPRESSION_MISMATCH", "existential expression is incomplete")]
+            )
+        return (node.property_iri, *_expression_iris(node.filler))
+    raise ProductDispositionError(
+        [issue("ROW_EXPRESSION_MISMATCH", f"unsupported expression node {node.kind!r}")]
+    )
+
+
+def axiom_input_from_canonical_row(
+    identity: AuthoritativeAxiomIdentity,
+    row: CanonicalRowInput,
+) -> DispositionAxiomInput:
+    """Build one axiom-level neutral input from a resolved canonical row."""
+
+    if row.predicate_iri is None:
+        raise ProductDispositionError(
+            [
+                issue(
+                    "INCOMPLETE_ZERO_AXIOM_ROW",
+                    "a zero-axiom row cannot be adapted as an authoritative axiom",
+                    row_id=row.row_id,
+                    field="predicate",
+                )
+            ]
+        )
+    if row.expression is not None:
+        target_iris = _expression_iris(row.expression)
+    elif row.target_property_iri is not None:
+        target_iris = (row.target_property_iri,)
+    else:
+        target_iris = row.property_chain
+    return DispositionAxiomInput(
+        identity=identity,
+        subject_iri=row.subject_iri,
+        predicate_iri=row.predicate_iri,
+        target_iris=tuple(target_iris),
+    )
+
+
+def referenced_iris(axiom_input: DispositionAxiomInput) -> tuple[str, ...]:
+    return tuple(
+        sorted(
+            {
+                nfc(axiom_input.subject_iri),
+                nfc(axiom_input.predicate_iri),
+                *(nfc(value) for value in axiom_input.target_iris),
+            }
+        )
+    )
+
+
+def classify_target_category(axiom_input: DispositionAxiomInput) -> str:
+    """Classify target vocabulary from structured, resolved axiom terms."""
+
+    issues: list[ValidationIssue] = []
+    axiom_id = f"sha256:{axiom_input.identity.sha256}"
+    if not _is_namespace(axiom_input.subject_iri, SOURCE_NAMESPACES):
+        issues.append(
+            issue(
+                "UNEXPECTED_TARGET_VOCABULARY",
+                f"governed subject is outside approved source namespaces: {axiom_input.subject_iri}",
+                axiom_id=axiom_id,
+                field="subject.iri",
+            )
+        )
+    if axiom_input.predicate_iri not in SUPPORTED_PREDICATE_IRIS:
+        issues.append(
+            issue(
+                "UNEXPECTED_TARGET_VOCABULARY",
+                f"unsupported mapping or typing predicate IRI: {axiom_input.predicate_iri}",
+                axiom_id=axiom_id,
+                field="predicate.iri",
+            )
+        )
+
+    has_bfo = False
+    has_cco = False
+    for value in axiom_input.target_iris:
+        if value.startswith(BFO_NAMESPACE):
+            has_bfo = True
+        elif value.startswith(CCO_NAMESPACE):
+            has_cco = True
+        elif _is_namespace(value, SOURCE_NAMESPACES) or _is_namespace(value, STRUCTURAL_NAMESPACES):
+            continue
+        else:
+            issues.append(
+                issue(
+                    "UNEXPECTED_TARGET_VOCABULARY",
+                    f"target IRI is outside approved namespaces: {value}",
+                    axiom_id=axiom_id,
+                    field="referenced_iris",
+                )
+            )
+    if issues:
+        raise ProductDispositionError(issues)
+    if has_bfo and has_cco:
+        return "mixed_bfo_cco"
+    if has_bfo:
+        return "bfo_bearing"
+    if has_cco:
+        return "cco_bearing"
+    return "target_neutral"
+
+
+def _disposition(status: str, reason_code: str | None = None) -> ProductDisposition:
+    return ProductDisposition(status=status, reason_code=reason_code)
+
+
+DISPOSITION_MATRIX = {
+    "target_neutral": {
+        "integrated": _disposition("emitted_unchanged"),
+        "alignment_core": _disposition("emitted_unchanged"),
+        "strict_bfo_mapping": _disposition("provided_through_import"),
+        "bfo_projection": _disposition("provided_transitively"),
+        "cco_extension": _disposition("provided_transitively"),
+    },
+    "bfo_bearing": {
+        "integrated": _disposition("emitted_unchanged"),
+        "alignment_core": _disposition("not_applicable", "TARGET_SPECIFIC"),
+        "strict_bfo_mapping": _disposition("emitted_unchanged"),
+        "bfo_projection": _disposition("provided_through_import"),
+        "cco_extension": _disposition("provided_through_import"),
+    },
+    "cco_bearing": {
+        "integrated": _disposition("emitted_unchanged"),
+        "alignment_core": _disposition("not_applicable", "TARGET_SPECIFIC"),
+        "strict_bfo_mapping": _disposition("deferred", "NO_APPROVED_TRANSFORMATION_RULE"),
+        "bfo_projection": _disposition("deferred", "NO_APPROVED_TRANSFORMATION_RULE"),
+        "cco_extension": _disposition("emitted_unchanged"),
+    },
+    "mixed_bfo_cco": {
+        "integrated": _disposition("emitted_unchanged"),
+        "alignment_core": _disposition("not_applicable", "TARGET_SPECIFIC"),
+        "strict_bfo_mapping": _disposition("deferred", "NO_APPROVED_TRANSFORMATION_RULE"),
+        "bfo_projection": _disposition("deferred", "NO_APPROVED_TRANSFORMATION_RULE"),
+        "cco_extension": _disposition("emitted_unchanged"),
+    },
+}
+
+
+def derive_product_dispositions(
+    target_category: str,
+    product_keys: Iterable[str],
+) -> tuple[tuple[str, ProductDisposition], ...]:
+    if target_category not in DISPOSITION_MATRIX:
+        raise ProductDispositionError(
+            [issue("UNKNOWN_TARGET_CATEGORY", f"unknown target category {target_category!r}")]
+        )
+    keys = tuple(product_keys)
+    unknown = sorted(set(keys) - POLICY_PRODUCTS)
+    missing = sorted(POLICY_PRODUCTS - set(keys))
+    issues = [issue("UNKNOWN_PRODUCT", f"unknown product {key!r}", field="product_order") for key in unknown]
+    issues.extend(
+        issue("MISSING_PRODUCT_DISPOSITION", f"missing product {key!r}", field="product_order")
+        for key in missing
+    )
+    if issues:
+        raise ProductDispositionError(issues)
+    return tuple((key, DISPOSITION_MATRIX[target_category][key]) for key in keys)
+
+
+def derive_zero_axiom_dispositions(
+    product_keys: Iterable[str],
+) -> tuple[tuple[str, ProductDisposition], ...]:
+    keys = tuple(product_keys)
+    unknown = sorted(set(keys) - POLICY_PRODUCTS)
+    missing = sorted(POLICY_PRODUCTS - set(keys))
+    if unknown or missing:
+        raise ProductDispositionError(
+            [
+                *[issue("UNKNOWN_PRODUCT", f"unknown product {key!r}") for key in unknown],
+                *[
+                    issue("MISSING_PRODUCT_DISPOSITION", f"missing product {key!r}")
+                    for key in missing
+                ],
+            ]
+        )
+    return tuple(
+        (key, _disposition("deferred", "EXPLICITLY_UNMAPPED_SOURCE_ROW"))
+        for key in keys
+    )
+
+
+def coverage_classification(mapping_type: str) -> str:
+    values = {
+        "class_mapping": "class_mapping",
+        "object_property_mapping": "relation_mapping",
+        "property_chain": "property_chain",
+        "domain": "property_typing",
+        "range": "property_typing",
+        "explicit_blank": "explicitly_unmapped",
+    }
+    try:
+        return values[mapping_type]
+    except KeyError as exc:
+        raise ProductDispositionError(
+            [issue("ROW_EXPRESSION_MISMATCH", f"unknown mapping type {mapping_type!r}")]
+        ) from exc
+
+
+def _normalize_canonical_expression(value: CanonicalRowExpression) -> CanonicalRowExpression:
+    return CanonicalRowExpression(
+        canonicalization=nfc(value.canonicalization),
+        mapping_type=nfc(value.mapping_type),
+        predicate_iri=None if value.predicate_iri is None else nfc(value.predicate_iri),
+        subject_iri=nfc(value.subject_iri),
+        target=None if value.target is None else nfc(value.target),
+    )
+
+
+def _validate_hashes(values: RequiredInputHashes) -> None:
+    issues = []
+    for field in values.__dataclass_fields__:
+        value = getattr(values, field)
+        if SHA256_RE.fullmatch(value) is None:
+            issues.append(issue("INVALID_INPUT_HASH", "expected 64 lowercase hexadecimal characters", field=field))
+    if issues:
+        raise ProductDispositionError(issues)
+
+
+def _build_summary(rows: tuple[DispositionRowRecord, ...]) -> DispositionSummary:
+    categories = Counter(
+        axiom.target_category
+        for row in rows
+        for axiom in row.authoritative_axioms
+    )
+    coverage = Counter(row.coverage_classification for row in rows)
+    axiom_ids = [axiom.axiom_id for row in rows for axiom in row.authoritative_axioms]
+    return DispositionSummary(
+        governed_row_count=len(rows),
+        unique_row_id_count=len({row.row_id for row in rows}),
+        authoritative_axiom_count=len(axiom_ids),
+        unique_authoritative_axiom_count=len(set(axiom_ids)),
+        zero_axiom_row_count=sum(not row.authoritative_axioms for row in rows),
+        target_neutral_axiom_count=categories["target_neutral"],
+        bfo_bearing_axiom_count=categories["bfo_bearing"],
+        cco_bearing_axiom_count=categories["cco_bearing"],
+        mixed_bfo_cco_axiom_count=categories["mixed_bfo_cco"],
+        class_mapping_row_count=coverage["class_mapping"],
+        relation_mapping_row_count=coverage["relation_mapping"],
+        property_chain_row_count=coverage["property_chain"],
+        property_typing_row_count=coverage["property_typing"],
+        explicitly_unmapped_row_count=coverage["explicitly_unmapped"],
+    )
+
+
+def build_disposition_document(
+    row_inputs: Iterable[DispositionRowInput],
+    publication_metadata: PublicationMetadata,
+    input_hashes: RequiredInputHashes,
+) -> DispositionDocument:
+    """Build canonical disposition evidence from resolved COMS row inputs."""
+
+    _validate_hashes(input_hashes)
+    product_keys = tuple(product.key for product in publication_metadata.products)
+    rows: list[DispositionRowRecord] = []
+    issues: list[ValidationIssue] = []
+    seen_rows: set[str] = set()
+    seen_axioms: set[str] = set()
+
+    for source in sorted(row_inputs, key=lambda value: value.row_id):
+        if source.row_id in seen_rows:
+            issues.append(
+                issue(
+                    "DUPLICATE_DISPOSITION_ROW",
+                    "RowID appears more than once",
+                    row_id=source.row_id,
+                )
+            )
+            continue
+        seen_rows.add(source.row_id)
+        canonical = _normalize_canonical_expression(source.canonical_row)
+        location = RowLocation(
+            nfc(source.location.worksheet),
+            source.location.row_number,
+        )
+        if source.mapping_type != canonical.mapping_type:
+            issues.append(
+                issue(
+                    "ROW_EXPRESSION_MISMATCH",
+                    f"{location.text}: source mapping type {source.mapping_type!r} "
+                    f"does not match canonical mapping type {canonical.mapping_type!r}",
+                    row_id=source.row_id,
+                    field="mapping_type",
+                )
+            )
+            continue
+        if not _is_namespace(canonical.subject_iri, SOURCE_NAMESPACES):
+            issues.append(
+                issue(
+                    "UNEXPECTED_TARGET_VOCABULARY",
+                    f"governed subject is outside approved source namespaces: {canonical.subject_iri}",
+                    row_id=source.row_id,
+                    field="subject.iri",
+                )
+            )
+        if canonical.predicate_iri is not None and canonical.predicate_iri not in SUPPORTED_PREDICATE_IRIS:
+            issues.append(
+                issue(
+                    "UNEXPECTED_TARGET_VOCABULARY",
+                    f"unsupported mapping or typing predicate IRI: {canonical.predicate_iri}",
+                    row_id=source.row_id,
+                    field="predicate.iri",
+                )
+            )
+        expected_hash = source_expression_sha256(canonical)
+        if source.source_expression_sha256 != expected_hash:
+            issues.append(
+                issue(
+                    "EXPRESSION_HASH_MISMATCH",
+                    f"expected {expected_hash}, got {source.source_expression_sha256}",
+                    row_id=source.row_id,
+                    field="source_expression_sha256",
+                )
+            )
+
+        row_axioms: list[DispositionAxiomRecord] = []
+        for axiom_input in source.authoritative_axioms:
+            axiom_id = f"sha256:{axiom_input.identity.sha256}"
+            if (
+                axiom_input.subject_iri != canonical.subject_iri
+                or axiom_input.predicate_iri != canonical.predicate_iri
+            ):
+                issues.append(
+                    issue(
+                        "ROW_EXPRESSION_MISMATCH",
+                        "axiom subject or predicate differs from its canonical row",
+                        row_id=source.row_id,
+                        axiom_id=axiom_id,
+                    )
+                )
+            actual_digest = sha256_text(nfc(axiom_input.identity.canonical_axiom))
+            if axiom_input.identity.sha256 != actual_digest:
+                issues.append(
+                    issue(
+                        "AXIOM_ID_MISMATCH",
+                        f"expected sha256:{actual_digest}, got {axiom_id}",
+                        row_id=source.row_id,
+                        axiom_id=axiom_id,
+                    )
+                )
+            if axiom_id in seen_axioms:
+                issues.append(
+                    issue(
+                        "DUPLICATE_AUTHORITATIVE_AXIOM",
+                        "canonical authoritative axiom appears more than once",
+                        row_id=source.row_id,
+                        axiom_id=axiom_id,
+                    )
+                )
+            seen_axioms.add(axiom_id)
+            try:
+                category = classify_target_category(axiom_input)
+                dispositions = derive_product_dispositions(category, product_keys)
+            except ProductDispositionError as exc:
+                issues.extend(
+                    issue(
+                        value.code,
+                        value.message,
+                        row_id=source.row_id,
+                        axiom_id=value.axiom_id or axiom_id,
+                        field=value.field,
+                    )
+                    for value in exc.issues
+                )
+                continue
+            row_axioms.append(
+                DispositionAxiomRecord(
+                    axiom_id=axiom_id,
+                    canonical_expression=nfc(axiom_input.identity.canonical_axiom),
+                    referenced_iris=referenced_iris(axiom_input),
+                    target_category=category,
+                    product_dispositions=dispositions,
+                )
+            )
+
+        row_axioms.sort(key=lambda value: value.axiom_id)
+        is_zero = not row_axioms
+        row_dispositions = derive_zero_axiom_dispositions(product_keys) if is_zero else None
+        predicate = None
+        target = None
+        if not is_zero:
+            if source.predicate_lexical is None or source.authoritative_target_lexical is None:
+                issues.append(
+                    issue(
+                        "INCOMPLETE_ZERO_AXIOM_ROW",
+                        "mapped rows require predicate and authoritative target values",
+                        row_id=source.row_id,
+                    )
+                )
+            elif canonical.predicate_iri is None:
+                issues.append(
+                    issue(
+                        "ROW_EXPRESSION_MISMATCH",
+                        "mapped canonical row lacks predicate IRI",
+                        row_id=source.row_id,
+                    )
+                )
+            else:
+                predicate = EntityReference(nfc(source.predicate_lexical), nfc(canonical.predicate_iri))
+                target = nfc(source.authoritative_target_lexical)
+        elif (
+            source.mapping_type != "explicit_blank"
+            or source.predicate_lexical is not None
+            or source.authoritative_target_lexical is not None
+            or canonical.predicate_iri is not None
+        ):
+            issues.append(
+                issue(
+                    "INCOMPLETE_ZERO_AXIOM_ROW",
+                    "zero-axiom rows must be explicit_blank with null predicate and target",
+                    row_id=source.row_id,
+                )
+            )
+
+        try:
+            coverage = coverage_classification(source.mapping_type)
+        except ProductDispositionError as exc:
+            issues.extend(
+                issue(value.code, value.message, row_id=source.row_id, field=value.field)
+                for value in exc.issues
+            )
+            continue
+        rows.append(
+            DispositionRowRecord(
+                row_id=nfc(source.row_id),
+                location=location,
+                subject=EntityReference(nfc(source.subject_lexical), nfc(canonical.subject_iri)),
+                predicate=predicate,
+                authoritative_target_lexical=target,
+                canonical_row_expression=canonical,
+                source_expression_sha256=source.source_expression_sha256,
+                mapping_type=source.mapping_type,
+                coverage_classification=coverage,
+                reasoning=nfc(source.reasoning),
+                authoritative_axioms=tuple(row_axioms),
+                row_product_dispositions=row_dispositions,
+            )
+        )
+    if issues:
+        raise ProductDispositionError(issues)
+    result_rows = tuple(sorted(rows, key=lambda value: value.row_id))
+    return DispositionDocument(
+        schema_version=SCHEMA_VERSION,
+        canonicalization_version=CANONICALIZATION_VERSION,
+        input_hashes=input_hashes,
+        product_order=product_keys,
+        summary=_build_summary(result_rows),
+        rows=result_rows,
+    )
+
+
+def _disposition_object(value: ProductDisposition) -> dict[str, object]:
+    result: dict[str, object] = {"status": nfc(value.status)}
+    if value.reason_code is not None:
+        result["reason_code"] = nfc(value.reason_code)
+    return result
+
+
+def _disposition_map_object(
+    values: tuple[tuple[str, ProductDisposition], ...],
+    product_order: tuple[str, ...],
+) -> dict[str, object]:
+    by_name = {nfc(key): value for key, value in values}
+    ordered_keys = [key for key in product_order if key in by_name]
+    ordered_keys.extend(sorted(set(by_name) - set(product_order)))
+    return {key: _disposition_object(by_name[key]) for key in ordered_keys}
+
+
+def _canonical_object(value: CanonicalRowExpression) -> dict[str, object]:
+    return {
+        "canonicalization": nfc(value.canonicalization),
+        "mapping_type": nfc(value.mapping_type),
+        "predicate_iri": None if value.predicate_iri is None else nfc(value.predicate_iri),
+        "subject_iri": nfc(value.subject_iri),
+        "target": None if value.target is None else nfc(value.target),
+    }
+
+
+def disposition_document_object(document: DispositionDocument) -> dict[str, object]:
+    hashes = document.input_hashes
+    summary = document.summary
+    product_order = tuple(nfc(key) for key in document.product_order)
+    rows = sorted(document.rows, key=lambda value: nfc(value.row_id))
+    return {
+        "schema_version": document.schema_version,
+        "canonicalization_version": nfc(document.canonicalization_version),
+        "workbook_sha256": hashes.workbook_sha256,
+        "generator_sha256": hashes.generator_sha256,
+        "row_identity_module_sha256": hashes.row_identity_module_sha256,
+        "disposition_module_sha256": hashes.disposition_module_sha256,
+        "publication_metadata_sha256": hashes.publication_metadata_sha256,
+        "product_order": list(product_order),
+        "summary": {
+            field: getattr(summary, field)
+            for field in summary.__dataclass_fields__
+        },
+        "rows": [
+            {
+                "row_id": nfc(row.row_id),
+                "location": {
+                    "worksheet": nfc(row.location.worksheet),
+                    "row": row.location.row_number,
+                },
+                "subject": {
+                    "lexical": nfc(row.subject.lexical),
+                    "iri": nfc(row.subject.iri),
+                },
+                "predicate": None
+                if row.predicate is None
+                else {
+                    "lexical": nfc(row.predicate.lexical),
+                    "iri": nfc(row.predicate.iri),
+                },
+                "authoritative_target_lexical": None
+                if row.authoritative_target_lexical is None
+                else nfc(row.authoritative_target_lexical),
+                "canonical_row_expression": _canonical_object(row.canonical_row_expression),
+                "source_expression_sha256": nfc(row.source_expression_sha256),
+                "mapping_type": nfc(row.mapping_type),
+                "coverage_classification": nfc(row.coverage_classification),
+                "reasoning": nfc(row.reasoning),
+                "authoritative_axioms": [
+                    {
+                        "axiom_id": nfc(axiom.axiom_id),
+                        "canonical_expression": nfc(axiom.canonical_expression),
+                        "referenced_iris": sorted(nfc(value) for value in axiom.referenced_iris),
+                        "target_category": nfc(axiom.target_category),
+                        "product_dispositions": _disposition_map_object(
+                            axiom.product_dispositions,
+                            product_order,
+                        ),
+                    }
+                    for axiom in sorted(
+                        row.authoritative_axioms,
+                        key=lambda value: nfc(value.axiom_id),
+                    )
+                ],
+                "row_product_dispositions": None
+                if row.row_product_dispositions is None
+                else _disposition_map_object(
+                    row.row_product_dispositions,
+                    product_order,
+                ),
+            }
+            for row in rows
+        ],
+    }
+
+
+def serialize_disposition_document(document: DispositionDocument) -> bytes:
+    """Serialize using the governed human-diffable JSON form."""
+
+    text = json.dumps(
+        disposition_document_object(document),
+        ensure_ascii=False,
+        indent=2,
+    )
+    return (text + "\n").encode("utf-8")
+
+
+TOP_LEVEL_KEYS = (
+    "schema_version",
+    "canonicalization_version",
+    "workbook_sha256",
+    "generator_sha256",
+    "row_identity_module_sha256",
+    "disposition_module_sha256",
+    "publication_metadata_sha256",
+    "product_order",
+    "summary",
+    "rows",
+)
+SUMMARY_KEYS = tuple(DispositionSummary.__dataclass_fields__)
+ROW_KEYS = (
+    "row_id",
+    "location",
+    "subject",
+    "predicate",
+    "authoritative_target_lexical",
+    "canonical_row_expression",
+    "source_expression_sha256",
+    "mapping_type",
+    "coverage_classification",
+    "reasoning",
+    "authoritative_axioms",
+    "row_product_dispositions",
+)
+AXIOM_KEYS = (
+    "axiom_id",
+    "canonical_expression",
+    "referenced_iris",
+    "target_category",
+    "product_dispositions",
+)
+
+
+def _expect_object(
+    value: object,
+    keys: tuple[str, ...],
+    field: str,
+    issues: list[ValidationIssue],
+    *,
+    row_id: str = "",
+    axiom_id: str = "",
+) -> dict[str, object]:
+    if not isinstance(value, dict):
+        issues.append(issue("WRONG_TYPE", "expected JSON object", row_id=row_id, axiom_id=axiom_id, field=field))
+        return {}
+    missing = [key for key in keys if key not in value]
+    extra = sorted(set(value) - set(keys))
+    issues.extend(
+        issue("MISSING_FIELD", f"missing required field {key!r}", row_id=row_id, axiom_id=axiom_id, field=field)
+        for key in missing
+    )
+    issues.extend(
+        issue("UNKNOWN_FIELD", f"unknown field {key!r}", row_id=row_id, axiom_id=axiom_id, field=field)
+        for key in extra
+    )
+    return value
+
+
+def _required_string(
+    value: object,
+    field: str,
+    issues: list[ValidationIssue],
+    *,
+    row_id: str = "",
+    axiom_id: str = "",
+) -> str:
+    if not isinstance(value, str):
+        issues.append(issue("WRONG_TYPE", "expected string", row_id=row_id, axiom_id=axiom_id, field=field))
+        return ""
+    return value
+
+
+def _parse_dispositions(
+    value: object,
+    field: str,
+    issues: list[ValidationIssue],
+    *,
+    row_id: str,
+    axiom_id: str = "",
+) -> tuple[tuple[str, ProductDisposition], ...]:
+    if not isinstance(value, dict):
+        issues.append(issue("WRONG_TYPE", "expected product-disposition object", row_id=row_id, axiom_id=axiom_id, field=field))
+        return ()
+    result = []
+    for product, raw in value.items():
+        if not isinstance(raw, dict):
+            issues.append(issue("WRONG_TYPE", "expected disposition object", row_id=row_id, axiom_id=axiom_id, field=f"{field}.{product}"))
+            continue
+        extra = sorted(set(raw) - {"status", "reason_code"})
+        if "status" not in raw:
+            issues.append(issue("MISSING_FIELD", "missing status", row_id=row_id, axiom_id=axiom_id, field=f"{field}.{product}"))
+        for key in extra:
+            issues.append(issue("UNKNOWN_FIELD", f"unknown field {key!r}", row_id=row_id, axiom_id=axiom_id, field=f"{field}.{product}"))
+        status = _required_string(raw.get("status"), f"{field}.{product}.status", issues, row_id=row_id, axiom_id=axiom_id)
+        reason_raw = raw.get("reason_code")
+        reason = None if reason_raw is None else _required_string(reason_raw, f"{field}.{product}.reason_code", issues, row_id=row_id, axiom_id=axiom_id)
+        result.append((str(product), ProductDisposition(status, reason)))
+    return tuple(result)
+
+
+def _parse_canonical(
+    value: object,
+    field: str,
+    issues: list[ValidationIssue],
+    row_id: str,
+) -> CanonicalRowExpression:
+    keys = ("canonicalization", "mapping_type", "predicate_iri", "subject_iri", "target")
+    raw = _expect_object(value, keys, field, issues, row_id=row_id)
+    predicate = raw.get("predicate_iri")
+    if predicate is not None and not isinstance(predicate, str):
+        issues.append(issue("WRONG_TYPE", "expected string or null", row_id=row_id, field=f"{field}.predicate_iri"))
+        predicate = None
+    target = raw.get("target")
+    if target is not None and not isinstance(target, str):
+        issues.append(issue("WRONG_TYPE", "expected string or null", row_id=row_id, field=f"{field}.target"))
+        target = None
+    return CanonicalRowExpression(
+        canonicalization=_required_string(raw.get("canonicalization"), f"{field}.canonicalization", issues, row_id=row_id),
+        mapping_type=_required_string(raw.get("mapping_type"), f"{field}.mapping_type", issues, row_id=row_id),
+        predicate_iri=predicate,
+        subject_iri=_required_string(raw.get("subject_iri"), f"{field}.subject_iri", issues, row_id=row_id),
+        target=target,
+    )
+
+
+def _parse_document(raw: object) -> DispositionDocument:
+    issues: list[ValidationIssue] = []
+    top = _expect_object(raw, TOP_LEVEL_KEYS, "document", issues)
+    product_raw = top.get("product_order")
+    if not isinstance(product_raw, list) or not all(isinstance(value, str) for value in product_raw):
+        issues.append(issue("WRONG_TYPE", "expected array of product strings", field="product_order"))
+        products: tuple[str, ...] = ()
+    else:
+        products = tuple(product_raw)
+
+    summary_raw = _expect_object(top.get("summary"), SUMMARY_KEYS, "summary", issues)
+    summary_values: dict[str, int] = {}
+    for key in SUMMARY_KEYS:
+        value = summary_raw.get(key)
+        if type(value) is not int or value < 0:
+            issues.append(issue("WRONG_TYPE", "expected nonnegative integer", field=f"summary.{key}"))
+            value = 0
+        summary_values[key] = value
+
+    rows_raw = top.get("rows")
+    if not isinstance(rows_raw, list):
+        issues.append(issue("WRONG_TYPE", "expected array", field="rows"))
+        rows_raw = []
+    rows: list[DispositionRowRecord] = []
+    for index, row_value in enumerate(rows_raw):
+        field = f"rows[{index}]"
+        row_raw = _expect_object(row_value, ROW_KEYS, field, issues)
+        row_id = _required_string(row_raw.get("row_id"), f"{field}.row_id", issues)
+        location_raw = _expect_object(row_raw.get("location"), ("worksheet", "row"), f"{field}.location", issues, row_id=row_id)
+        worksheet = nfc(
+            _required_string(
+                location_raw.get("worksheet"),
+                f"{field}.location.worksheet",
+                issues,
+                row_id=row_id,
+            )
+        )
+        row_number = location_raw.get("row")
+        if type(row_number) is not int or row_number < 1:
+            issues.append(issue("WRONG_TYPE", "expected positive integer", row_id=row_id, field=f"{field}.location.row"))
+            row_number = 1
+        subject_raw = _expect_object(row_raw.get("subject"), ("lexical", "iri"), f"{field}.subject", issues, row_id=row_id)
+        subject = EntityReference(
+            _required_string(subject_raw.get("lexical"), f"{field}.subject.lexical", issues, row_id=row_id),
+            _required_string(subject_raw.get("iri"), f"{field}.subject.iri", issues, row_id=row_id),
+        )
+        predicate_raw = row_raw.get("predicate")
+        predicate = None
+        if predicate_raw is not None:
+            predicate_object = _expect_object(predicate_raw, ("lexical", "iri"), f"{field}.predicate", issues, row_id=row_id)
+            predicate = EntityReference(
+                _required_string(predicate_object.get("lexical"), f"{field}.predicate.lexical", issues, row_id=row_id),
+                _required_string(predicate_object.get("iri"), f"{field}.predicate.iri", issues, row_id=row_id),
+            )
+        target_raw = row_raw.get("authoritative_target_lexical")
+        target = None if target_raw is None else _required_string(target_raw, f"{field}.authoritative_target_lexical", issues, row_id=row_id)
+        canonical = _parse_canonical(row_raw.get("canonical_row_expression"), f"{field}.canonical_row_expression", issues, row_id)
+
+        axioms_raw = row_raw.get("authoritative_axioms")
+        if not isinstance(axioms_raw, list):
+            issues.append(issue("WRONG_TYPE", "expected array", row_id=row_id, field=f"{field}.authoritative_axioms"))
+            axioms_raw = []
+        axioms: list[DispositionAxiomRecord] = []
+        for axiom_index, axiom_value in enumerate(axioms_raw):
+            axiom_field = f"{field}.authoritative_axioms[{axiom_index}]"
+            axiom_raw = _expect_object(axiom_value, AXIOM_KEYS, axiom_field, issues, row_id=row_id)
+            axiom_id = _required_string(axiom_raw.get("axiom_id"), f"{axiom_field}.axiom_id", issues, row_id=row_id)
+            refs_raw = axiom_raw.get("referenced_iris")
+            if not isinstance(refs_raw, list) or not all(isinstance(value, str) for value in refs_raw):
+                issues.append(issue("WRONG_TYPE", "expected array of IRI strings", row_id=row_id, axiom_id=axiom_id, field=f"{axiom_field}.referenced_iris"))
+                refs: tuple[str, ...] = ()
+            else:
+                refs = tuple(refs_raw)
+            axioms.append(
+                DispositionAxiomRecord(
+                    axiom_id=axiom_id,
+                    canonical_expression=_required_string(axiom_raw.get("canonical_expression"), f"{axiom_field}.canonical_expression", issues, row_id=row_id, axiom_id=axiom_id),
+                    referenced_iris=refs,
+                    target_category=_required_string(axiom_raw.get("target_category"), f"{axiom_field}.target_category", issues, row_id=row_id, axiom_id=axiom_id),
+                    product_dispositions=_parse_dispositions(axiom_raw.get("product_dispositions"), f"{axiom_field}.product_dispositions", issues, row_id=row_id, axiom_id=axiom_id),
+                )
+            )
+        row_dispositions_raw = row_raw.get("row_product_dispositions")
+        row_dispositions = None
+        if row_dispositions_raw is not None:
+            row_dispositions = _parse_dispositions(row_dispositions_raw, f"{field}.row_product_dispositions", issues, row_id=row_id)
+        rows.append(
+            DispositionRowRecord(
+                row_id=row_id,
+                location=RowLocation(worksheet, row_number),
+                subject=subject,
+                predicate=predicate,
+                authoritative_target_lexical=target,
+                canonical_row_expression=canonical,
+                source_expression_sha256=_required_string(row_raw.get("source_expression_sha256"), f"{field}.source_expression_sha256", issues, row_id=row_id),
+                mapping_type=_required_string(row_raw.get("mapping_type"), f"{field}.mapping_type", issues, row_id=row_id),
+                coverage_classification=_required_string(row_raw.get("coverage_classification"), f"{field}.coverage_classification", issues, row_id=row_id),
+                reasoning=_required_string(row_raw.get("reasoning"), f"{field}.reasoning", issues, row_id=row_id),
+                authoritative_axioms=tuple(axioms),
+                row_product_dispositions=row_dispositions,
+            )
+        )
+    if issues:
+        raise ProductDispositionError(issues)
+    return DispositionDocument(
+        schema_version=top.get("schema_version") if type(top.get("schema_version")) is int else 0,
+        canonicalization_version=str(top.get("canonicalization_version", "")),
+        input_hashes=RequiredInputHashes(
+            workbook_sha256=str(top.get("workbook_sha256", "")),
+            generator_sha256=str(top.get("generator_sha256", "")),
+            row_identity_module_sha256=str(top.get("row_identity_module_sha256", "")),
+            disposition_module_sha256=str(top.get("disposition_module_sha256", "")),
+            publication_metadata_sha256=str(top.get("publication_metadata_sha256", "")),
+        ),
+        product_order=products,
+        summary=DispositionSummary(**summary_values),
+        rows=tuple(rows),
+    )
+
+
+def load_disposition_document(path: str | Path) -> DispositionDocument:
+    """Load UTF-8 disposition JSON and enforce its exact governed schema."""
+
+    source = Path(path)
+    try:
+        data = source.read_bytes()
+        text = data.decode("utf-8")
+        raw = json.loads(text)
+    except OSError as exc:
+        raise ProductDispositionError(
+            [issue("DISPOSITION_IO", f"cannot read disposition document: {exc}", field=str(source))]
+        ) from exc
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise ProductDispositionError(
+            [issue("DISPOSITION_JSON_PARSE", f"cannot parse UTF-8 JSON: {exc}", field=str(source))]
+        ) from exc
+    return _parse_document(raw)
+
+
+def _validate_disposition_values(
+    values: tuple[tuple[str, ProductDisposition], ...],
+    expected: tuple[tuple[str, ProductDisposition], ...],
+    *,
+    row_id: str,
+    axiom_id: str,
+    field: str,
+) -> list[ValidationIssue]:
+    issues: list[ValidationIssue] = []
+    names = [name for name, _ in values]
+    expected_names = [name for name, _ in expected]
+    for product in sorted(set(expected_names) - set(names)):
+        issues.append(issue("MISSING_PRODUCT_DISPOSITION", f"missing product {product!r}", row_id=row_id, axiom_id=axiom_id, field=field))
+    for product in sorted(set(names) - set(expected_names)):
+        issues.append(issue("UNKNOWN_PRODUCT", f"unknown product {product!r}", row_id=row_id, axiom_id=axiom_id, field=field))
+    by_name = dict(values)
+    for product, required in expected:
+        actual = by_name.get(product)
+        if actual is None:
+            continue
+        if actual.status not in DISPOSITION_STATUSES:
+            issues.append(issue("UNKNOWN_DISPOSITION_STATUS", f"unknown status {actual.status!r}", row_id=row_id, axiom_id=axiom_id, field=f"{field}.{product}.status"))
+        if actual.reason_code is not None and actual.reason_code not in REASON_CODES:
+            issues.append(issue("INVALID_REASON_CODE", f"unknown reason code {actual.reason_code!r}", row_id=row_id, axiom_id=axiom_id, field=f"{field}.{product}.reason_code"))
+        if required.reason_code is None and actual.reason_code is not None:
+            issues.append(issue("PROHIBITED_REASON_CODE", "reason_code is prohibited for this status", row_id=row_id, axiom_id=axiom_id, field=f"{field}.{product}.reason_code"))
+        if required.reason_code is not None and actual.reason_code is None:
+            issues.append(issue("MISSING_REASON_CODE", f"expected {required.reason_code}", row_id=row_id, axiom_id=axiom_id, field=f"{field}.{product}.reason_code"))
+        elif required.reason_code is not None and actual.reason_code != required.reason_code:
+            issues.append(issue("INVALID_REASON_CODE", f"expected {required.reason_code}, got {actual.reason_code}", row_id=row_id, axiom_id=axiom_id, field=f"{field}.{product}.reason_code"))
+        if actual != required:
+            issues.append(issue("DISPOSITION_POLICY_MISMATCH", f"expected {required}, got {actual}", row_id=row_id, axiom_id=axiom_id, field=f"{field}.{product}"))
+    return issues
+
+
+def validate_disposition_document(
+    document: DispositionDocument,
+    expected_row_inputs: Iterable[DispositionRowInput],
+    publication_metadata: PublicationMetadata,
+    expected_hashes: RequiredInputHashes,
+) -> tuple[ValidationIssue, ...]:
+    """Reconcile a disposition document with structured authoritative inputs."""
+
+    issues: list[ValidationIssue] = []
+    try:
+        expected = build_disposition_document(
+            expected_row_inputs,
+            publication_metadata,
+            expected_hashes,
+        )
+    except ProductDispositionError as exc:
+        return exc.issues
+
+    if document.schema_version != SCHEMA_VERSION:
+        issues.append(issue("SCHEMA_VERSION", f"expected {SCHEMA_VERSION}, got {document.schema_version}", field="schema_version"))
+    if document.canonicalization_version != CANONICALIZATION_VERSION:
+        issues.append(issue("ROW_EXPRESSION_MISMATCH", f"expected {CANONICALIZATION_VERSION}, got {document.canonicalization_version}", field="canonicalization_version"))
+    hash_codes = {
+        "workbook_sha256": "STALE_WORKBOOK",
+        "generator_sha256": "STALE_GENERATOR",
+        "row_identity_module_sha256": "STALE_ROW_IDENTITY_MODULE",
+        "disposition_module_sha256": "STALE_DISPOSITION_MODULE",
+        "publication_metadata_sha256": "STALE_PUBLICATION_METADATA",
+    }
+    for field, code in hash_codes.items():
+        actual = getattr(document.input_hashes, field)
+        required = getattr(expected_hashes, field)
+        if actual != required:
+            issues.append(issue(code, f"expected {required}, got {actual}", field=field))
+    if document.product_order != expected.product_order:
+        issues.append(issue("PRODUCT_ORDER_MISMATCH", f"expected {expected.product_order}, got {document.product_order}", field="product_order"))
+
+    actual_rows: dict[str, DispositionRowRecord] = {}
+    for row in document.rows:
+        if row.row_id in actual_rows:
+            issues.append(issue("DUPLICATE_DISPOSITION_ROW", "RowID appears more than once", row_id=row.row_id))
+        actual_rows[row.row_id] = row
+    expected_rows = {row.row_id: row for row in expected.rows}
+    for row_id in sorted(set(expected_rows) - set(actual_rows)):
+        issues.append(issue("MISSING_DISPOSITION_ROW", "governed row is absent", row_id=row_id))
+    for row_id in sorted(set(actual_rows) - set(expected_rows)):
+        issues.append(issue("UNKNOWN_DISPOSITION_ROW", "document row is not governed", row_id=row_id))
+
+    for row_id in sorted(set(actual_rows) & set(expected_rows)):
+        actual = actual_rows[row_id]
+        required = expected_rows[row_id]
+        if actual.location != required.location:
+            issues.append(issue("ROW_LOCATION_MISMATCH", f"expected {required.location.text}, got {actual.location.text}", row_id=row_id, field="location"))
+        if actual.canonical_row_expression != required.canonical_row_expression:
+            issues.append(issue("ROW_EXPRESSION_MISMATCH", "canonical row expression differs", row_id=row_id, field="canonical_row_expression"))
+        if actual.source_expression_sha256 != required.source_expression_sha256:
+            issues.append(issue("EXPRESSION_HASH_MISMATCH", f"expected {required.source_expression_sha256}, got {actual.source_expression_sha256}", row_id=row_id, field="source_expression_sha256"))
+        for field in (
+            "subject",
+            "predicate",
+            "authoritative_target_lexical",
+            "mapping_type",
+            "coverage_classification",
+            "reasoning",
+        ):
+            if getattr(actual, field) != getattr(required, field):
+                issues.append(issue("ROW_EXPRESSION_MISMATCH", "row value differs from governed input", row_id=row_id, field=field))
+
+        actual_axioms: dict[str, DispositionAxiomRecord] = {}
+        for axiom in actual.authoritative_axioms:
+            if axiom.axiom_id in actual_axioms:
+                issues.append(issue("UNKNOWN_AUTHORITATIVE_AXIOM", "axiom ID appears more than once", row_id=row_id, axiom_id=axiom.axiom_id))
+            actual_axioms[axiom.axiom_id] = axiom
+        required_axioms = {axiom.axiom_id: axiom for axiom in required.authoritative_axioms}
+        for axiom_id in sorted(set(required_axioms) - set(actual_axioms)):
+            issues.append(issue("MISSING_AUTHORITATIVE_AXIOM", "expected axiom is absent", row_id=row_id, axiom_id=axiom_id))
+        for axiom_id in sorted(set(actual_axioms) - set(required_axioms)):
+            issues.append(issue("UNKNOWN_AUTHORITATIVE_AXIOM", "unexpected axiom is present", row_id=row_id, axiom_id=axiom_id))
+        for axiom_id in sorted(set(actual_axioms) & set(required_axioms)):
+            axiom = actual_axioms[axiom_id]
+            expected_axiom = required_axioms[axiom_id]
+            match = AXIOM_ID_RE.fullmatch(axiom.axiom_id)
+            computed = sha256_text(axiom.canonical_expression)
+            if match is None or match.group(1) != computed:
+                issues.append(issue("AXIOM_ID_MISMATCH", f"canonical expression hashes to sha256:{computed}", row_id=row_id, axiom_id=axiom_id))
+            if axiom.canonical_expression != expected_axiom.canonical_expression:
+                issues.append(issue("AXIOM_EXPRESSION_MISMATCH", "canonical axiom expression differs", row_id=row_id, axiom_id=axiom_id))
+            if tuple(sorted(axiom.referenced_iris)) != expected_axiom.referenced_iris:
+                issues.append(issue("REFERENCED_IRI_MISMATCH", f"expected {expected_axiom.referenced_iris}, got {axiom.referenced_iris}", row_id=row_id, axiom_id=axiom_id))
+            if axiom.target_category not in TARGET_CATEGORIES:
+                issues.append(issue("UNKNOWN_TARGET_CATEGORY", f"unknown category {axiom.target_category!r}", row_id=row_id, axiom_id=axiom_id))
+            if axiom.target_category != expected_axiom.target_category:
+                issues.append(issue("TARGET_CATEGORY_MISMATCH", f"expected {expected_axiom.target_category}, got {axiom.target_category}", row_id=row_id, axiom_id=axiom_id))
+            issues.extend(_validate_disposition_values(axiom.product_dispositions, expected_axiom.product_dispositions, row_id=row_id, axiom_id=axiom_id, field="product_dispositions"))
+        if not actual.authoritative_axioms:
+            if actual.mapping_type != "explicit_blank" or actual.coverage_classification != "explicitly_unmapped" or actual.predicate is not None or actual.authoritative_target_lexical is not None or actual.row_product_dispositions is None:
+                issues.append(issue("INCOMPLETE_ZERO_AXIOM_ROW", "zero-axiom row fields are incomplete", row_id=row_id))
+            elif required.row_product_dispositions is not None:
+                issues.extend(_validate_disposition_values(actual.row_product_dispositions, required.row_product_dispositions, row_id=row_id, axiom_id="", field="row_product_dispositions"))
+        elif actual.row_product_dispositions is not None:
+            issues.append(issue("INCOMPLETE_ZERO_AXIOM_ROW", "mapped row must use axiom-level dispositions", row_id=row_id, field="row_product_dispositions"))
+
+    if document.summary != expected.summary:
+        for field in SUMMARY_KEYS:
+            actual = getattr(document.summary, field)
+            required = getattr(expected.summary, field)
+            if actual != required:
+                issues.append(issue("SUMMARY_MISMATCH", f"expected {required}, got {actual}", field=f"summary.{field}"))
+    return sort_issues(issues)
+
+
+def validate_disposition_file(
+    path: str | Path,
+    expected_row_inputs: Iterable[DispositionRowInput],
+    publication_metadata: PublicationMetadata,
+    expected_hashes: RequiredInputHashes,
+) -> tuple[DispositionDocument, tuple[ValidationIssue, ...]]:
+    """Load, reconcile, and require canonical serialized bytes."""
+
+    source = Path(path)
+    document = load_disposition_document(source)
+    issues = list(
+        validate_disposition_document(
+            document,
+            expected_row_inputs,
+            publication_metadata,
+            expected_hashes,
+        )
+    )
+    if source.read_bytes() != serialize_disposition_document(document):
+        issues.append(
+            issue(
+                "NONCANONICAL_SERIALIZATION",
+                "loaded bytes differ from canonical disposition serialization",
+                field=str(source),
+            )
+        )
+    return document, sort_issues(issues)

--- a/tools/run_validation_suite.py
+++ b/tools/run_validation_suite.py
@@ -59,6 +59,7 @@ def compile_check() -> StepResult:
             "tools/test_instance_data.py",
             "tools/compare_mappings.py",
             "tools/coms_row_identity.py",
+            "tools/product_dispositions.py",
             "tools/generate_mapping_from_coms.py",
             "tools/check_coms_mapping.py",
             "tools/watch_coms_mapping.py",
@@ -66,6 +67,7 @@ def compile_check() -> StepResult:
             "tools/check_publication_metadata.py",
             "tests/test_generate_mapping_from_coms.py",
             "tests/test_coms_row_identity.py",
+            "tests/test_product_dispositions.py",
             "tests/test_publication_metadata.py",
         ],
     )
@@ -134,6 +136,22 @@ def main() -> int:
                     "tests",
                     "-p",
                     "test_coms_row_identity.py",
+                ],
+            )
+        )
+    if results[-1].passed:
+        results.append(
+            run_command(
+                "COMS product-disposition focused tests",
+                [
+                    sys.executable,
+                    "-m",
+                    "unittest",
+                    "discover",
+                    "-s",
+                    "tests",
+                    "-p",
+                    "test_product_dispositions.py",
                 ],
             )
         )

--- a/tools/watch_coms_mapping.py
+++ b/tools/watch_coms_mapping.py
@@ -22,6 +22,7 @@ MAINTAINED_OUTPUTS = (
     REPO_ROOT / "reports/coms-generation-validation.md",
     REPO_ROOT / "reports/coms-source-term-coverage.md",
     REPO_ROOT / "reports/coms-vs-pre-coms-legacy-diff.md",
+    REPO_ROOT / "reports/coms-product-dispositions.json",
 )
 POLL_SECONDS = 1.0
 DEBOUNCE_SECONDS = 1.5

--- a/tools/workflow_check.py
+++ b/tools/workflow_check.py
@@ -24,12 +24,14 @@ COMPILE_COMMAND = [
     "tools/test_instance_data.py",
     "tools/compare_mappings.py",
     "tools/coms_row_identity.py",
+    "tools/product_dispositions.py",
     "tools/check_coms_mapping.py",
     "tools/watch_coms_mapping.py",
     "tools/publication_metadata.py",
     "tools/check_publication_metadata.py",
     "tests/test_generate_mapping_from_coms.py",
     "tests/test_coms_row_identity.py",
+    "tests/test_product_dispositions.py",
     "tests/test_publication_metadata.py",
     "tools/workflow_check.py",
 ]
@@ -187,6 +189,7 @@ def mapping_change_scope(state: WorkflowState) -> None:
         "reports/mapping-consistency-audit.md",
         "reports/mapping-consistency-audit.csv",
         "reports/elk-instance-mapping-entailments.md",
+        "reports/coms-product-dispositions.json",
     }
     unexpected = [
         path


### PR DESCRIPTION
# Add COMS product disposition accounting

## Changed files

- Makefile
- README.md
- reports/coms-automatic-validation-setup.md
- reports/coms-generation-validation.md
- reports/coms-product-dispositions.json
- tests/test_generate_mapping_from_coms.py
- tests/test_product_dispositions.py
- tools/check_coms_mapping.py
- tools/generate_mapping_from_coms.py
- tools/product_dispositions.py
- tools/run_validation_suite.py
- tools/watch_coms_mapping.py
- tools/workflow_check.py

## Validation

- Human gate required: confirm validation output before merge.
