### PR TITLE
Generate strict BFO mapping

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: validate validate-write audit-write legacy-audit-write compile check check-coms check-coms-row-identities check-coms-product-dispositions check-alignment-core check-publication-metadata watch-coms coms-status post-merge-check status diffstat
+.PHONY: validate validate-write audit-write legacy-audit-write compile check check-coms check-coms-row-identities check-coms-product-dispositions check-alignment-core check-strict-bfo-mapping check-publication-metadata watch-coms coms-status post-merge-check status diffstat
 
 validate:
 	python tools/run_validation_suite.py
@@ -34,6 +34,7 @@ compile:
 		tests/test_coms_row_identity.py \
 		tests/test_product_dispositions.py \
 		tests/test_modular_products.py \
+		tests/test_strict_bfo_mapping.py \
 		tests/test_publication_metadata.py \
 		tools/workflow_check.py
 
@@ -55,6 +56,10 @@ check-coms-product-dispositions:
 
 check-alignment-core:
 	python -m unittest discover -s tests -p 'test_modular_products.py'
+	python tools/check_coms_mapping.py --check-only
+
+check-strict-bfo-mapping:
+	python -m unittest discover -s tests -p 'test_strict_bfo_mapping.py'
 	python tools/check_coms_mapping.py --check-only
 
 watch-coms:

--- a/README.md
+++ b/README.md
@@ -43,7 +43,13 @@ The artifact classifies axioms as target-neutral, BFO-bearing, CCO-bearing, or m
 
 `releases/current-ssn-sosa/ssn-sosa-alignment-core.ttl` is the maintained authoritative development artifact for the 29 target-neutral governed COMS axioms. It is generated from the same in-memory COMS identities and product dispositions as the integrated root, contains 15 domain and 14 range axioms, and imports no source, target, or project ontology. The integrated `SSN2BFO.ttl` remains the complete standalone authoritative product; the alignment core does not replace it.
 
-The development artifact has only its governed stable ontology IRI and ontology declaration. Complete publication metadata, formal release identity, the strict BFO mapping, BFO projection, CCO extension, and transformation rules remain unimplemented. Run its focused tests and the shared nonmutating six-output transaction with `make check-alignment-core`.
+The development artifact has only its governed stable ontology IRI and ontology declaration. Complete publication metadata and formal release identity remain deferred. Run its focused tests and the shared nonmutating transaction with `make check-alignment-core`.
+
+### Strict BFO mapping
+
+`releases/current-ssn-sosa/ssn-sosa-bfo-mapping.ttl` is the maintained authoritative development artifact for the 19 unchanged BFO-bearing governed COMS axioms. It imports only the alignment core, so the locally resolved project-module closure contains 48 governed axioms: 19 direct strict-BFO axioms plus 29 target-neutral core axioms. The 57 CCO-bearing or mixed mappings remain explicitly deferred because no transformation or weakened projection is approved.
+
+The published strict graph contains no CCO or RO logical terms and does not import an external ontology. Validation reasons over an explicit, network-free pinned merged CCO/BFO closure that includes `imports/cco.ttl`; this validation dependency does not make CCO part of the published strict graph and is not mapping authority. Full publication metadata, formal release identity, the BFO projection, CCO extension, and transformation rules remain deferred. The old `releases/current-ssn-sosa/ssn-sosa-bfo-directmappings.ttl` file remains inactive, non-authoritative scaffolding pending complete modular-product migration. Run `make check-strict-bfo-mapping` for the focused tests and shared nonmutating seven-output transaction.
 
 ## Validation environment
 

--- a/releases/current-ssn-sosa/ssn-sosa-bfo-mapping.ttl
+++ b/releases/current-ssn-sosa/ssn-sosa-bfo-mapping.ttl
@@ -1,0 +1,157 @@
+# GENERATED FILE: produced from mappings/SSN2BFO-COMS.xlsx and governed product dispositions; do not edit directly.
+
+@prefix bfo: <http://purl.obolibrary.org/obo/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sampling: <http://www.w3.org/ns/sosa/sampling/> .
+@prefix sosa: <http://www.w3.org/ns/sosa/> .
+@prefix ssn: <http://www.w3.org/ns/ssn/> .
+@prefix ssn-system: <http://www.w3.org/ns/ssn/systems/> .
+
+<http://www.sks.ai/SSN2BFO/current-ssn-sosa/bfo-mapping> rdf:type owl:Ontology ;
+    owl:imports <http://www.sks.ai/SSN2BFO/current-ssn-sosa/alignment-core> .
+
+<http://www.w3.org/ns/ssn/isPropertyOf> rdfs:domain _:a0caeec31770247fe2efeb443e85fefe9b4e1648a7d9569adc35d2972b77682b1_target .
+_:a0caeec31770247fe2efeb443e85fefe9b4e1648a7d9569adc35d2972b77682b1_target rdf:type owl:Class .
+_:a0caeec31770247fe2efeb443e85fefe9b4e1648a7d9569adc35d2972b77682b1_target owl:unionOf _:a0caeec31770247fe2efeb443e85fefe9b4e1648a7d9569adc35d2972b77682b1_target_list_0 .
+_:a0caeec31770247fe2efeb443e85fefe9b4e1648a7d9569adc35d2972b77682b1_target_list_0 rdf:first <http://purl.obolibrary.org/obo/BFO_0000020> .
+_:a0caeec31770247fe2efeb443e85fefe9b4e1648a7d9569adc35d2972b77682b1_target_list_0 rdf:rest _:a0caeec31770247fe2efeb443e85fefe9b4e1648a7d9569adc35d2972b77682b1_target_list_1 .
+_:a0caeec31770247fe2efeb443e85fefe9b4e1648a7d9569adc35d2972b77682b1_target_list_1 rdf:first <http://purl.obolibrary.org/obo/BFO_0000144> .
+_:a0caeec31770247fe2efeb443e85fefe9b4e1648a7d9569adc35d2972b77682b1_target_list_1 rdf:rest rdf:nil .
+
+<http://www.w3.org/ns/ssn/System> owl:equivalentClass _:a0db60d0e9764151246aa7f88574dbc9fb112eecb2191d00822192f51ec298678_target .
+_:a0db60d0e9764151246aa7f88574dbc9fb112eecb2191d00822192f51ec298678_target rdf:type owl:Class .
+_:a0db60d0e9764151246aa7f88574dbc9fb112eecb2191d00822192f51ec298678_target owl:intersectionOf _:a0db60d0e9764151246aa7f88574dbc9fb112eecb2191d00822192f51ec298678_target_list_0 .
+_:a0db60d0e9764151246aa7f88574dbc9fb112eecb2191d00822192f51ec298678_target_list_0 rdf:first <http://purl.obolibrary.org/obo/BFO_0000040> .
+_:a0db60d0e9764151246aa7f88574dbc9fb112eecb2191d00822192f51ec298678_target_list_0 rdf:rest _:a0db60d0e9764151246aa7f88574dbc9fb112eecb2191d00822192f51ec298678_target_list_1 .
+_:a0db60d0e9764151246aa7f88574dbc9fb112eecb2191d00822192f51ec298678_target_list_1 rdf:first _:a0db60d0e9764151246aa7f88574dbc9fb112eecb2191d00822192f51ec298678_target_child_1 .
+_:a0db60d0e9764151246aa7f88574dbc9fb112eecb2191d00822192f51ec298678_target_list_1 rdf:rest rdf:nil .
+_:a0db60d0e9764151246aa7f88574dbc9fb112eecb2191d00822192f51ec298678_target_child_1 rdf:type owl:Restriction .
+_:a0db60d0e9764151246aa7f88574dbc9fb112eecb2191d00822192f51ec298678_target_child_1 owl:onProperty <http://www.w3.org/ns/ssn/implements> .
+_:a0db60d0e9764151246aa7f88574dbc9fb112eecb2191d00822192f51ec298678_target_child_1 owl:someValuesFrom <http://www.w3.org/ns/sosa/Procedure> .
+
+<http://www.w3.org/ns/ssn/hasDeployment> rdfs:subPropertyOf <http://purl.obolibrary.org/obo/BFO_0000056> .
+
+<http://www.w3.org/ns/ssn/deployedOnPlatform> rdfs:subPropertyOf <http://purl.obolibrary.org/obo/BFO_0000057> .
+
+<http://www.w3.org/ns/sosa/phenomenonTime> rdfs:subPropertyOf <http://purl.obolibrary.org/obo/BFO_0000199> .
+
+<http://www.w3.org/ns/ssn/deployedSystem> rdfs:subPropertyOf <http://purl.obolibrary.org/obo/BFO_0000057> .
+
+<http://www.w3.org/ns/sosa/isHostedBy> owl:propertyChainAxiom _:a47859e2cfd5df437d1f55c83560793ab22f035de9b829ccdedcc4d3118cc4f3e_chain_list_0 .
+_:a47859e2cfd5df437d1f55c83560793ab22f035de9b829ccdedcc4d3118cc4f3e_chain_list_0 rdf:first <http://purl.obolibrary.org/obo/BFO_0000056> .
+_:a47859e2cfd5df437d1f55c83560793ab22f035de9b829ccdedcc4d3118cc4f3e_chain_list_0 rdf:rest _:a47859e2cfd5df437d1f55c83560793ab22f035de9b829ccdedcc4d3118cc4f3e_chain_list_1 .
+_:a47859e2cfd5df437d1f55c83560793ab22f035de9b829ccdedcc4d3118cc4f3e_chain_list_1 rdf:first <http://purl.obolibrary.org/obo/BFO_0000055> .
+_:a47859e2cfd5df437d1f55c83560793ab22f035de9b829ccdedcc4d3118cc4f3e_chain_list_1 rdf:rest _:a47859e2cfd5df437d1f55c83560793ab22f035de9b829ccdedcc4d3118cc4f3e_chain_list_2 .
+_:a47859e2cfd5df437d1f55c83560793ab22f035de9b829ccdedcc4d3118cc4f3e_chain_list_2 rdf:first <http://purl.obolibrary.org/obo/BFO_0000197> .
+_:a47859e2cfd5df437d1f55c83560793ab22f035de9b829ccdedcc4d3118cc4f3e_chain_list_2 rdf:rest rdf:nil .
+
+<http://www.w3.org/ns/sosa/Platform> owl:equivalentClass _:a480ce3257f6b1baaaacee7b06ce730cdf63a7dd14c16b4a1bedc09597a5d96ef_target .
+_:a480ce3257f6b1baaaacee7b06ce730cdf63a7dd14c16b4a1bedc09597a5d96ef_target rdf:type owl:Class .
+_:a480ce3257f6b1baaaacee7b06ce730cdf63a7dd14c16b4a1bedc09597a5d96ef_target owl:intersectionOf _:a480ce3257f6b1baaaacee7b06ce730cdf63a7dd14c16b4a1bedc09597a5d96ef_target_list_0 .
+_:a480ce3257f6b1baaaacee7b06ce730cdf63a7dd14c16b4a1bedc09597a5d96ef_target_list_0 rdf:first <http://purl.obolibrary.org/obo/BFO_0000040> .
+_:a480ce3257f6b1baaaacee7b06ce730cdf63a7dd14c16b4a1bedc09597a5d96ef_target_list_0 rdf:rest _:a480ce3257f6b1baaaacee7b06ce730cdf63a7dd14c16b4a1bedc09597a5d96ef_target_list_1 .
+_:a480ce3257f6b1baaaacee7b06ce730cdf63a7dd14c16b4a1bedc09597a5d96ef_target_list_1 rdf:first _:a480ce3257f6b1baaaacee7b06ce730cdf63a7dd14c16b4a1bedc09597a5d96ef_target_child_1 .
+_:a480ce3257f6b1baaaacee7b06ce730cdf63a7dd14c16b4a1bedc09597a5d96ef_target_list_1 rdf:rest rdf:nil .
+_:a480ce3257f6b1baaaacee7b06ce730cdf63a7dd14c16b4a1bedc09597a5d96ef_target_child_1 rdf:type owl:Restriction .
+_:a480ce3257f6b1baaaacee7b06ce730cdf63a7dd14c16b4a1bedc09597a5d96ef_target_child_1 owl:onProperty <http://www.w3.org/ns/sosa/hosts> .
+_:a480ce3257f6b1baaaacee7b06ce730cdf63a7dd14c16b4a1bedc09597a5d96ef_target_child_1 owl:someValuesFrom <http://www.w3.org/ns/ssn/System> .
+
+<http://www.w3.org/ns/ssn/systems/hasOperatingProperty> rdfs:subPropertyOf <http://purl.obolibrary.org/obo/BFO_0000194> .
+
+<http://www.w3.org/ns/sosa/ObservableProperty> rdfs:subClassOf _:a5606980322dc337a4e5d0eb2daef2e5acbba7ee42a782247375fcf3f39d12e00_target .
+_:a5606980322dc337a4e5d0eb2daef2e5acbba7ee42a782247375fcf3f39d12e00_target rdf:type owl:Class .
+_:a5606980322dc337a4e5d0eb2daef2e5acbba7ee42a782247375fcf3f39d12e00_target owl:unionOf _:a5606980322dc337a4e5d0eb2daef2e5acbba7ee42a782247375fcf3f39d12e00_target_list_0 .
+_:a5606980322dc337a4e5d0eb2daef2e5acbba7ee42a782247375fcf3f39d12e00_target_list_0 rdf:first _:a5606980322dc337a4e5d0eb2daef2e5acbba7ee42a782247375fcf3f39d12e00_target_child_0 .
+_:a5606980322dc337a4e5d0eb2daef2e5acbba7ee42a782247375fcf3f39d12e00_target_list_0 rdf:rest _:a5606980322dc337a4e5d0eb2daef2e5acbba7ee42a782247375fcf3f39d12e00_target_list_1 .
+_:a5606980322dc337a4e5d0eb2daef2e5acbba7ee42a782247375fcf3f39d12e00_target_list_1 rdf:first _:a5606980322dc337a4e5d0eb2daef2e5acbba7ee42a782247375fcf3f39d12e00_target_child_1 .
+_:a5606980322dc337a4e5d0eb2daef2e5acbba7ee42a782247375fcf3f39d12e00_target_list_1 rdf:rest rdf:nil .
+_:a5606980322dc337a4e5d0eb2daef2e5acbba7ee42a782247375fcf3f39d12e00_target_child_0 rdf:type owl:Class .
+_:a5606980322dc337a4e5d0eb2daef2e5acbba7ee42a782247375fcf3f39d12e00_target_child_0 owl:intersectionOf _:a5606980322dc337a4e5d0eb2daef2e5acbba7ee42a782247375fcf3f39d12e00_target_child_0_list_0 .
+_:a5606980322dc337a4e5d0eb2daef2e5acbba7ee42a782247375fcf3f39d12e00_target_child_0_list_0 rdf:first <http://purl.obolibrary.org/obo/BFO_0000020> .
+_:a5606980322dc337a4e5d0eb2daef2e5acbba7ee42a782247375fcf3f39d12e00_target_child_0_list_0 rdf:rest _:a5606980322dc337a4e5d0eb2daef2e5acbba7ee42a782247375fcf3f39d12e00_target_child_0_list_1 .
+_:a5606980322dc337a4e5d0eb2daef2e5acbba7ee42a782247375fcf3f39d12e00_target_child_0_list_1 rdf:first _:a5606980322dc337a4e5d0eb2daef2e5acbba7ee42a782247375fcf3f39d12e00_target_child_0_child_1 .
+_:a5606980322dc337a4e5d0eb2daef2e5acbba7ee42a782247375fcf3f39d12e00_target_child_0_list_1 rdf:rest rdf:nil .
+_:a5606980322dc337a4e5d0eb2daef2e5acbba7ee42a782247375fcf3f39d12e00_target_child_0_child_1 rdf:type owl:Restriction .
+_:a5606980322dc337a4e5d0eb2daef2e5acbba7ee42a782247375fcf3f39d12e00_target_child_0_child_1 owl:onProperty <http://purl.obolibrary.org/obo/BFO_0000197> .
+_:a5606980322dc337a4e5d0eb2daef2e5acbba7ee42a782247375fcf3f39d12e00_target_child_0_child_1 owl:someValuesFrom <http://www.w3.org/ns/sosa/FeatureOfInterest> .
+_:a5606980322dc337a4e5d0eb2daef2e5acbba7ee42a782247375fcf3f39d12e00_target_child_1 rdf:type owl:Class .
+_:a5606980322dc337a4e5d0eb2daef2e5acbba7ee42a782247375fcf3f39d12e00_target_child_1 owl:intersectionOf _:a5606980322dc337a4e5d0eb2daef2e5acbba7ee42a782247375fcf3f39d12e00_target_child_1_list_0 .
+_:a5606980322dc337a4e5d0eb2daef2e5acbba7ee42a782247375fcf3f39d12e00_target_child_1_list_0 rdf:first <http://purl.obolibrary.org/obo/BFO_0000144> .
+_:a5606980322dc337a4e5d0eb2daef2e5acbba7ee42a782247375fcf3f39d12e00_target_child_1_list_0 rdf:rest _:a5606980322dc337a4e5d0eb2daef2e5acbba7ee42a782247375fcf3f39d12e00_target_child_1_list_1 .
+_:a5606980322dc337a4e5d0eb2daef2e5acbba7ee42a782247375fcf3f39d12e00_target_child_1_list_1 rdf:first _:a5606980322dc337a4e5d0eb2daef2e5acbba7ee42a782247375fcf3f39d12e00_target_child_1_child_1 .
+_:a5606980322dc337a4e5d0eb2daef2e5acbba7ee42a782247375fcf3f39d12e00_target_child_1_list_1 rdf:rest rdf:nil .
+_:a5606980322dc337a4e5d0eb2daef2e5acbba7ee42a782247375fcf3f39d12e00_target_child_1_child_1 rdf:type owl:Restriction .
+_:a5606980322dc337a4e5d0eb2daef2e5acbba7ee42a782247375fcf3f39d12e00_target_child_1_child_1 owl:onProperty <http://purl.obolibrary.org/obo/BFO_0000132> .
+_:a5606980322dc337a4e5d0eb2daef2e5acbba7ee42a782247375fcf3f39d12e00_target_child_1_child_1 owl:someValuesFrom <http://www.w3.org/ns/sosa/FeatureOfInterest> .
+
+<http://www.w3.org/ns/ssn/hasProperty> rdfs:range _:a6dfa77b04dfaea343d0a8767e6467c603eafddf10395ff40ac7416f52c7fd4d4_target .
+_:a6dfa77b04dfaea343d0a8767e6467c603eafddf10395ff40ac7416f52c7fd4d4_target rdf:type owl:Class .
+_:a6dfa77b04dfaea343d0a8767e6467c603eafddf10395ff40ac7416f52c7fd4d4_target owl:unionOf _:a6dfa77b04dfaea343d0a8767e6467c603eafddf10395ff40ac7416f52c7fd4d4_target_list_0 .
+_:a6dfa77b04dfaea343d0a8767e6467c603eafddf10395ff40ac7416f52c7fd4d4_target_list_0 rdf:first <http://purl.obolibrary.org/obo/BFO_0000020> .
+_:a6dfa77b04dfaea343d0a8767e6467c603eafddf10395ff40ac7416f52c7fd4d4_target_list_0 rdf:rest _:a6dfa77b04dfaea343d0a8767e6467c603eafddf10395ff40ac7416f52c7fd4d4_target_list_1 .
+_:a6dfa77b04dfaea343d0a8767e6467c603eafddf10395ff40ac7416f52c7fd4d4_target_list_1 rdf:first <http://purl.obolibrary.org/obo/BFO_0000144> .
+_:a6dfa77b04dfaea343d0a8767e6467c603eafddf10395ff40ac7416f52c7fd4d4_target_list_1 rdf:rest rdf:nil .
+
+<http://www.w3.org/ns/sosa/hosts> owl:propertyChainAxiom _:a90d2b3a965084a150dcd254003bbdd2e5d706d8dd1b7a941c44e44ee2ea1737e_chain_list_0 .
+_:a90d2b3a965084a150dcd254003bbdd2e5d706d8dd1b7a941c44e44ee2ea1737e_chain_list_0 rdf:first <http://purl.obolibrary.org/obo/BFO_0000196> .
+_:a90d2b3a965084a150dcd254003bbdd2e5d706d8dd1b7a941c44e44ee2ea1737e_chain_list_0 rdf:rest _:a90d2b3a965084a150dcd254003bbdd2e5d706d8dd1b7a941c44e44ee2ea1737e_chain_list_1 .
+_:a90d2b3a965084a150dcd254003bbdd2e5d706d8dd1b7a941c44e44ee2ea1737e_chain_list_1 rdf:first <http://purl.obolibrary.org/obo/BFO_0000054> .
+_:a90d2b3a965084a150dcd254003bbdd2e5d706d8dd1b7a941c44e44ee2ea1737e_chain_list_1 rdf:rest _:a90d2b3a965084a150dcd254003bbdd2e5d706d8dd1b7a941c44e44ee2ea1737e_chain_list_2 .
+_:a90d2b3a965084a150dcd254003bbdd2e5d706d8dd1b7a941c44e44ee2ea1737e_chain_list_2 rdf:first <http://purl.obolibrary.org/obo/BFO_0000057> .
+_:a90d2b3a965084a150dcd254003bbdd2e5d706d8dd1b7a941c44e44ee2ea1737e_chain_list_2 rdf:rest rdf:nil .
+
+<http://www.w3.org/ns/ssn/systems/hasSystemProperty> rdfs:subPropertyOf <http://purl.obolibrary.org/obo/BFO_0000194> .
+
+<http://www.w3.org/ns/ssn/hasSubSystem> rdfs:subPropertyOf <http://purl.obolibrary.org/obo/BFO_0000178> .
+
+<http://www.w3.org/ns/ssn/systems/hasSurvivalProperty> rdfs:subPropertyOf <http://purl.obolibrary.org/obo/BFO_0000194> .
+
+<http://www.w3.org/ns/ssn/inDeployment> rdfs:subPropertyOf <http://purl.obolibrary.org/obo/BFO_0000056> .
+
+<http://www.w3.org/ns/ssn/Property> owl:equivalentClass _:ae97401fddd65d2c240938d965cb3ecb82f52b396f7fbdc7ccee0de7edf3ff74b_target .
+_:ae97401fddd65d2c240938d965cb3ecb82f52b396f7fbdc7ccee0de7edf3ff74b_target rdf:type owl:Class .
+_:ae97401fddd65d2c240938d965cb3ecb82f52b396f7fbdc7ccee0de7edf3ff74b_target owl:unionOf _:ae97401fddd65d2c240938d965cb3ecb82f52b396f7fbdc7ccee0de7edf3ff74b_target_list_0 .
+_:ae97401fddd65d2c240938d965cb3ecb82f52b396f7fbdc7ccee0de7edf3ff74b_target_list_0 rdf:first <http://purl.obolibrary.org/obo/BFO_0000020> .
+_:ae97401fddd65d2c240938d965cb3ecb82f52b396f7fbdc7ccee0de7edf3ff74b_target_list_0 rdf:rest _:ae97401fddd65d2c240938d965cb3ecb82f52b396f7fbdc7ccee0de7edf3ff74b_target_list_1 .
+_:ae97401fddd65d2c240938d965cb3ecb82f52b396f7fbdc7ccee0de7edf3ff74b_target_list_1 rdf:first <http://purl.obolibrary.org/obo/BFO_0000144> .
+_:ae97401fddd65d2c240938d965cb3ecb82f52b396f7fbdc7ccee0de7edf3ff74b_target_list_1 rdf:rest rdf:nil .
+
+<http://www.w3.org/ns/sosa/FeatureOfInterest> rdfs:subClassOf _:aebc5a554a5a02d96a177a4905b1f58369c2a1b3cb0c5e952b40208fd3d70f720_target .
+_:aebc5a554a5a02d96a177a4905b1f58369c2a1b3cb0c5e952b40208fd3d70f720_target rdf:type owl:Class .
+_:aebc5a554a5a02d96a177a4905b1f58369c2a1b3cb0c5e952b40208fd3d70f720_target owl:unionOf _:aebc5a554a5a02d96a177a4905b1f58369c2a1b3cb0c5e952b40208fd3d70f720_target_list_0 .
+_:aebc5a554a5a02d96a177a4905b1f58369c2a1b3cb0c5e952b40208fd3d70f720_target_list_0 rdf:first <http://purl.obolibrary.org/obo/BFO_0000020> .
+_:aebc5a554a5a02d96a177a4905b1f58369c2a1b3cb0c5e952b40208fd3d70f720_target_list_0 rdf:rest _:aebc5a554a5a02d96a177a4905b1f58369c2a1b3cb0c5e952b40208fd3d70f720_target_list_1 .
+_:aebc5a554a5a02d96a177a4905b1f58369c2a1b3cb0c5e952b40208fd3d70f720_target_list_1 rdf:first <http://purl.obolibrary.org/obo/BFO_0000144> .
+_:aebc5a554a5a02d96a177a4905b1f58369c2a1b3cb0c5e952b40208fd3d70f720_target_list_1 rdf:rest _:aebc5a554a5a02d96a177a4905b1f58369c2a1b3cb0c5e952b40208fd3d70f720_target_list_2 .
+_:aebc5a554a5a02d96a177a4905b1f58369c2a1b3cb0c5e952b40208fd3d70f720_target_list_2 rdf:first <http://purl.obolibrary.org/obo/BFO_0000040> .
+_:aebc5a554a5a02d96a177a4905b1f58369c2a1b3cb0c5e952b40208fd3d70f720_target_list_2 rdf:rest _:aebc5a554a5a02d96a177a4905b1f58369c2a1b3cb0c5e952b40208fd3d70f720_target_list_3 .
+_:aebc5a554a5a02d96a177a4905b1f58369c2a1b3cb0c5e952b40208fd3d70f720_target_list_3 rdf:first <http://purl.obolibrary.org/obo/BFO_0000015> .
+_:aebc5a554a5a02d96a177a4905b1f58369c2a1b3cb0c5e952b40208fd3d70f720_target_list_3 rdf:rest rdf:nil .
+
+<http://www.w3.org/ns/sosa/ActuatableProperty> rdfs:subClassOf _:af0ed25535d9f911882545913dac2c83339346e2ca16a5e939b2a2e27cd5f1c4e_target .
+_:af0ed25535d9f911882545913dac2c83339346e2ca16a5e939b2a2e27cd5f1c4e_target rdf:type owl:Class .
+_:af0ed25535d9f911882545913dac2c83339346e2ca16a5e939b2a2e27cd5f1c4e_target owl:unionOf _:af0ed25535d9f911882545913dac2c83339346e2ca16a5e939b2a2e27cd5f1c4e_target_list_0 .
+_:af0ed25535d9f911882545913dac2c83339346e2ca16a5e939b2a2e27cd5f1c4e_target_list_0 rdf:first _:af0ed25535d9f911882545913dac2c83339346e2ca16a5e939b2a2e27cd5f1c4e_target_child_0 .
+_:af0ed25535d9f911882545913dac2c83339346e2ca16a5e939b2a2e27cd5f1c4e_target_list_0 rdf:rest _:af0ed25535d9f911882545913dac2c83339346e2ca16a5e939b2a2e27cd5f1c4e_target_list_1 .
+_:af0ed25535d9f911882545913dac2c83339346e2ca16a5e939b2a2e27cd5f1c4e_target_list_1 rdf:first _:af0ed25535d9f911882545913dac2c83339346e2ca16a5e939b2a2e27cd5f1c4e_target_child_1 .
+_:af0ed25535d9f911882545913dac2c83339346e2ca16a5e939b2a2e27cd5f1c4e_target_list_1 rdf:rest rdf:nil .
+_:af0ed25535d9f911882545913dac2c83339346e2ca16a5e939b2a2e27cd5f1c4e_target_child_0 rdf:type owl:Class .
+_:af0ed25535d9f911882545913dac2c83339346e2ca16a5e939b2a2e27cd5f1c4e_target_child_0 owl:intersectionOf _:af0ed25535d9f911882545913dac2c83339346e2ca16a5e939b2a2e27cd5f1c4e_target_child_0_list_0 .
+_:af0ed25535d9f911882545913dac2c83339346e2ca16a5e939b2a2e27cd5f1c4e_target_child_0_list_0 rdf:first <http://purl.obolibrary.org/obo/BFO_0000020> .
+_:af0ed25535d9f911882545913dac2c83339346e2ca16a5e939b2a2e27cd5f1c4e_target_child_0_list_0 rdf:rest _:af0ed25535d9f911882545913dac2c83339346e2ca16a5e939b2a2e27cd5f1c4e_target_child_0_list_1 .
+_:af0ed25535d9f911882545913dac2c83339346e2ca16a5e939b2a2e27cd5f1c4e_target_child_0_list_1 rdf:first _:af0ed25535d9f911882545913dac2c83339346e2ca16a5e939b2a2e27cd5f1c4e_target_child_0_child_1 .
+_:af0ed25535d9f911882545913dac2c83339346e2ca16a5e939b2a2e27cd5f1c4e_target_child_0_list_1 rdf:rest rdf:nil .
+_:af0ed25535d9f911882545913dac2c83339346e2ca16a5e939b2a2e27cd5f1c4e_target_child_0_child_1 rdf:type owl:Restriction .
+_:af0ed25535d9f911882545913dac2c83339346e2ca16a5e939b2a2e27cd5f1c4e_target_child_0_child_1 owl:onProperty <http://purl.obolibrary.org/obo/BFO_0000197> .
+_:af0ed25535d9f911882545913dac2c83339346e2ca16a5e939b2a2e27cd5f1c4e_target_child_0_child_1 owl:someValuesFrom <http://www.w3.org/ns/sosa/FeatureOfInterest> .
+_:af0ed25535d9f911882545913dac2c83339346e2ca16a5e939b2a2e27cd5f1c4e_target_child_1 rdf:type owl:Class .
+_:af0ed25535d9f911882545913dac2c83339346e2ca16a5e939b2a2e27cd5f1c4e_target_child_1 owl:intersectionOf _:af0ed25535d9f911882545913dac2c83339346e2ca16a5e939b2a2e27cd5f1c4e_target_child_1_list_0 .
+_:af0ed25535d9f911882545913dac2c83339346e2ca16a5e939b2a2e27cd5f1c4e_target_child_1_list_0 rdf:first <http://purl.obolibrary.org/obo/BFO_0000144> .
+_:af0ed25535d9f911882545913dac2c83339346e2ca16a5e939b2a2e27cd5f1c4e_target_child_1_list_0 rdf:rest _:af0ed25535d9f911882545913dac2c83339346e2ca16a5e939b2a2e27cd5f1c4e_target_child_1_list_1 .
+_:af0ed25535d9f911882545913dac2c83339346e2ca16a5e939b2a2e27cd5f1c4e_target_child_1_list_1 rdf:first _:af0ed25535d9f911882545913dac2c83339346e2ca16a5e939b2a2e27cd5f1c4e_target_child_1_child_1 .
+_:af0ed25535d9f911882545913dac2c83339346e2ca16a5e939b2a2e27cd5f1c4e_target_child_1_list_1 rdf:rest rdf:nil .
+_:af0ed25535d9f911882545913dac2c83339346e2ca16a5e939b2a2e27cd5f1c4e_target_child_1_child_1 rdf:type owl:Restriction .
+_:af0ed25535d9f911882545913dac2c83339346e2ca16a5e939b2a2e27cd5f1c4e_target_child_1_child_1 owl:onProperty <http://purl.obolibrary.org/obo/BFO_0000132> .
+_:af0ed25535d9f911882545913dac2c83339346e2ca16a5e939b2a2e27cd5f1c4e_target_child_1_child_1 owl:someValuesFrom <http://www.w3.org/ns/sosa/FeatureOfInterest> .

--- a/reports/coms-automatic-validation-setup.md
+++ b/reports/coms-automatic-validation-setup.md
@@ -76,7 +76,8 @@ Each complete check:
 10. Requires all generated reports and validates hash-based source metadata.
 11. Derives and reconciles all per-product row and canonical-axiom dispositions, including target-vocabulary categories and canonical JSON serialization.
 12. Generates and validates the import-free 29-axiom SSN/SOSA alignment core, including root reconciliation and a fixed local source-ontology HermiT closure.
-13. Runs `git diff --check`.
+13. Generates and validates the 19-axiom strict BFO mapping, its sole alignment-core import, the 48-axiom project-module closure, and the explicit network-free pinned merged CCO/BFO HermiT closure.
+14. Runs `git diff --check`.
 
 The generated validation report records the workbook SHA-256, generator-file SHA-256, UTC generation timestamp, maintained ontology path, and generated ontology SHA-256. Freshness never relies on timestamps alone.
 
@@ -90,10 +91,11 @@ Generation and validation happen under `.cache/coms/`. The maintained files are 
 - `reports/coms-vs-pre-coms-legacy-diff.md`
 - `reports/coms-product-dispositions.json`
 - `releases/current-ssn-sosa/ssn-sosa-alignment-core.ttl`
+- `releases/current-ssn-sosa/ssn-sosa-bfo-mapping.ttl`
 
 Each replacement is atomic. If any check fails, the maintained last-known-good files remain unchanged. A post-replacement whitespace failure also triggers rollback from temporary backups.
 
-The product-disposition JSON is generated evidence rather than an editable mapping source. The alignment core is an import-free maintained authoritative development artifact, not a frozen formal release. Both are published in the same six-output transaction as the integrated ontology and other reports, so no maintained output can become newer or older than its disposition accounting or selected modular content.
+The product-disposition JSON is generated evidence rather than an editable mapping source. The alignment core and strict BFO mapping are maintained authoritative development artifacts, not frozen formal releases. The strict graph imports only the alignment core; `imports/cco.ttl` is used solely in the pinned merged CCO/BFO validation closure and is not a published strict-product import. All artifacts are published in one seven-output transaction, so no maintained output can become newer or older than its disposition accounting or selected modular content.
 
 `SSN2BFO.ttl` is the authoritative generated publication artifact. `mappings/SSN2BFO-COMS.xlsx` is its sole editable mapping source, and `legacy/SSN2BFO-pre-COMS.ttl` is used only as the frozen informational comparison baseline.
 

--- a/reports/coms-generation-validation.md
+++ b/reports/coms-generation-validation.md
@@ -9,18 +9,20 @@ Freshness is determined from content hashes, not file timestamps.
 | Item | Value |
 |---|---|
 | workbook SHA-256 | `febb8b58b4a701cead90697412a9721112c4e6dfd3af47d3c3a77c93754690e0` |
-| generator SHA-256 | `6e2897f5bbb49be748da66d9924dd220c0cba057758e033e6e219164be604c09` |
+| generator SHA-256 | `b5fe2f8986cff22849f30740581bc539c7c2cfaf8322e46e7e50d73fd5be4796` |
 | row-identity module SHA-256 | `9af9f9ed5b9321040428960e1293cffe27ebb48cc7a68a71f53f84cf18a60425` |
 | product-disposition module SHA-256 | `987fa4809e5780831f9e50e0b5cacc52888284fc7eae82a0928056c45c14a7d8` |
-| modular-products module SHA-256 | `67b7da97b1218f72fa05afc72fa06cf0d1afe21cabac5c1e01144d327ade2226` |
+| modular-products module SHA-256 | `f0e77fabb7d1010d1825e33d8be0ab26669895192445cf8a0eb54c21688ced9a` |
 | publication metadata SHA-256 | `a25196f873bc849a0a5b33012c22312d3ea9e70504219c9e781e77e595993564` |
-| generation timestamp (UTC) | `2026-07-15T18:28:01+00:00` |
+| generation timestamp (UTC) | `2026-07-15T22:55:30+00:00` |
 | maintained ontology path | `SSN2BFO.ttl` |
 | generated ontology SHA-256 | `fd6eadf1bcbd4bfc6dc06df58915116d8f909bc8c3238592b1f13509cec47d16` |
 | maintained product-disposition path | `reports/coms-product-dispositions.json` |
-| product-disposition JSON SHA-256 | `55f9652b7a37556cb2558ea5a6084fefe0ba608431a1da8660eeb024a59eabc7` |
+| product-disposition JSON SHA-256 | `2de7b52bfc89f75da013489749236df0c8ebbec7e3c09fe58275aa7f7b55ff55` |
 | maintained alignment-core path | `releases/current-ssn-sosa/ssn-sosa-alignment-core.ttl` |
 | alignment-core Turtle SHA-256 | `95f71184b90224906b0ba703d0ea60fd2f8b993b3853b803c66b88b91ba0b01c` |
+| maintained strict-BFO path | `releases/current-ssn-sosa/ssn-sosa-bfo-mapping.ttl` |
+| strict-BFO Turtle SHA-256 | `15f080145c6803d174a00cf9e13c971925b40485049744dba6e0847093016ea7` |
 
 ## Workbook
 
@@ -307,6 +309,39 @@ This is the maintained authoritative development artifact at the approved produc
 - Source-closure HermiT result: PASS
 - Full publication metadata and formal release identity remain deferred.
 
+## Strict BFO Mapping
+
+This is the maintained authoritative development artifact at the approved production path; it is not a frozen formal release.
+
+- Path: `releases/current-ssn-sosa/ssn-sosa-bfo-mapping.ttl`
+- Stable ontology IRI: `http://www.sks.ai/SSN2BFO/current-ssn-sosa/bfo-mapping`
+- Direct governed authoritative axioms: 19
+- Subclass axioms: 3
+- Equivalent-class axioms: 3
+- Direct subproperty axioms: 9
+- Property-chain axioms: 2
+- Domain axioms: 1
+- Range axioms: 1
+- Logical RDF triples: 125
+- Ontology-header and import triples: 2
+- Total RDF triples: 127
+- Import: `http://www.sks.ai/SSN2BFO/current-ssn-sosa/alignment-core`
+- Imported alignment-core governed axioms: 29
+- Project-module closure governed axioms: 48
+- Direct/alignment-core governed overlap: 0
+- CCO/RO and unexpected logical-vocabulary audit: PASS
+- Integrated-root and project-module canonical-axiom reconciliation: PASS
+- Deterministic serialization: PASS
+- Pinned merged CCO/BFO validation closure: `imports/sosa.ttl`, `imports/sosa-sampling.ttl`, `imports/ssn.ttl`, `imports/ssn-systems.ttl`, `imports/cco.ttl`
+- Pinned closure triple count: 14972
+- HermiT return code: 0
+- Reasoned output produced: yes
+- Named unsatisfiable classes: 0
+- HermiT result: PASS
+- The validation dependency `imports/cco.ttl` is not imported by the published strict graph and does not authorize CCO mappings or transformations.
+- The 57 CCO-bearing or mixed mappings remain deferred; no transformation or projection is implemented.
+- Full publication metadata and formal release identity remain deferred.
+
 ## Generated Ontology
 
 - Path: `SSN2BFO.ttl`
@@ -476,4 +511,4 @@ This section records mapping and domain/range property-typing rows after parsing
 
 ## Runtime
 
-- Runtime seconds: 3.76
+- Runtime seconds: 6.19

--- a/reports/coms-product-dispositions.json
+++ b/reports/coms-product-dispositions.json
@@ -2,7 +2,7 @@
   "schema_version": 1,
   "canonicalization_version": "coms-row-expression-v1",
   "workbook_sha256": "febb8b58b4a701cead90697412a9721112c4e6dfd3af47d3c3a77c93754690e0",
-  "generator_sha256": "6e2897f5bbb49be748da66d9924dd220c0cba057758e033e6e219164be604c09",
+  "generator_sha256": "b5fe2f8986cff22849f30740581bc539c7c2cfaf8322e46e7e50d73fd5be4796",
   "row_identity_module_sha256": "9af9f9ed5b9321040428960e1293cffe27ebb48cc7a68a71f53f84cf18a60425",
   "disposition_module_sha256": "987fa4809e5780831f9e50e0b5cacc52888284fc7eae82a0928056c45c14a7d8",
   "publication_metadata_sha256": "a25196f873bc849a0a5b33012c22312d3ea9e70504219c9e781e77e595993564",

--- a/tests/test_generate_mapping_from_coms.py
+++ b/tests/test_generate_mapping_from_coms.py
@@ -118,6 +118,8 @@ class ComsDomainRangeTests(unittest.TestCase):
                 str(disposition_path),
                 "--alignment-core-output",
                 str(self.root / "alignment-core.ttl"),
+                "--strict-bfo-output",
+                str(self.root / "strict-bfo.ttl"),
                 "--coverage-report",
                 str(self.root / "coverage.md"),
                 "--diff-report",
@@ -139,6 +141,7 @@ class ComsDomainRangeTests(unittest.TestCase):
         self.assertFalse(output_path.exists())
         self.assertFalse(disposition_path.exists())
         self.assertFalse((self.root / "alignment-core.ttl").exists())
+        self.assertFalse((self.root / "strict-bfo.ttl").exists())
         self.assertTrue(report_path.is_file())
         report = report_path.read_text(encoding="utf-8")
         self.assertIn("| overall status | FAIL |", report)
@@ -168,6 +171,7 @@ class ComsDomainRangeTests(unittest.TestCase):
         self.assertFalse(output_path.exists())
         self.assertFalse(disposition_path.exists())
         self.assertFalse((self.root / "alignment-core.ttl").exists())
+        self.assertFalse((self.root / "strict-bfo.ttl").exists())
         report = report_path.read_text(encoding="utf-8")
         self.assertIn("TARGET_CATEGORY_MISMATCH", report)
         self.assertIn("| overall status | FAIL |", report)
@@ -705,6 +709,8 @@ class ComsGenerationReportTests(unittest.TestCase):
         disposition_document: dispositions.DispositionDocument | None = None,
         alignment_core_result: object | None = None,
         alignment_core_hermit: object | None = None,
+        strict_bfo_result: object | None = None,
+        strict_bfo_hermit: object | None = None,
     ) -> str:
         path = self.root / f"{name}.md"
         coms.write_generation_report(
@@ -737,6 +743,12 @@ class ComsGenerationReportTests(unittest.TestCase):
             ),
             alignment_core_sha256="alignment-core-hash",
             alignment_core_hermit=alignment_core_hermit,
+            strict_bfo_result=strict_bfo_result,
+            strict_bfo_path=Path(
+                "releases/current-ssn-sosa/ssn-sosa-bfo-mapping.ttl"
+            ),
+            strict_bfo_sha256="strict-bfo-hash",
+            strict_bfo_hermit=strict_bfo_hermit,
         )
         return path.read_text(encoding="utf-8")
 
@@ -871,6 +883,43 @@ class ComsGenerationReportTests(unittest.TestCase):
         self.assertIn("Total RDF triples: 54", report)
         self.assertIn("Source-closure HermiT result: PASS", report)
 
+    def test_generation_report_includes_strict_bfo_results(self) -> None:
+        result = SimpleNamespace(
+            metadata=SimpleNamespace(
+                stable_ontology_iri=(
+                    "http://www.sks.ai/SSN2BFO/current-ssn-sosa/bfo-mapping"
+                )
+            ),
+            governed_axiom_count=19,
+            subclass_axiom_count=3,
+            equivalent_class_axiom_count=3,
+            direct_subproperty_axiom_count=9,
+            property_chain_axiom_count=2,
+            domain_axiom_count=1,
+            range_axiom_count=1,
+            logical_triple_count=125,
+            ontology_header_triple_count=2,
+            total_triple_count=127,
+        )
+        hermit = SimpleNamespace(
+            closure_triple_count=14972,
+            return_code=0,
+            reasoned_output_produced=True,
+            unsat_classes=[],
+            passed=True,
+        )
+        report = self.render_report(
+            "strict-bfo",
+            "/opt/robot",
+            strict_bfo_result=result,
+            strict_bfo_hermit=hermit,
+        )
+        self.assertIn("## Strict BFO Mapping", report)
+        self.assertIn("Direct governed authoritative axioms: 19", report)
+        self.assertIn("Project-module closure governed axioms: 48", report)
+        self.assertIn("Pinned closure triple count: 14972", report)
+        self.assertIn("HermiT result: PASS", report)
+
 
 class ComsAuthorityMigrationTests(unittest.TestCase):
     def setUp(self) -> None:
@@ -886,6 +935,7 @@ class ComsAuthorityMigrationTests(unittest.TestCase):
             "diff_report": self.root / "reports/coms-vs-pre-coms-legacy-diff.md",
             "disposition_report": self.root / "reports/coms-product-dispositions.json",
             "alignment_core": self.root / "releases/current-ssn-sosa/ssn-sosa-alignment-core.ttl",
+            "strict_bfo_mapping": self.root / "releases/current-ssn-sosa/ssn-sosa-bfo-mapping.ttl",
         }
 
     @staticmethod
@@ -906,6 +956,10 @@ class ComsAuthorityMigrationTests(unittest.TestCase):
         self.assertEqual(
             checker.MAINTAINED_OUTPUTS["alignment_core"],
             REPO_ROOT / "releases/current-ssn-sosa/ssn-sosa-alignment-core.ttl",
+        )
+        self.assertEqual(
+            checker.MAINTAINED_OUTPUTS["strict_bfo_mapping"],
+            REPO_ROOT / "releases/current-ssn-sosa/ssn-sosa-bfo-mapping.ttl",
         )
 
     def test_legacy_ontology_is_the_comparison_baseline(self) -> None:
@@ -939,6 +993,7 @@ class ComsAuthorityMigrationTests(unittest.TestCase):
         modular_products_module_hash = checker.sha256_file(checker.MODULAR_PRODUCTS_MODULE)
         publication_metadata_hash = checker.sha256_file(checker.PUBLICATION_METADATA)
         alignment_core_hash = checker.sha256_file(outputs["alignment_core"])
+        strict_bfo_hash = checker.sha256_file(outputs["strict_bfo_mapping"])
         self.write(
             outputs["generation_report"],
             "\n".join(
@@ -955,6 +1010,8 @@ class ComsAuthorityMigrationTests(unittest.TestCase):
                     f"| product-disposition JSON SHA-256 | `{disposition_hash}` |",
                     "| maintained alignment-core path | `releases/current-ssn-sosa/ssn-sosa-alignment-core.ttl` |",
                     f"| alignment-core Turtle SHA-256 | `{alignment_core_hash}` |",
+                    "| maintained strict-BFO path | `releases/current-ssn-sosa/ssn-sosa-bfo-mapping.ttl` |",
+                    f"| strict-BFO Turtle SHA-256 | `{strict_bfo_hash}` |",
                 ]
             ),
         )
@@ -999,6 +1056,7 @@ class ComsAuthorityMigrationTests(unittest.TestCase):
         modular_products_module_hash = checker.sha256_file(checker.MODULAR_PRODUCTS_MODULE)
         publication_metadata_hash = checker.sha256_file(checker.PUBLICATION_METADATA)
         alignment_core_hash = checker.sha256_file(outputs["alignment_core"])
+        strict_bfo_hash = checker.sha256_file(outputs["strict_bfo_mapping"])
         self.write(
             outputs["generation_report"],
             "\n".join(
@@ -1015,6 +1073,8 @@ class ComsAuthorityMigrationTests(unittest.TestCase):
                     f"| product-disposition JSON SHA-256 | `{disposition_hash}` |",
                     "| maintained alignment-core path | `releases/current-ssn-sosa/ssn-sosa-alignment-core.ttl` |",
                     f"| alignment-core Turtle SHA-256 | `{alignment_core_hash}` |",
+                    "| maintained strict-BFO path | `releases/current-ssn-sosa/ssn-sosa-bfo-mapping.ttl` |",
+                    f"| strict-BFO Turtle SHA-256 | `{strict_bfo_hash}` |",
                 ]
             ),
         )
@@ -1068,6 +1128,77 @@ class ComsAuthorityMigrationTests(unittest.TestCase):
             )
             self.assertEqual(checker.main(["--check-only"]), 1)
 
+        run_generator.assert_not_called()
+        for path, content in expected.items():
+            self.assertEqual(path.read_bytes(), content)
+        self.assertEqual(list(cache_dir.glob("run-*")), [])
+
+    def test_stale_strict_bfo_hash_fails_check_only_without_rewriting_outputs(self) -> None:
+        outputs = self.maintained_outputs()
+        for name, path in outputs.items():
+            self.write(path, f"maintained-{name}\n")
+        hashes = {name: checker.sha256_file(path) for name, path in outputs.items()}
+        disposition_module_hash = checker.sha256_file(checker.DISPOSITION_MODULE)
+        modular_products_module_hash = checker.sha256_file(checker.MODULAR_PRODUCTS_MODULE)
+        publication_metadata_hash = checker.sha256_file(checker.PUBLICATION_METADATA)
+        self.write(
+            outputs["generation_report"],
+            "\n".join(
+                [
+                    "| workbook SHA-256 | `workbook-hash` |",
+                    "| generator SHA-256 | `generator-hash` |",
+                    f"| product-disposition module SHA-256 | `{disposition_module_hash}` |",
+                    f"| modular-products module SHA-256 | `{modular_products_module_hash}` |",
+                    f"| publication metadata SHA-256 | `{publication_metadata_hash}` |",
+                    "| generation timestamp (UTC) | `2026-01-01T00:00:00+00:00` |",
+                    "| maintained ontology path | `SSN2BFO.ttl` |",
+                    f"| generated ontology SHA-256 | `{hashes['candidate']}` |",
+                    "| maintained product-disposition path | `reports/coms-product-dispositions.json` |",
+                    f"| product-disposition JSON SHA-256 | `{hashes['disposition_report']}` |",
+                    "| maintained alignment-core path | `releases/current-ssn-sosa/ssn-sosa-alignment-core.ttl` |",
+                    f"| alignment-core Turtle SHA-256 | `{hashes['alignment_core']}` |",
+                    "| maintained strict-BFO path | `releases/current-ssn-sosa/ssn-sosa-bfo-mapping.ttl` |",
+                    f"| strict-BFO Turtle SHA-256 | `{hashes['strict_bfo_mapping']}` |",
+                ]
+            ),
+        )
+        fake_disposition = SimpleNamespace(
+            input_hashes=SimpleNamespace(
+                workbook_sha256="workbook-hash",
+                generator_sha256="generator-hash",
+                row_identity_module_sha256=checker.sha256_file(checker.ROW_IDENTITY_MODULE),
+                disposition_module_sha256=disposition_module_hash,
+                publication_metadata_sha256=publication_metadata_hash,
+            ),
+            product_order=tuple(
+                product.key for product in load_metadata(checker.PUBLICATION_METADATA).products
+            ),
+        )
+        cache_dir = self.root / ".cache/coms"
+        run_generator = mock.Mock()
+        self.write(outputs["strict_bfo_mapping"], "modified maintained strict BFO mapping\n")
+        expected = {path: path.read_bytes() for path in outputs.values()}
+        with (
+            mock.patch.object(checker, "REPO_ROOT", self.root),
+            mock.patch.object(checker, "CACHE_DIR", cache_dir),
+            mock.patch.object(checker, "LAST_SUCCESS", cache_dir / "last-success.json"),
+            mock.patch.object(checker, "LAST_FAILURE", cache_dir / "last-failure.log"),
+            mock.patch.object(checker, "MAINTAINED_OUTPUTS", outputs),
+            mock.patch.object(checker, "verify_workbook", return_value="workbook-hash"),
+            mock.patch.object(checker, "compile_generator", return_value="generator-hash"),
+            mock.patch.object(checker, "run_generator", run_generator),
+            mock.patch.object(checker, "load_disposition_document", return_value=fake_disposition),
+            mock.patch.object(
+                checker,
+                "serialize_disposition_document",
+                return_value=outputs["disposition_report"].read_bytes(),
+            ),
+            mock.patch.object(checker, "write_failure_log"),
+        ):
+            errors = checker.freshness_errors("workbook-hash", "generator-hash")
+            self.assertEqual(errors, ["strict-BFO hash differs from the generated report"])
+            self.assertNotIn("generated candidate hash differs from the generated report", errors)
+            self.assertEqual(checker.main(["--check-only"]), 1)
         run_generator.assert_not_called()
         for path, content in expected.items():
             self.assertEqual(path.read_bytes(), content)
@@ -1182,6 +1313,87 @@ class ComsAuthorityMigrationTests(unittest.TestCase):
         self.assertFalse(transaction_dirs[0].exists())
         self.assertEqual(list(cache_dir.glob("run-*")), [])
 
+    def test_first_successful_update_creates_initially_absent_strict_bfo_mapping(self) -> None:
+        outputs = self.maintained_outputs()
+        existing = {
+            name: path for name, path in outputs.items() if name != "strict_bfo_mapping"
+        }
+        for name, path in existing.items():
+            self.write(path, f"old-{name}\n")
+        self.assertFalse(outputs["strict_bfo_mapping"].exists())
+        expected_generated = {
+            name: f"new-{name}\n".encode("utf-8") for name in existing
+        }
+        strict_bytes = (
+            REPO_ROOT / "releases/current-ssn-sosa/ssn-sosa-bfo-mapping.ttl"
+        ).read_bytes()
+        ontology_iri = URIRef(
+            "http://www.sks.ai/SSN2BFO/current-ssn-sosa/bfo-mapping"
+        )
+        alignment_iri = URIRef(
+            "http://www.sks.ai/SSN2BFO/current-ssn-sosa/alignment-core"
+        )
+        cache_dir = self.root / ".cache/coms"
+        transaction_dirs: list[Path] = []
+        validation_complete = False
+
+        def fake_run_generator(paths: dict[str, Path], _log: list[str]) -> None:
+            self.assertFalse(outputs["strict_bfo_mapping"].exists())
+            transaction_dirs.append(paths["candidate"].parents[1])
+            for name, content in expected_generated.items():
+                paths[name].parent.mkdir(parents=True, exist_ok=True)
+                paths[name].write_bytes(content)
+            paths["strict_bfo_mapping"].parent.mkdir(parents=True, exist_ok=True)
+            paths["strict_bfo_mapping"].write_bytes(strict_bytes)
+            self.write(paths["summary"], "{}\n")
+
+        def fake_validate(paths: dict[str, Path], *_args, **_kwargs):
+            nonlocal validation_complete
+            self.assertFalse(outputs["strict_bfo_mapping"].exists())
+            graph = coms.Graph().parse(paths["strict_bfo_mapping"], format="turtle")
+            self.assertEqual(set(graph.subjects(RDF.type, OWL.Ontology)), {ontology_iri})
+            self.assertEqual(
+                set(graph.triples((None, OWL.imports, None))),
+                {(ontology_iri, OWL.imports, alignment_iri)},
+            )
+            self.assertEqual(len(graph), 127)
+            validation_complete = True
+            return {}
+
+        production_replace = checker.replace_outputs_atomically
+
+        def observe_replace(paths: dict[str, Path], transaction_dir: Path, log: list[str]) -> None:
+            self.assertTrue(validation_complete)
+            self.assertFalse(outputs["strict_bfo_mapping"].exists())
+            production_replace(paths, transaction_dir, log)
+            self.assertTrue(outputs["strict_bfo_mapping"].exists())
+
+        with (
+            mock.patch.object(checker, "REPO_ROOT", self.root),
+            mock.patch.object(checker, "CACHE_DIR", cache_dir),
+            mock.patch.object(checker, "LAST_SUCCESS", cache_dir / "last-success.json"),
+            mock.patch.object(checker, "LAST_FAILURE", cache_dir / "last-failure.log"),
+            mock.patch.object(checker, "MAINTAINED_OUTPUTS", outputs),
+            mock.patch.object(checker, "verify_workbook", return_value="workbook-hash"),
+            mock.patch.object(checker, "compile_generator", return_value="generator-hash"),
+            mock.patch.object(checker, "freshness_errors", return_value=["missing strict BFO mapping"]),
+            mock.patch.object(checker, "run_generator", side_effect=fake_run_generator),
+            mock.patch.object(checker, "validate_temporary_outputs", side_effect=fake_validate),
+            mock.patch.object(checker, "git_diff_check"),
+            mock.patch.object(checker, "output_differences", return_value=list(outputs)),
+            mock.patch.object(checker, "replace_outputs_atomically", side_effect=observe_replace),
+            mock.patch.object(checker, "record_success"),
+            mock.patch.object(checker, "write_failure_log"),
+        ):
+            self.assertEqual(checker.main([]), 0)
+        for name, content in expected_generated.items():
+            self.assertEqual(outputs[name].read_bytes(), content)
+        self.assertEqual(outputs["strict_bfo_mapping"].read_bytes(), strict_bytes)
+        self.assertTrue(all(path.is_file() for path in outputs.values()))
+        self.assertEqual(len(transaction_dirs), 1)
+        self.assertFalse(transaction_dirs[0].exists())
+        self.assertEqual(list(cache_dir.glob("run-*")), [])
+
     def test_temporary_validation_precedes_atomic_root_replacement(self) -> None:
         outputs = self.maintained_outputs()
         for name, path in outputs.items():
@@ -1217,7 +1429,7 @@ class ComsAuthorityMigrationTests(unittest.TestCase):
 
         self.assertEqual(outputs["candidate"].read_text(encoding="utf-8"), "new-candidate\n")
 
-    def test_check_only_preserves_all_six_outputs_and_workbook(self) -> None:
+    def test_check_only_preserves_all_seven_outputs_and_workbook(self) -> None:
         outputs = self.maintained_outputs()
         workbook = self.root / "mappings/SSN2BFO-COMS.xlsx"
         self.write(workbook, "workbook-bytes\n")
@@ -1375,6 +1587,55 @@ class ComsAuthorityMigrationTests(unittest.TestCase):
         self.assertEqual(len(transaction_dirs), 1)
         self.assertFalse(transaction_dirs[0].exists())
 
+    def test_rollback_removes_new_strict_bfo_when_it_was_initially_absent(self) -> None:
+        outputs = self.maintained_outputs()
+        existing = {
+            name: path for name, path in outputs.items() if name != "strict_bfo_mapping"
+        }
+        for name, path in existing.items():
+            self.write(path, f"old-{name}\n")
+        before = {path: path.read_bytes() for path in existing.values()}
+        cache_dir = self.root / ".cache/coms"
+        transaction_dirs: list[Path] = []
+
+        def fake_run_generator(paths: dict[str, Path], _log: list[str]) -> None:
+            transaction_dirs.append(paths["candidate"].parents[1])
+            for name in outputs:
+                self.write(paths[name], f"new-{name}\n")
+            self.write(paths["summary"], "{}\n")
+
+        diff_checks = 0
+
+        def fail_post_update(_log: list[str], _label: str) -> None:
+            nonlocal diff_checks
+            diff_checks += 1
+            if diff_checks == 2:
+                raise checker.CheckFailure("post-update failure")
+
+        with (
+            mock.patch.object(checker, "REPO_ROOT", self.root),
+            mock.patch.object(checker, "CACHE_DIR", cache_dir),
+            mock.patch.object(checker, "LAST_SUCCESS", cache_dir / "last-success.json"),
+            mock.patch.object(checker, "LAST_FAILURE", cache_dir / "last-failure.log"),
+            mock.patch.object(checker, "MAINTAINED_OUTPUTS", outputs),
+            mock.patch.object(checker, "verify_workbook", return_value="workbook-hash"),
+            mock.patch.object(checker, "compile_generator", return_value="generator-hash"),
+            mock.patch.object(checker, "freshness_errors", return_value=["stale"]),
+            mock.patch.object(checker, "run_generator", side_effect=fake_run_generator),
+            mock.patch.object(checker, "validate_temporary_outputs", return_value={}),
+            mock.patch.object(checker, "git_diff_check", side_effect=fail_post_update),
+            mock.patch.object(checker, "output_differences", return_value=list(outputs)),
+            mock.patch.object(checker, "record_success"),
+            mock.patch.object(checker, "write_failure_log"),
+        ):
+            self.assertEqual(checker.main([]), 1)
+        self.assertEqual(diff_checks, 2)
+        for path, expected in before.items():
+            self.assertEqual(path.read_bytes(), expected)
+        self.assertFalse(outputs["strict_bfo_mapping"].exists())
+        self.assertEqual(len(transaction_dirs), 1)
+        self.assertFalse(transaction_dirs[0].exists())
+
     def test_written_malformed_disposition_fails_before_replacement(self) -> None:
         outputs = self.maintained_outputs()
         for name, path in outputs.items():
@@ -1517,6 +1778,120 @@ class ComsAuthorityMigrationTests(unittest.TestCase):
         ):
             self.assertEqual(checker.main([]), 1)
 
+        self.assertEqual(len(observed_candidates), 1)
+        self.assertIn(b"[", observed_candidates[0])
+        for path, expected in before.items():
+            self.assertEqual(path.read_bytes(), expected)
+        self.assertEqual(len(transaction_dirs), 1)
+        self.assertFalse(transaction_dirs[0].exists())
+
+    def test_written_malformed_strict_bfo_fails_before_replacement(self) -> None:
+        outputs = self.maintained_outputs()
+        for name, path in outputs.items():
+            self.write(path, f"old-{name}\n")
+        before = {path: path.read_bytes() for path in outputs.values()}
+        cache_dir = self.root / ".cache/coms"
+        transaction_dirs: list[Path] = []
+        observed_candidates: list[bytes] = []
+        disposition_source = REPO_ROOT / "reports/coms-product-dispositions.json"
+        disposition = checker.load_disposition_document(disposition_source)
+        disposition_bytes = disposition_source.read_bytes()
+        alignment_bytes = (
+            REPO_ROOT / "releases/current-ssn-sosa/ssn-sosa-alignment-core.ttl"
+        ).read_bytes()
+        workbook_hash = disposition.input_hashes.workbook_sha256
+        generator_hash = disposition.input_hashes.generator_sha256
+
+        def fake_run_generator(paths: dict[str, Path], _log: list[str]) -> None:
+            transaction_dirs.append(paths["candidate"].parents[1])
+            for name in outputs:
+                self.write(paths[name], f"temporary-{name}\n")
+            paths["disposition_report"].write_bytes(disposition_bytes)
+            paths["alignment_core"].write_bytes(alignment_bytes)
+            malformed_strict = b"@prefix owl: <http://www.w3.org/2002/07/owl#> .\n[\n"
+            paths["strict_bfo_mapping"].write_bytes(malformed_strict)
+            self.write(
+                paths["summary"],
+                json.dumps(
+                    {
+                        "status": "PASS",
+                        "workbook_sha256": workbook_hash,
+                        "generator_sha256": generator_hash,
+                        "product_disposition_report_sha256": checker.sha256_file(paths["disposition_report"]),
+                        "product_dispositions": {
+                            field: getattr(disposition.summary, field)
+                            for field in disposition.summary.__dataclass_fields__
+                        },
+                        "alignment_core_sha256": checker.sha256_file(paths["alignment_core"]),
+                        "modular_products_module_sha256": checker.sha256_file(checker.MODULAR_PRODUCTS_MODULE),
+                        "alignment_core": {
+                            "product_key": "alignment_core",
+                            "stable_ontology_iri": "http://www.sks.ai/SSN2BFO/current-ssn-sosa/alignment-core",
+                            "governed_axiom_count": 29,
+                            "logical_triple_count": 53,
+                            "ontology_header_triple_count": 1,
+                            "total_triple_count": 54,
+                            "domain_axiom_count": 15,
+                            "range_axiom_count": 14,
+                            "named_target_count": 26,
+                            "union_target_count": 3,
+                            "hermit_return_code": 0,
+                            "hermit_result": "PASS",
+                            "named_unsat_count": 0,
+                        },
+                        "strict_bfo_mapping_sha256": checker.sha256_file(paths["strict_bfo_mapping"]),
+                        "strict_bfo_mapping": {
+                            "product_key": "strict_bfo_mapping",
+                            "stable_ontology_iri": "http://www.sks.ai/SSN2BFO/current-ssn-sosa/bfo-mapping",
+                            "governed_axiom_count": 19,
+                            "logical_triple_count": 125,
+                            "ontology_header_triple_count": 2,
+                            "import_triple_count": 1,
+                            "total_triple_count": 127,
+                            "subclass_axiom_count": 3,
+                            "equivalent_class_axiom_count": 3,
+                            "direct_subproperty_axiom_count": 9,
+                            "property_chain_axiom_count": 2,
+                            "domain_axiom_count": 1,
+                            "range_axiom_count": 1,
+                            "union_expression_count": 6,
+                            "intersection_expression_count": 6,
+                            "existential_restriction_count": 6,
+                            "rdf_list_count": 14,
+                            "project_closure_governed_axiom_count": 48,
+                            "project_graph_triple_count": 181,
+                            "local_project_graph_triple_count": 180,
+                            "hermit_return_code": 0,
+                            "hermit_result": "PASS",
+                            "closure_triple_count": 14972,
+                            "named_unsat_count": 0,
+                        },
+                    }
+                )
+                + "\n",
+            )
+
+        original_parse = checker.Graph.parse
+
+        def observe_parse(graph, source=None, *args, **kwargs):
+            if source == checker.transaction_paths(transaction_dirs[0])["strict_bfo_mapping"]:
+                observed_candidates.append(Path(source).read_bytes())
+            return original_parse(graph, source, *args, **kwargs)
+
+        with (
+            mock.patch.object(checker, "REPO_ROOT", self.root),
+            mock.patch.object(checker, "CACHE_DIR", cache_dir),
+            mock.patch.object(checker, "LAST_SUCCESS", cache_dir / "last-success.json"),
+            mock.patch.object(checker, "LAST_FAILURE", cache_dir / "last-failure.log"),
+            mock.patch.object(checker, "MAINTAINED_OUTPUTS", outputs),
+            mock.patch.object(checker, "verify_workbook", return_value=workbook_hash),
+            mock.patch.object(checker, "compile_generator", return_value=generator_hash),
+            mock.patch.object(checker, "freshness_errors", return_value=["stale"]),
+            mock.patch.object(checker, "run_generator", side_effect=fake_run_generator),
+            mock.patch.object(checker.Graph, "parse", new=observe_parse),
+            mock.patch.object(checker, "write_failure_log"),
+        ):
+            self.assertEqual(checker.main([]), 1)
         self.assertEqual(len(observed_candidates), 1)
         self.assertIn(b"[", observed_candidates[0])
         for path, expected in before.items():

--- a/tests/test_product_dispositions.py
+++ b/tests/test_product_dispositions.py
@@ -672,11 +672,11 @@ class ProductDispositionTests(unittest.TestCase):
                     code,
                 )
 
-    def test_disposition_build_does_not_require_unimplemented_modular_ttl_files(self) -> None:
+    def test_disposition_build_does_not_require_remaining_unimplemented_modular_ttl_files(self) -> None:
         products = {product.key: product for product in self.metadata.products}
         self.assertTrue((REPO_ROOT / products["alignment_core"].path).is_file())
+        self.assertTrue((REPO_ROOT / products["strict_bfo_mapping"].path).is_file())
         for product_key in (
-            "strict_bfo_mapping",
             "bfo_projection",
             "cco_extension",
         ):

--- a/tests/test_strict_bfo_mapping.py
+++ b/tests/test_strict_bfo_mapping.py
@@ -1,0 +1,478 @@
+#!/usr/bin/env python3
+"""Focused tests for the maintained strict BFO mapping product."""
+
+from __future__ import annotations
+
+import dataclasses
+import hashlib
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+from rdflib import BNode, Graph, RDF, RDFS, OWL, URIRef
+from rdflib.collection import Collection
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT / "tools"))
+
+import generate_mapping_from_coms as coms  # noqa: E402
+import modular_products as modular  # noqa: E402
+from coms_row_identity import RowLocation  # noqa: E402
+from product_dispositions import ProductDisposition, load_disposition_document  # noqa: E402
+from publication_metadata import load_metadata  # noqa: E402
+
+
+EXPECTED_ROW_IDS = frozenset(
+    "urn:uuid:" + value
+    for value in (
+        "02294d3c-f88d-4d3d-921e-8d6c00457476",
+        "06782965-88c5-4345-ab99-ea027513ec86",
+        "158c0cce-2c1d-4baf-90b5-243d7cdce34d",
+        "17528e16-1f22-4c6e-9e29-e3b3c6699804",
+        "1b7c27d4-1b0e-461f-8a77-7a81631ab342",
+        "2abe4468-736d-4db8-99d7-1670730a6710",
+        "37576663-68e9-4298-8652-a3c614c34ae3",
+        "3af8734c-ac86-46b0-8c0c-27a19525bc1e",
+        "43ad1a14-e8a4-48d5-ae2b-3b5a5b28f8d3",
+        "66010702-8134-4e08-a972-f0767ec8dead",
+        "6c58598b-8de6-4559-82fa-53a6efc6a3c4",
+        "99b22791-b2d1-4667-901e-861a44f2b8a2",
+        "af48aae7-263f-436d-a76a-4e7232c609c5",
+        "b1421726-3675-4b2a-9824-150e108157e4",
+        "b4508c03-1b79-4f53-b525-d5db6d80c7cb",
+        "c0a94c70-33c7-41ac-8906-49ad2efe48b5",
+        "d8f45381-cd95-4251-ae69-803a033a8f49",
+        "e866de80-683d-4138-a713-be9646d37148",
+        "f0fbd0af-655a-46c8-bda9-1c2adb24a10a",
+    )
+)
+
+EXPECTED_AXIOM_IDS = frozenset(
+    "sha256:" + value
+    for value in (
+        "0caeec31770247fe2efeb443e85fefe9b4e1648a7d9569adc35d2972b77682b1",
+        "ebc5a554a5a02d96a177a4905b1f58369c2a1b3cb0c5e952b40208fd3d70f720",
+        "a967fdeccb6b435f0f84de94b976dec27307580651a7d16a08b900be0daa4dd1",
+        "cb03fd4e0013c6cb36cdae6f435a71662e5ace11c4b60fd6121e30a58cfddbaf",
+        "f0ed25535d9f911882545913dac2c83339346e2ca16a5e939b2a2e27cd5f1c4e",
+        "39946148848f627dc9bd67601c5d0d1184960c34054c876541a77fa9d42e3d6b",
+        "4ee0a31d0d7abc626e19715ee1f31b610823136f2ea133155491a644f72db22a",
+        "90d2b3a965084a150dcd254003bbdd2e5d706d8dd1b7a941c44e44ee2ea1737e",
+        "6dfa77b04dfaea343d0a8767e6467c603eafddf10395ff40ac7416f52c7fd4d4",
+        "0db60d0e9764151246aa7f88574dbc9fb112eecb2191d00822192f51ec298678",
+        "205b4f09b9778256d60879903b8e03e20a284c0ce6d3dd085b87d5c2e3b44cad",
+        "5606980322dc337a4e5d0eb2daef2e5acbba7ee42a782247375fcf3f39d12e00",
+        "20d91e47601ba6ee027a45b1292383a93db5223addd66a57f6b0ce832054b0d6",
+        "e97401fddd65d2c240938d965cb3ecb82f52b396f7fbdc7ccee0de7edf3ff74b",
+        "480ce3257f6b1baaaacee7b06ce730cdf63a7dd14c16b4a1bedc09597a5d96ef",
+        "3e6d4c8e6ae7f32b3fde12f2e976c4c91ea66a0893e45ae7a3bb7ddf974dafba",
+        "9df2ac96dda81289facb4e871c73c208fa2ae4fc7f33cfd9bc293c8e50b0439c",
+        "47859e2cfd5df437d1f55c83560793ab22f035de9b829ccdedcc4d3118cc4f3e",
+        "b87f9b4fe09c1df974c9c698e4501efaab8762b8a376aa207f83810b6f2ae7dd",
+    )
+)
+
+
+class StrictBfoMappingTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        rows, stats = coms.read_workbook(REPO_ROOT / "mappings/SSN2BFO-COMS.xlsx")
+        cls.processed = coms.validate_and_process_rows(rows, coms.Resolver(), stats)
+        cls.canonical_rows = tuple(
+            coms.canonical_input_for_processed_row(row) for row in cls.processed
+        )
+        cls.audits = tuple(row.identity_audit for row in cls.processed)
+        cls.disposition = load_disposition_document(
+            REPO_ROOT / "reports/coms-product-dispositions.json"
+        )
+        cls.metadata = load_metadata(REPO_ROOT / "config/publication-metadata.toml")
+        cls.strict_selected = modular.select_product_axioms(
+            "strict_bfo_mapping",
+            cls.canonical_rows,
+            cls.audits,
+            cls.disposition,
+        )
+        cls.core_selected = modular.select_product_axioms(
+            "alignment_core",
+            cls.canonical_rows,
+            cls.audits,
+            cls.disposition,
+        )
+        cls.strict_result = modular.build_strict_bfo_mapping(
+            cls.strict_selected, cls.metadata
+        )
+        cls.core_result = modular.build_alignment_core(cls.core_selected, cls.metadata)
+        cls.root_graph = Graph().parse(REPO_ROOT / "SSN2BFO.ttl", format="turtle")
+
+    @staticmethod
+    def codes(error: modular.ModularProductError) -> set[str]:
+        return {value.code for value in error.issues}
+
+    def replace_disposition_row(self, row_id: str, replacement) -> object:
+        return dataclasses.replace(
+            self.disposition,
+            rows=tuple(
+                replacement if row.row_id == row_id else row
+                for row in self.disposition.rows
+            ),
+        )
+
+    def validate_bytes(self, data: bytes, *, closure: Graph | None = None) -> set[str]:
+        return {
+            value.code
+            for value in modular.validate_strict_bfo_mapping(
+                data,
+                self.strict_selected,
+                self.core_result.serialized_bytes,
+                self.core_selected,
+                self.metadata,
+                integrated_graph=self.root_graph,
+                fixed_semantic_closure=closure,
+            )
+        }
+
+    def test_exact_selection_identity_lock_and_distribution(self) -> None:
+        self.assertEqual({value.row_id for value in self.strict_selected}, EXPECTED_ROW_IDS)
+        self.assertEqual({value.axiom_id for value in self.strict_selected}, EXPECTED_AXIOM_IDS)
+        predicates = [value.canonical_input.predicate_iri for value in self.strict_selected]
+        self.assertEqual(predicates.count(str(RDFS.subClassOf)), 3)
+        self.assertEqual(predicates.count(str(OWL.equivalentClass)), 3)
+        self.assertEqual(predicates.count(str(RDFS.subPropertyOf)), 9)
+        self.assertEqual(
+            sum(value.canonical_input.mapping_type == "property_chain" for value in self.strict_selected),
+            2,
+        )
+        self.assertEqual(sum(value.canonical_input.mapping_type == "domain" for value in self.strict_selected), 1)
+        self.assertEqual(sum(value.canonical_input.mapping_type == "range" for value in self.strict_selected), 1)
+
+    def test_nonselected_product_policy_is_reconciled(self) -> None:
+        counts = {"provided_through_import": 0, "deferred": 0, "emitted_unchanged": 0}
+        for row in self.disposition.rows:
+            disposition = dict(row.authoritative_axioms[0].product_dispositions)[
+                "strict_bfo_mapping"
+            ]
+            counts[disposition.status] += 1
+        self.assertEqual(counts, {"provided_through_import": 29, "deferred": 57, "emitted_unchanged": 19})
+
+    def test_wrong_disposition_category_and_prohibited_direct_selection_fail(self) -> None:
+        cases = []
+        strict_row = next(row for row in self.disposition.rows if row.row_id in EXPECTED_ROW_IDS)
+        strict_axiom = strict_row.authoritative_axioms[0]
+        wrong_strict = tuple(
+            (key, ProductDisposition("provided_through_import"))
+            if key == "strict_bfo_mapping"
+            else (key, value)
+            for key, value in strict_axiom.product_dispositions
+        )
+        cases.append(
+            dataclasses.replace(
+                strict_row,
+                authoritative_axioms=(dataclasses.replace(strict_axiom, product_dispositions=wrong_strict),),
+            )
+        )
+        cases.append(
+            dataclasses.replace(
+                strict_row,
+                authoritative_axioms=(dataclasses.replace(strict_axiom, target_category="target_neutral"),),
+            )
+        )
+        for category in ("target_neutral", "cco_bearing", "mixed_bfo_cco"):
+            row = next(
+                row
+                for row in self.disposition.rows
+                if row.authoritative_axioms[0].target_category == category
+            )
+            axiom = row.authoritative_axioms[0]
+            changed_dispositions = tuple(
+                (key, ProductDisposition("emitted_unchanged"))
+                if key == "strict_bfo_mapping"
+                else (key, value)
+                for key, value in axiom.product_dispositions
+            )
+            cases.append(
+                dataclasses.replace(
+                    row,
+                    authoritative_axioms=(dataclasses.replace(axiom, product_dispositions=changed_dispositions),),
+                )
+            )
+        for changed in cases:
+            with self.subTest(row_id=changed.row_id):
+                with self.assertRaises(modular.ModularProductError) as raised:
+                    modular.select_product_axioms(
+                        "strict_bfo_mapping",
+                        self.canonical_rows,
+                        self.audits,
+                        self.replace_disposition_row(changed.row_id, changed),
+                    )
+                self.assertTrue(
+                    self.codes(raised.exception)
+                    & {"WRONG_PRODUCT_DISPOSITION", "TARGET_CATEGORY_MISMATCH"}
+                )
+
+    def test_missing_extra_duplicate_and_substituted_row_ids_fail(self) -> None:
+        replacement = dataclasses.replace(
+            self.canonical_rows[0],
+            row_id="urn:uuid:ffffffff-ffff-4fff-8fff-ffffffffffff",
+        )
+        duplicate = (*self.canonical_rows, self.canonical_rows[0])
+        for rows in (
+            self.canonical_rows[1:],
+            (*self.canonical_rows, replacement),
+            (replacement, *self.canonical_rows[1:]),
+            duplicate,
+        ):
+            with self.subTest(count=len(rows)):
+                with self.assertRaises(modular.ModularProductError):
+                    modular.select_product_axioms(
+                        "strict_bfo_mapping", rows, self.audits, self.disposition
+                    )
+
+    def test_axiom_identity_location_hash_and_expression_mismatches_fail(self) -> None:
+        selected_row = next(row for row in self.disposition.rows if row.row_id in EXPECTED_ROW_IDS)
+        axiom = selected_row.authoritative_axioms[0]
+        changed_rows = (
+            dataclasses.replace(selected_row, authoritative_axioms=()),
+            dataclasses.replace(
+                selected_row,
+                authoritative_axioms=(dataclasses.replace(axiom, axiom_id="sha256:" + "0" * 64),),
+            ),
+            dataclasses.replace(selected_row, authoritative_axioms=(axiom, axiom)),
+        )
+        for changed in changed_rows:
+            with self.assertRaises(modular.ModularProductError):
+                modular.select_product_axioms(
+                    "strict_bfo_mapping",
+                    self.canonical_rows,
+                    self.audits,
+                    self.replace_disposition_row(selected_row.row_id, changed),
+                )
+        row = self.canonical_rows[0]
+        moved = dataclasses.replace(row, location=RowLocation("Other", row.location.row_number))
+        with self.assertRaises(modular.ModularProductError) as raised:
+            modular.select_product_axioms(
+                "strict_bfo_mapping", (moved, *self.canonical_rows[1:]), self.audits, self.disposition
+            )
+        self.assertIn("ROW_LOCATION_MISMATCH", self.codes(raised.exception))
+        for changed in (
+            dataclasses.replace(self.audits[0], source_expression_sha256="0" * 64),
+            dataclasses.replace(
+                self.audits[0],
+                expression=dataclasses.replace(
+                    self.audits[0].expression,
+                    target="<http://example.org/Changed>",
+                ),
+            ),
+        ):
+            with self.assertRaises(modular.ModularProductError):
+                modular.select_product_axioms(
+                    "strict_bfo_mapping",
+                    self.canonical_rows,
+                    (changed, *self.audits[1:]),
+                    self.disposition,
+                )
+
+    def test_duplicate_axiom_and_wrong_count_fail_build(self) -> None:
+        for selected in (
+            (*self.strict_selected, self.strict_selected[0]),
+            self.strict_selected[:-1],
+        ):
+            with self.assertRaises(modular.ModularProductError):
+                modular.build_strict_bfo_mapping(selected, self.metadata)
+
+    def test_direct_graph_identity_import_counts_and_structures(self) -> None:
+        graph = Graph().parse(data=self.strict_result.serialized_bytes.decode(), format="turtle")
+        ontology = URIRef("http://www.sks.ai/SSN2BFO/current-ssn-sosa/bfo-mapping")
+        core = URIRef("http://www.sks.ai/SSN2BFO/current-ssn-sosa/alignment-core")
+        self.assertEqual(set(graph.subjects(RDF.type, OWL.Ontology)), {ontology})
+        self.assertEqual(set(graph.triples((None, OWL.imports, None))), {(ontology, OWL.imports, core)})
+        self.assertEqual(self.strict_result.logical_triple_count, 125)
+        self.assertEqual(len(graph), 127)
+        self.assertEqual(len(set(graph.subjects(OWL.unionOf, None))), 6)
+        self.assertEqual(len(set(graph.subjects(OWL.intersectionOf, None))), 6)
+        self.assertEqual(len(set(graph.subjects(OWL.someValuesFrom, None))), 6)
+        chains = set(graph.subjects(OWL.propertyChainAxiom, None))
+        self.assertEqual(len(chains), 2)
+        self.assertTrue(
+            all(len(list(Collection(graph, next(graph.objects(chain, OWL.propertyChainAxiom))))) == 3 for chain in chains)
+        )
+        self.assertEqual(self.strict_result.rdf_list_count, 14)
+        self.assertFalse(any(True for _ in graph.triples((None, OWL.inverseOf, None))))
+
+    def test_import_vocabulary_and_copied_declarations_are_rejected(self) -> None:
+        graph = Graph().parse(data=self.strict_result.serialized_bytes.decode(), format="turtle")
+        ontology = URIRef(self.strict_result.metadata.stable_ontology_iri)
+        graph.add((ontology, OWL.imports, URIRef("http://example.org/external")))
+        graph.add((URIRef("http://www.w3.org/ns/sosa/Sensor"), RDF.type, OWL.Class))
+        graph.add((URIRef("http://purl.obolibrary.org/obo/BFO_0000001"), RDF.type, OWL.Class))
+        graph.add((BNode("annotation"), RDF.type, OWL.Axiom))
+        data = graph.serialize(format="turtle").encode()
+        codes = self.validate_bytes(data)
+        self.assertIn("IMPORT_POLICY_MISMATCH", codes)
+        self.assertIn("COPIED_SOURCE_DECLARATION", codes)
+        self.assertIn("COPIED_BFO_DECLARATION", codes)
+        self.assertIn("ANNOTATION_ONLY_PSEUDO_MAPPING", codes)
+        for original, replacement in (
+            (b"http://purl.obolibrary.org/obo/BFO_0000001", b"https://www.commoncoreontologies.org/Artifact"),
+            (b"http://purl.obolibrary.org/obo/BFO_0000001", b"http://purl.obolibrary.org/obo/RO_0000052"),
+            (b"http://purl.obolibrary.org/obo/BFO_0000001", b"http://example.org/Unexpected"),
+        ):
+            if original in self.strict_result.serialized_bytes:
+                self.assertTrue(
+                    self.validate_bytes(self.strict_result.serialized_bytes.replace(original, replacement, 1))
+                    & {"PROHIBITED_LOGICAL_VOCABULARY", "UNEXPECTED_LOGICAL_VOCABULARY"}
+                )
+
+    def test_deterministic_serialization_and_alignment_core_preservation(self) -> None:
+        reversed_result = modular.build_strict_bfo_mapping(
+            tuple(reversed(self.strict_selected)), self.metadata
+        )
+        self.assertEqual(reversed_result.serialized_bytes, self.strict_result.serialized_bytes)
+        self.assertTrue(self.strict_result.serialized_bytes.endswith(b"\n"))
+        self.assertFalse(self.strict_result.serialized_bytes.endswith(b"\n\n"))
+        self.assertEqual(
+            hashlib.sha256(self.core_result.serialized_bytes).hexdigest(),
+            "95f71184b90224906b0ba703d0ea60fd2f8b993b3853b803c66b88b91ba0b01c",
+        )
+
+    def test_processed_row_and_audit_order_do_not_affect_strict_bfo_output(self) -> None:
+        baseline_selected = modular.select_product_axioms(
+            "strict_bfo_mapping",
+            self.canonical_rows,
+            self.audits,
+            self.disposition,
+        )
+        baseline_result = modular.build_strict_bfo_mapping(
+            baseline_selected,
+            self.metadata,
+        )
+        reordered_selected = modular.select_product_axioms(
+            "strict_bfo_mapping",
+            tuple(reversed(self.canonical_rows)),
+            tuple(reversed(self.audits)),
+            self.disposition,
+        )
+        reordered_result = modular.build_strict_bfo_mapping(
+            reordered_selected,
+            self.metadata,
+        )
+
+        self.assertEqual(len(reordered_selected), 19)
+        self.assertEqual(
+            {value.row_id for value in reordered_selected},
+            {value.row_id for value in baseline_selected},
+        )
+        self.assertEqual(
+            {value.axiom_id for value in reordered_selected},
+            {value.axiom_id for value in baseline_selected},
+        )
+        baseline_bytes = modular.serialize_modular_product(baseline_result)
+        reordered_bytes = modular.serialize_modular_product(reordered_result)
+        self.assertEqual(reordered_bytes, baseline_bytes)
+        self.assertEqual(
+            hashlib.sha256(reordered_bytes).hexdigest(),
+            "15f080145c6803d174a00cf9e13c971925b40485049744dba6e0847093016ea7",
+        )
+
+    def test_fresh_process_generation_is_byte_deterministic(self) -> None:
+        code = (
+            "from pathlib import Path; import hashlib; "
+            "import generate_mapping_from_coms as g; "
+            "from product_dispositions import load_disposition_document; "
+            "from publication_metadata import load_metadata; "
+            "from modular_products import select_product_axioms,build_strict_bfo_mapping; "
+            "r,s=g.read_workbook(Path('mappings/SSN2BFO-COMS.xlsx')); "
+            "p=g.validate_and_process_rows(r,g.Resolver(),s); "
+            "c=[g.canonical_input_for_processed_row(x) for x in p]; "
+            "a=[x.identity_audit for x in p]; "
+            "d=load_disposition_document('reports/coms-product-dispositions.json'); "
+            "m=load_metadata('config/publication-metadata.toml'); "
+            "x=build_strict_bfo_mapping(select_product_axioms('strict_bfo_mapping',c,a,d),m); "
+            "print(hashlib.sha256(x.serialized_bytes).hexdigest())"
+        )
+        values = []
+        for _ in range(2):
+            proc = subprocess.run(
+                [sys.executable, "-c", code],
+                cwd=REPO_ROOT,
+                env={"PYTHONPATH": str(REPO_ROOT / "tools")},
+                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                check=True,
+            )
+            values.append(proc.stdout.strip())
+        self.assertEqual(values, [self.strict_result.sha256, self.strict_result.sha256])
+
+    def test_root_and_project_module_reconciliation(self) -> None:
+        self.assertEqual(
+            modular.validate_strict_bfo_mapping(
+                self.strict_result.serialized_bytes,
+                self.strict_selected,
+                self.core_result.serialized_bytes,
+                self.core_selected,
+                self.metadata,
+                integrated_graph=self.root_graph,
+            ),
+            (),
+        )
+        strict_ids = {value.axiom_id for value in self.strict_selected}
+        core_ids = {value.axiom_id for value in self.core_selected}
+        self.assertFalse(strict_ids & core_ids)
+        self.assertEqual(len(strict_ids | core_ids), 48)
+        graph = Graph().parse(data=self.strict_result.serialized_bytes.decode(), format="turtle")
+        graph.parse(data=self.core_result.serialized_bytes.decode(), format="turtle")
+        self.assertEqual(len(graph), 181)
+        for triple in list(graph.triples((None, OWL.imports, None))):
+            graph.remove(triple)
+        self.assertEqual(len(graph), 180)
+
+    def test_fixed_pinned_merged_cco_bfo_closure(self) -> None:
+        dependencies = (
+            REPO_ROOT / "imports/cco.ttl",
+            REPO_ROOT / "imports/sosa.ttl",
+            REPO_ROOT / "imports/sosa-sampling.ttl",
+            REPO_ROOT / "imports/ssn.ttl",
+            REPO_ROOT / "imports/ssn-systems.ttl",
+        )
+        self.assertTrue(all(path.is_file() for path in dependencies))
+        closure = modular.build_fixed_validation_closure(
+            (self.strict_result.serialized_bytes, self.core_result.serialized_bytes),
+            dependencies,
+            coms.CLEANUP_TRIPLES,
+        )
+        self.assertEqual(len(closure), 14972)
+        self.assertFalse(any(True for _ in closure.triples((None, OWL.imports, None))))
+        bfo_iris = {
+            iri
+            for selected in self.strict_selected
+            for iri in modular.axiom_input_from_canonical_row(
+                selected.identity,
+                selected.canonical_input,
+            ).target_iris
+            if iri.startswith(modular.BFO_NAMESPACE)
+        }
+        self.assertEqual(len(bfo_iris), 14)
+        cco = Graph().parse(REPO_ROOT / "imports/cco.ttl", format="turtle")
+        self.assertTrue(all(any(True for _ in cco.triples((URIRef(iri), None, None))) for iri in bfo_iris))
+        self.assertEqual(self.validate_bytes(self.strict_result.serialized_bytes, closure=closure), set())
+
+    def test_pinned_closure_hermit_is_clean(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="strict-bfo-hermit-") as temp:
+            root = Path(temp)
+            strict_path = root / "strict.ttl"
+            core_path = root / "core.ttl"
+            strict_path.write_bytes(self.strict_result.serialized_bytes)
+            core_path.write_bytes(self.core_result.serialized_bytes)
+            result = coms.run_strict_bfo_hermit(strict_path, core_path, root / "reasoner")
+        self.assertTrue(result.passed, result.robot_output)
+        self.assertEqual(result.return_code, 0)
+        self.assertTrue(result.reasoned_output_produced)
+        self.assertEqual(result.closure_triple_count, 14972)
+        self.assertEqual(result.unsat_classes, [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/check_coms_mapping.py
+++ b/tools/check_coms_mapping.py
@@ -60,6 +60,7 @@ MAINTAINED_OUTPUTS = {
     "diff_report": REPO_ROOT / "reports/coms-vs-pre-coms-legacy-diff.md",
     "disposition_report": REPO_ROOT / "reports/coms-product-dispositions.json",
     "alignment_core": REPO_ROOT / "releases/current-ssn-sosa/ssn-sosa-alignment-core.ttl",
+    "strict_bfo_mapping": REPO_ROOT / "releases/current-ssn-sosa/ssn-sosa-bfo-mapping.ttl",
 }
 
 METADATA_LABELS = {
@@ -75,6 +76,8 @@ METADATA_LABELS = {
     "product-disposition JSON SHA-256": "disposition_report_sha256",
     "maintained alignment-core path": "alignment_core_path",
     "alignment-core Turtle SHA-256": "alignment_core_sha256",
+    "maintained strict-BFO path": "strict_bfo_mapping_path",
+    "strict-BFO Turtle SHA-256": "strict_bfo_mapping_sha256",
 }
 
 
@@ -173,6 +176,7 @@ def transaction_paths(transaction_dir: Path) -> dict[str, Path]:
         "diff_report": transaction_dir / "reports/coms-vs-pre-coms-legacy-diff.md",
         "disposition_report": transaction_dir / "reports/coms-product-dispositions.json",
         "alignment_core": transaction_dir / "releases/current-ssn-sosa/ssn-sosa-alignment-core.ttl",
+        "strict_bfo_mapping": transaction_dir / "releases/current-ssn-sosa/ssn-sosa-bfo-mapping.ttl",
         "summary": transaction_dir / "summary.json",
         "hermit": transaction_dir / "hermit",
     }
@@ -193,6 +197,8 @@ def run_generator(paths: dict[str, Path], log: list[str]) -> None:
         str(paths["disposition_report"]),
         "--alignment-core-output",
         str(paths["alignment_core"]),
+        "--strict-bfo-output",
+        str(paths["strict_bfo_mapping"]),
         "--coverage-report",
         str(paths["coverage_report"]),
         "--diff-report",
@@ -207,6 +213,8 @@ def run_generator(paths: dict[str, Path], log: list[str]) -> None:
         relative(MAINTAINED_OUTPUTS["disposition_report"]),
         "--report-alignment-core-path",
         relative(MAINTAINED_OUTPUTS["alignment_core"]),
+        "--report-strict-bfo-path",
+        relative(MAINTAINED_OUTPUTS["strict_bfo_mapping"]),
         "--summary-json",
         str(paths["summary"]),
     ]
@@ -337,6 +345,75 @@ def validate_temporary_outputs(
         log,
     )
 
+    strict_path = paths["strict_bfo_mapping"]
+    strict_hash = sha256_file(strict_path)
+    strict_summary = summary.get("strict_bfo_mapping")
+    if not isinstance(strict_summary, dict):
+        raise CheckFailure("generator summary is missing strict-BFO results")
+    strict_metadata = next(
+        product
+        for product in publication_metadata.products
+        if product.key == "strict_bfo_mapping"
+    )
+    expected_strict = {
+        "product_key": "strict_bfo_mapping",
+        "stable_ontology_iri": strict_metadata.stable_ontology_iri,
+        "governed_axiom_count": 19,
+        "logical_triple_count": 125,
+        "ontology_header_triple_count": 2,
+        "import_triple_count": 1,
+        "total_triple_count": 127,
+        "subclass_axiom_count": 3,
+        "equivalent_class_axiom_count": 3,
+        "direct_subproperty_axiom_count": 9,
+        "property_chain_axiom_count": 2,
+        "domain_axiom_count": 1,
+        "range_axiom_count": 1,
+        "union_expression_count": 6,
+        "intersection_expression_count": 6,
+        "existential_restriction_count": 6,
+        "rdf_list_count": 14,
+        "project_closure_governed_axiom_count": 48,
+        "project_graph_triple_count": 181,
+        "local_project_graph_triple_count": 180,
+        "hermit_return_code": 0,
+        "hermit_result": "PASS",
+        "closure_triple_count": 14972,
+        "named_unsat_count": 0,
+    }
+    for field, expected in expected_strict.items():
+        if strict_summary.get(field) != expected:
+            raise CheckFailure(
+                f"strict-BFO summary mismatch for {field}: "
+                f"expected {expected!r}, got {strict_summary.get(field)!r}"
+            )
+    if summary.get("strict_bfo_mapping_sha256") != strict_hash:
+        raise CheckFailure("strict-BFO hash does not match generator summary")
+    strict_graph = Graph()
+    try:
+        strict_graph.parse(strict_path, format="turtle")
+    except Exception as exc:
+        raise CheckFailure(
+            f"strict-BFO parse failed: {type(exc).__name__}: {exc}"
+        ) from exc
+    strict_ontology_iri = URIRef(strict_metadata.stable_ontology_iri)
+    if set(strict_graph.subjects(RDF.type, OWL.Ontology)) != {strict_ontology_iri}:
+        raise CheckFailure("strict BFO mapping has an incorrect ontology declaration")
+    expected_import = URIRef(alignment_metadata.stable_ontology_iri)
+    if set(strict_graph.triples((None, OWL.imports, None))) != {
+        (strict_ontology_iri, OWL.imports, expected_import)
+    }:
+        raise CheckFailure("strict BFO mapping must import only the alignment core")
+    if len(strict_graph) != 127:
+        raise CheckFailure(
+            f"strict-BFO parsed triple count is {len(strict_graph)}, expected 127"
+        )
+    emit(
+        "Strict BFO mapping: PASS "
+        "(19 direct governed axioms; 125 logical triples; 127 total triples)",
+        log,
+    )
+
     emit("[5/11] Confirming maintained SPARQL source-term coverage checks ran", log)
     coverage = summary.get("source_term_coverage")
     if not isinstance(coverage, dict):
@@ -399,6 +476,8 @@ def validate_temporary_outputs(
         "disposition_report_sha256": disposition_hash,
         "alignment_core_path": relative(MAINTAINED_OUTPUTS["alignment_core"]),
         "alignment_core_sha256": alignment_hash,
+        "strict_bfo_mapping_path": relative(MAINTAINED_OUTPUTS["strict_bfo_mapping"]),
+        "strict_bfo_mapping_sha256": strict_hash,
     }
     for key, expected in expected_metadata.items():
         if metadata.get(key) != expected:
@@ -410,6 +489,7 @@ def validate_temporary_outputs(
         paths["coverage_report"],
         paths["diff_report"],
         paths["alignment_core"],
+        paths["strict_bfo_mapping"],
     ):
         assert_no_trailing_whitespace(path)
     return summary
@@ -479,6 +559,12 @@ def freshness_errors(workbook_hash: str, generator_hash: str) -> list[str]:
         errors.append("alignment-core path differs from the generated report")
     if metadata.get("alignment_core_sha256") != alignment_hash:
         errors.append("alignment-core hash differs from the generated report")
+    strict_path = MAINTAINED_OUTPUTS["strict_bfo_mapping"]
+    strict_hash = sha256_file(strict_path)
+    if metadata.get("strict_bfo_mapping_path") != relative(strict_path):
+        errors.append("strict-BFO path differs from the generated report")
+    if metadata.get("strict_bfo_mapping_sha256") != strict_hash:
+        errors.append("strict-BFO hash differs from the generated report")
     try:
         disposition = load_disposition_document(disposition_path)
         publication_metadata = load_metadata(PUBLICATION_METADATA)
@@ -520,6 +606,7 @@ def output_differences(paths: dict[str, Path]) -> list[str]:
         "diff_report",
         "disposition_report",
         "alignment_core",
+        "strict_bfo_mapping",
     ):
         current = MAINTAINED_OUTPUTS[name]
         if not current.is_file() or current.read_bytes() != paths[name].read_bytes():
@@ -598,6 +685,9 @@ def record_success(summary: dict[str, object], workbook_hash: str, generator_has
         "alignment_core_path": summary.get("alignment_core_path"),
         "alignment_core_sha256": summary.get("alignment_core_sha256"),
         "alignment_core": summary.get("alignment_core"),
+        "strict_bfo_mapping_path": summary.get("strict_bfo_mapping_path"),
+        "strict_bfo_mapping_sha256": summary.get("strict_bfo_mapping_sha256"),
+        "strict_bfo_mapping": summary.get("strict_bfo_mapping"),
         "timestamp": utc_now(),
         "generated_ontology_triple_count": summary.get("generated_ontology_triple_count"),
         "candidate_closure_triple_count": summary.get("candidate_closure_triple_count"),

--- a/tools/generate_mapping_from_coms.py
+++ b/tools/generate_mapping_from_coms.py
@@ -46,9 +46,12 @@ from modular_products import (
     ModularProductResult,
     build_alignment_core,
     build_fixed_source_closure,
+    build_fixed_validation_closure,
+    build_strict_bfo_mapping,
     select_product_axioms,
     serialize_modular_product,
     validate_alignment_core,
+    validate_strict_bfo_mapping,
 )
 from publication_metadata import PublicationMetadataError, load_metadata
 
@@ -128,6 +131,8 @@ SOURCE_IMPORTS = (
     Path("imports/ssn.ttl"),
     Path("imports/ssn-systems.ttl"),
 )
+
+BFO_VALIDATION_DEPENDENCY = Path("imports/cco.ttl")
 
 CANDIDATE_CLOSURE_INPUTS = (
     Path("imports/cco.ttl"),
@@ -1387,6 +1392,89 @@ def run_alignment_core_hermit(generated_path: Path, tmp_dir: Path) -> HermitResu
     )
 
 
+def run_strict_bfo_hermit(
+    generated_path: Path,
+    alignment_core_path: Path,
+    tmp_dir: Path,
+) -> HermitResult:
+    """Reason over the strict product and its explicit pinned validation closure."""
+
+    generated_graph = Graph()
+    generated_graph.parse(generated_path, format="turtle")
+    closure = build_fixed_validation_closure(
+        (generated_path.read_bytes(), alignment_core_path.read_bytes()),
+        (
+            REPO_ROOT / BFO_VALIDATION_DEPENDENCY,
+            *(REPO_ROOT / path for path in SOURCE_IMPORTS),
+        ),
+        CLEANUP_TRIPLES,
+    )
+
+    tmp_dir.mkdir(parents=True, exist_ok=True)
+    graph_path = tmp_dir / "strict-bfo-pinned-merged-cco-bfo-closure.ttl"
+    reasoned_path = tmp_dir / "strict-bfo-pinned-merged-cco-bfo-closure-reasoned.ttl"
+    if reasoned_path.exists():
+        reasoned_path.unlink()
+    closure.serialize(destination=graph_path, format="turtle")
+
+    robot = shutil.which("robot")
+    if robot is None:
+        return HermitResult(
+            graph_path=graph_path,
+            reasoned_path=reasoned_path,
+            generated_triple_count=len(generated_graph),
+            closure_triple_count=len(closure),
+            return_code=None,
+            reasoned_output_produced=False,
+            owl_nothing_count=None,
+            unsat_classes=[],
+            robot_output="ROBOT executable not found on PATH.",
+            robot_path=None,
+        )
+
+    command = [
+        robot,
+        "reason",
+        "--reasoner",
+        "HermiT",
+        "--input",
+        str(graph_path),
+        "--output",
+        str(reasoned_path),
+    ]
+    proc = subprocess.run(
+        command,
+        cwd=REPO_ROOT,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    output = "\n".join(part for part in (proc.stdout.strip(), proc.stderr.strip()) if part)
+    output_unsats = {URIRef(match.group(1)) for match in UNSAT_RE.finditer(output)}
+    reasoned_output_produced = reasoned_path.exists() and reasoned_path.stat().st_size > 0
+    owl_nothing_count: int | None = None
+    inferred_unsats: set[URIRef] = set(output_unsats)
+    if reasoned_output_produced:
+        reasoned_graph = Graph()
+        bind_prefixes(reasoned_graph)
+        reasoned_graph.parse(reasoned_path, format="turtle")
+        inferred_unsats |= set(unsat_classes(reasoned_graph))
+        owl_nothing_count = len(inferred_unsats)
+
+    return HermitResult(
+        graph_path=graph_path,
+        reasoned_path=reasoned_path,
+        generated_triple_count=len(generated_graph),
+        closure_triple_count=len(closure),
+        return_code=proc.returncode,
+        reasoned_output_produced=reasoned_output_produced,
+        owl_nothing_count=owl_nothing_count,
+        unsat_classes=sorted(inferred_unsats, key=str),
+        robot_output=output,
+        robot_path=robot,
+    )
+
+
 def build_and_write_alignment_core(
     processed_rows: list[ProcessedRow],
     identity_audits: list[CanonicalRowAudit],
@@ -1429,6 +1517,66 @@ def build_and_write_alignment_core(
     if not hermit.passed:
         output_path.unlink(missing_ok=True)
         raise GenerationError("alignment-core fixed source closure is not HermiT-clean")
+    return result, hermit
+
+
+def build_and_write_strict_bfo_mapping(
+    processed_rows: list[ProcessedRow],
+    identity_audits: list[CanonicalRowAudit],
+    disposition_document: DispositionDocument,
+    integrated_graph: Graph,
+    alignment_core_result: ModularProductResult,
+    alignment_core_path: Path,
+    output_path: Path,
+    tmp_dir: Path,
+) -> tuple[ModularProductResult, HermitResult]:
+    """Build and validate the strict BFO development artifact and fixed closure."""
+
+    try:
+        metadata = load_metadata(PUBLICATION_METADATA)
+        canonical_rows = [canonical_input_for_processed_row(item) for item in processed_rows]
+        selected = select_product_axioms(
+            "strict_bfo_mapping",
+            canonical_rows,
+            identity_audits,
+            disposition_document,
+        )
+        alignment_selected = tuple(
+            axiom
+            for row in alignment_core_result.selected_rows
+            for axiom in row.axioms
+        )
+        result = build_strict_bfo_mapping(selected, metadata)
+        fixed_closure = build_fixed_validation_closure(
+            (result.serialized_bytes, alignment_core_result.serialized_bytes),
+            (
+                REPO_ROOT / BFO_VALIDATION_DEPENDENCY,
+                *(REPO_ROOT / path for path in SOURCE_IMPORTS),
+            ),
+            CLEANUP_TRIPLES,
+        )
+        structural_issues = validate_strict_bfo_mapping(
+            result.serialized_bytes,
+            selected,
+            alignment_core_result.serialized_bytes,
+            alignment_selected,
+            metadata,
+            integrated_graph=integrated_graph,
+            fixed_semantic_closure=fixed_closure,
+        )
+        if structural_issues:
+            raise ModularProductError(structural_issues)
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_bytes(serialize_modular_product(result))
+        hermit = run_strict_bfo_hermit(output_path, alignment_core_path, tmp_dir)
+    except (ModularProductError, PublicationMetadataError) as exc:
+        output_path.unlink(missing_ok=True)
+        raise GenerationError(str(exc)) from exc
+    if not hermit.passed:
+        output_path.unlink(missing_ok=True)
+        raise GenerationError(
+            "strict BFO mapping pinned merged CCO/BFO validation closure is not HermiT-clean"
+        )
     return result, hermit
 
 
@@ -1855,6 +2003,10 @@ def write_generation_report(
     alignment_core_path: Path | None = None,
     alignment_core_sha256: str = "unavailable",
     alignment_core_hermit: HermitResult | None = None,
+    strict_bfo_result: ModularProductResult | None = None,
+    strict_bfo_path: Path | None = None,
+    strict_bfo_sha256: str = "unavailable",
+    strict_bfo_hermit: HermitResult | None = None,
 ) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     error_lines = [f"- {error}" for error in errors] or ["- none"]
@@ -1888,6 +2040,8 @@ def write_generation_report(
         f"| product-disposition JSON SHA-256 | `{disposition_sha256}` |",
         f"| maintained alignment-core path | `{alignment_core_path or 'unavailable'}` |",
         f"| alignment-core Turtle SHA-256 | `{alignment_core_sha256}` |",
+        f"| maintained strict-BFO path | `{strict_bfo_path or 'unavailable'}` |",
+        f"| strict-BFO Turtle SHA-256 | `{strict_bfo_sha256}` |",
         "",
         "## Workbook",
         "",
@@ -2007,6 +2161,52 @@ def write_generation_report(
             "- Full publication metadata and formal release identity remain deferred.",
         ]
 
+    if strict_bfo_result is None:
+        strict_bfo_lines = [
+            "## Strict BFO Mapping",
+            "",
+            "- Generation and validation: unavailable",
+        ]
+    else:
+        closure_paths = ", ".join(
+            f"`{path}`"
+            for path in (*SOURCE_IMPORTS, BFO_VALIDATION_DEPENDENCY)
+        )
+        strict_bfo_lines = [
+            "## Strict BFO Mapping",
+            "",
+            "This is the maintained authoritative development artifact at the approved production path; it is not a frozen formal release.",
+            "",
+            f"- Path: `{strict_bfo_path}`",
+            f"- Stable ontology IRI: `{strict_bfo_result.metadata.stable_ontology_iri}`",
+            f"- Direct governed authoritative axioms: {strict_bfo_result.governed_axiom_count}",
+            f"- Subclass axioms: {strict_bfo_result.subclass_axiom_count}",
+            f"- Equivalent-class axioms: {strict_bfo_result.equivalent_class_axiom_count}",
+            f"- Direct subproperty axioms: {strict_bfo_result.direct_subproperty_axiom_count}",
+            f"- Property-chain axioms: {strict_bfo_result.property_chain_axiom_count}",
+            f"- Domain axioms: {strict_bfo_result.domain_axiom_count}",
+            f"- Range axioms: {strict_bfo_result.range_axiom_count}",
+            f"- Logical RDF triples: {strict_bfo_result.logical_triple_count}",
+            f"- Ontology-header and import triples: {strict_bfo_result.ontology_header_triple_count}",
+            f"- Total RDF triples: {strict_bfo_result.total_triple_count}",
+            "- Import: `http://www.sks.ai/SSN2BFO/current-ssn-sosa/alignment-core`",
+            "- Imported alignment-core governed axioms: 29",
+            "- Project-module closure governed axioms: 48",
+            "- Direct/alignment-core governed overlap: 0",
+            "- CCO/RO and unexpected logical-vocabulary audit: PASS",
+            "- Integrated-root and project-module canonical-axiom reconciliation: PASS",
+            "- Deterministic serialization: PASS",
+            f"- Pinned merged CCO/BFO validation closure: {closure_paths}",
+            f"- Pinned closure triple count: {'n/a' if strict_bfo_hermit is None else strict_bfo_hermit.closure_triple_count}",
+            f"- HermiT return code: {'n/a' if strict_bfo_hermit is None else strict_bfo_hermit.return_code}",
+            f"- Reasoned output produced: {'no' if strict_bfo_hermit is None else 'yes' if strict_bfo_hermit.reasoned_output_produced else 'no'}",
+            f"- Named unsatisfiable classes: {'n/a' if strict_bfo_hermit is None else len(strict_bfo_hermit.unsat_classes)}",
+            f"- HermiT result: {'FAIL' if strict_bfo_hermit is None else 'PASS' if strict_bfo_hermit.passed else 'FAIL'}",
+            "- The validation dependency `imports/cco.ttl` is not imported by the published strict graph and does not authorize CCO mappings or transformations.",
+            "- The 57 CCO-bearing or mixed mappings remain deferred; no transformation or projection is implemented.",
+            "- Full publication metadata and formal release identity remain deferred.",
+        ]
+
     lines.extend(
         [
             "",
@@ -2075,6 +2275,8 @@ def write_generation_report(
             *disposition_lines,
             "",
             *alignment_core_lines,
+            "",
+            *strict_bfo_lines,
             "",
             "## Generated Ontology",
             "",
@@ -2275,6 +2477,10 @@ def write_summary_json(
     alignment_core_path: Path | None = None,
     alignment_core_sha256: str = "unavailable",
     alignment_core_hermit: HermitResult | None = None,
+    strict_bfo_result: ModularProductResult | None = None,
+    strict_bfo_path: Path | None = None,
+    strict_bfo_sha256: str = "unavailable",
+    strict_bfo_hermit: HermitResult | None = None,
 ) -> None:
     payload = {
         "status": "PASS" if not errors else "FAIL",
@@ -2309,6 +2515,36 @@ def write_summary_json(
             "hermit_result": "FAIL" if alignment_core_hermit is None else "PASS" if alignment_core_hermit.passed else "FAIL",
             "closure_triple_count": None if alignment_core_hermit is None else alignment_core_hermit.closure_triple_count,
             "named_unsat_count": None if alignment_core_hermit is None else len(alignment_core_hermit.unsat_classes),
+        },
+        "strict_bfo_mapping_path": None if strict_bfo_path is None else str(strict_bfo_path),
+        "strict_bfo_mapping_sha256": strict_bfo_sha256,
+        "strict_bfo_mapping": None
+        if strict_bfo_result is None
+        else {
+            "product_key": strict_bfo_result.metadata.product_key,
+            "stable_ontology_iri": strict_bfo_result.metadata.stable_ontology_iri,
+            "governed_axiom_count": strict_bfo_result.governed_axiom_count,
+            "logical_triple_count": strict_bfo_result.logical_triple_count,
+            "ontology_header_triple_count": strict_bfo_result.ontology_header_triple_count,
+            "import_triple_count": strict_bfo_result.import_triple_count,
+            "total_triple_count": strict_bfo_result.total_triple_count,
+            "subclass_axiom_count": strict_bfo_result.subclass_axiom_count,
+            "equivalent_class_axiom_count": strict_bfo_result.equivalent_class_axiom_count,
+            "direct_subproperty_axiom_count": strict_bfo_result.direct_subproperty_axiom_count,
+            "property_chain_axiom_count": strict_bfo_result.property_chain_axiom_count,
+            "domain_axiom_count": strict_bfo_result.domain_axiom_count,
+            "range_axiom_count": strict_bfo_result.range_axiom_count,
+            "union_expression_count": strict_bfo_result.union_target_count,
+            "intersection_expression_count": strict_bfo_result.intersection_expression_count,
+            "existential_restriction_count": strict_bfo_result.existential_restriction_count,
+            "rdf_list_count": strict_bfo_result.rdf_list_count,
+            "project_closure_governed_axiom_count": 48,
+            "project_graph_triple_count": 181,
+            "local_project_graph_triple_count": 180,
+            "hermit_return_code": None if strict_bfo_hermit is None else strict_bfo_hermit.return_code,
+            "hermit_result": "FAIL" if strict_bfo_hermit is None else "PASS" if strict_bfo_hermit.passed else "FAIL",
+            "closure_triple_count": None if strict_bfo_hermit is None else strict_bfo_hermit.closure_triple_count,
+            "named_unsat_count": None if strict_bfo_hermit is None else len(strict_bfo_hermit.unsat_classes),
         },
         "worksheets_read": stats.worksheets_read,
         "active_axiom_rows": stats.active_axiom_rows,
@@ -2409,6 +2645,11 @@ def main(argv: list[str] | None = None) -> int:
         help="Generated import-free SSN/SOSA alignment-core Turtle path.",
     )
     parser.add_argument(
+        "--strict-bfo-output",
+        required=True,
+        help="Generated strict SSN/SOSA-to-BFO mapping Turtle path.",
+    )
+    parser.add_argument(
         "--coverage-report",
         default="reports/coms-source-term-coverage.md",
         help="Source-term coverage report path.",
@@ -2440,6 +2681,10 @@ def main(argv: list[str] | None = None) -> int:
         help="Alignment-core path displayed in reports. Defaults to the actual --alignment-core-output path.",
     )
     parser.add_argument(
+        "--report-strict-bfo-path",
+        help="Strict-BFO path displayed in reports. Defaults to the actual --strict-bfo-output path.",
+    )
+    parser.add_argument(
         "--summary-json",
         help="Optional machine-readable generation summary path.",
     )
@@ -2451,12 +2696,14 @@ def main(argv: list[str] | None = None) -> int:
     report_path = REPO_ROOT / args.report if not Path(args.report).is_absolute() else Path(args.report)
     disposition_report_path = REPO_ROOT / args.disposition_report if not Path(args.disposition_report).is_absolute() else Path(args.disposition_report)
     alignment_core_output_path = REPO_ROOT / args.alignment_core_output if not Path(args.alignment_core_output).is_absolute() else Path(args.alignment_core_output)
+    strict_bfo_output_path = REPO_ROOT / args.strict_bfo_output if not Path(args.strict_bfo_output).is_absolute() else Path(args.strict_bfo_output)
     coverage_report_path = REPO_ROOT / args.coverage_report if not Path(args.coverage_report).is_absolute() else Path(args.coverage_report)
     diff_report_path = REPO_ROOT / args.diff_report if not Path(args.diff_report).is_absolute() else Path(args.diff_report)
     report_workbook_path = Path(args.report_workbook_path) if args.report_workbook_path else input_path
     report_output_path = Path(args.report_output_path) if args.report_output_path else output_path
     report_disposition_path = Path(args.report_disposition_path) if args.report_disposition_path else disposition_report_path
     report_alignment_core_path = Path(args.report_alignment_core_path) if args.report_alignment_core_path else alignment_core_output_path
+    report_strict_bfo_path = Path(args.report_strict_bfo_path) if args.report_strict_bfo_path else strict_bfo_output_path
     summary_json_path = None
     if args.summary_json:
         summary_json_path = REPO_ROOT / args.summary_json if not Path(args.summary_json).is_absolute() else Path(args.summary_json)
@@ -2470,6 +2717,7 @@ def main(argv: list[str] | None = None) -> int:
     candidate_sha256 = "unavailable"
     disposition_sha256 = "unavailable"
     alignment_core_sha256 = "unavailable"
+    strict_bfo_sha256 = "unavailable"
 
     stats = WorkbookStats()
     resolver = Resolver()
@@ -2482,6 +2730,8 @@ def main(argv: list[str] | None = None) -> int:
     disposition_document: DispositionDocument | None = None
     alignment_core_result: ModularProductResult | None = None
     alignment_core_hermit: HermitResult | None = None
+    strict_bfo_result: ModularProductResult | None = None
+    strict_bfo_hermit: HermitResult | None = None
 
     try:
         rows, stats = read_workbook(input_path)
@@ -2513,6 +2763,17 @@ def main(argv: list[str] | None = None) -> int:
             Path(args.tmp_dir) / "alignment-core",
         )
         alignment_core_sha256 = sha256_file(alignment_core_output_path)
+        strict_bfo_result, strict_bfo_hermit = build_and_write_strict_bfo_mapping(
+            processed,
+            identity_audits,
+            disposition_document,
+            graph,
+            alignment_core_result,
+            alignment_core_output_path,
+            strict_bfo_output_path,
+            Path(args.tmp_dir) / "strict-bfo",
+        )
+        strict_bfo_sha256 = sha256_file(strict_bfo_output_path)
         normalized_rows = normalized_axiom_rows(processed, graph)
         coverage = build_coverage(processed, [], coverage_report_path)
         graph.parse(output_path, format="turtle")
@@ -2556,6 +2817,10 @@ def main(argv: list[str] | None = None) -> int:
         alignment_core_path=report_alignment_core_path,
         alignment_core_sha256=alignment_core_sha256,
         alignment_core_hermit=alignment_core_hermit,
+        strict_bfo_result=strict_bfo_result,
+        strict_bfo_path=report_strict_bfo_path,
+        strict_bfo_sha256=strict_bfo_sha256,
+        strict_bfo_hermit=strict_bfo_hermit,
     )
     if summary_json_path is not None:
         write_summary_json(
@@ -2584,6 +2849,10 @@ def main(argv: list[str] | None = None) -> int:
             alignment_core_path=report_alignment_core_path,
             alignment_core_sha256=alignment_core_sha256,
             alignment_core_hermit=alignment_core_hermit,
+            strict_bfo_result=strict_bfo_result,
+            strict_bfo_path=report_strict_bfo_path,
+            strict_bfo_sha256=strict_bfo_sha256,
+            strict_bfo_hermit=strict_bfo_hermit,
         )
 
     print(f"Wrote {report_path}")
@@ -2597,6 +2866,8 @@ def main(argv: list[str] | None = None) -> int:
         print(f"Wrote {disposition_report_path}")
     if alignment_core_output_path.exists():
         print(f"Wrote {alignment_core_output_path}")
+    if strict_bfo_output_path.exists():
+        print(f"Wrote {strict_bfo_output_path}")
     print(f"Worksheets read: {', '.join(stats.worksheets_read) or 'none'}")
     print(f"Mapped rows: {stats.mapped_rows}")
     print(f"Blank mapping rows: {stats.blank_mapping_rows}")
@@ -2626,6 +2897,16 @@ def main(argv: list[str] | None = None) -> int:
         print(f"Alignment-core SHA-256: {alignment_core_result.sha256}")
     if alignment_core_hermit is not None:
         print(f"Alignment-core source-closure HermiT: {'PASS' if alignment_core_hermit.passed else 'FAIL'}")
+    if strict_bfo_result is not None:
+        print(f"Strict-BFO governed axioms: {strict_bfo_result.governed_axiom_count}")
+        print(f"Strict-BFO logical triples: {strict_bfo_result.logical_triple_count}")
+        print(f"Strict-BFO total triples: {strict_bfo_result.total_triple_count}")
+        print(f"Strict-BFO SHA-256: {strict_bfo_result.sha256}")
+    if strict_bfo_hermit is not None:
+        print(
+            "Strict-BFO pinned merged CCO/BFO closure HermiT: "
+            f"{'PASS' if strict_bfo_hermit.passed else 'FAIL'}"
+        )
     if hermit is not None:
         print(f"Generated triple count: {hermit.generated_triple_count}")
         print(f"Candidate closure triple count: {hermit.closure_triple_count}")

--- a/tools/modular_products.py
+++ b/tools/modular_products.py
@@ -28,6 +28,7 @@ from product_dispositions import (
     ProductDisposition,
     axiom_input_from_canonical_row,
     classify_target_category,
+    derive_product_dispositions,
 )
 from publication_metadata import ProductMetadata, PublicationMetadata
 
@@ -40,6 +41,28 @@ ALIGNMENT_CORE_LOGICAL_TRIPLE_COUNT = 53
 ALIGNMENT_CORE_TOTAL_TRIPLE_COUNT = 54
 ALIGNMENT_CORE_NAMED_TARGET_COUNT = 26
 ALIGNMENT_CORE_UNION_TARGET_COUNT = 3
+
+STRICT_BFO_MAPPING_KEY = "strict_bfo_mapping"
+STRICT_BFO_AXIOM_COUNT = 19
+STRICT_BFO_SUBCLASS_COUNT = 3
+STRICT_BFO_EQUIVALENT_CLASS_COUNT = 3
+STRICT_BFO_DIRECT_SUBPROPERTY_COUNT = 9
+STRICT_BFO_PROPERTY_CHAIN_COUNT = 2
+STRICT_BFO_DOMAIN_COUNT = 1
+STRICT_BFO_RANGE_COUNT = 1
+STRICT_BFO_LOGICAL_TRIPLE_COUNT = 125
+STRICT_BFO_TOTAL_TRIPLE_COUNT = 127
+STRICT_BFO_UNION_COUNT = 6
+STRICT_BFO_INTERSECTION_COUNT = 6
+STRICT_BFO_EXISTENTIAL_COUNT = 6
+STRICT_BFO_RDF_LIST_COUNT = 14
+STRICT_BFO_PROJECT_CLOSURE_AXIOM_COUNT = 48
+STRICT_BFO_PROJECT_GRAPH_TRIPLE_COUNT = 181
+STRICT_BFO_LOCAL_PROJECT_GRAPH_TRIPLE_COUNT = 180
+STRICT_BFO_FIXED_CLOSURE_TRIPLE_COUNT = 14972
+ALIGNMENT_CORE_IMPORT_IRI = (
+    "http://www.sks.ai/SSN2BFO/current-ssn-sosa/alignment-core"
+)
 
 GENERATED_NOTICE = (
     "# GENERATED FILE: produced from mappings/SSN2BFO-COMS.xlsx and governed "
@@ -70,6 +93,12 @@ PREFIXES = (
     ("ssn", "http://www.w3.org/ns/ssn/"),
     ("ssn-system", "http://www.w3.org/ns/ssn/systems/"),
 )
+STRICT_BFO_PREFIXES = (("bfo", "http://purl.obolibrary.org/obo/"), *PREFIXES)
+
+PRODUCT_SELECTION = {
+    ALIGNMENT_CORE_KEY: ("target_neutral", ALIGNMENT_CORE_AXIOM_COUNT),
+    STRICT_BFO_MAPPING_KEY: ("bfo_bearing", STRICT_BFO_AXIOM_COUNT),
+}
 
 PREDICATE_QNAMES = {
     str(RDFS.subClassOf): "rdfs:subClassOf",
@@ -158,6 +187,14 @@ class ModularProductResult:
     range_axiom_count: int
     named_target_count: int
     union_target_count: int
+    subclass_axiom_count: int
+    equivalent_class_axiom_count: int
+    direct_subproperty_axiom_count: int
+    property_chain_axiom_count: int
+    intersection_expression_count: int
+    existential_restriction_count: int
+    rdf_list_count: int
+    import_triple_count: int
     sha256: str
 
 
@@ -240,13 +277,15 @@ def select_product_axioms(
     canonical_audits: Iterable[CanonicalRowAudit],
     disposition_document: DispositionDocument,
 ) -> tuple[SelectedProductAxiom, ...]:
-    """Reconcile governed identities and select unchanged alignment-core axioms."""
+    """Reconcile governed identities and select unchanged product axioms."""
 
     issues: list[ModularProductValidationIssue] = []
-    if product_key != ALIGNMENT_CORE_KEY:
+    selection_policy = PRODUCT_SELECTION.get(product_key)
+    if selection_policy is None:
         raise ModularProductError(
             [issue("UNSUPPORTED_PRODUCT", f"generation is not implemented for {product_key!r}")]
         )
+    selected_category, expected_count = selection_policy
 
     processed_by_id, duplicate_processed = _unique_by_row_id(
         processed_rows,
@@ -401,11 +440,9 @@ def select_product_axioms(
                 axiom_id=axiom_id,
                 issues=issues,
             )
-            expected = (
-                ProductDisposition("emitted_unchanged")
-                if category == "target_neutral"
-                else ProductDisposition("not_applicable", "TARGET_SPECIFIC")
-            )
+            expected = dict(
+                derive_product_dispositions(category, disposition_document.product_order)
+            )[product_key]
             if product_disposition != expected:
                 issues.append(
                     issue(
@@ -416,7 +453,7 @@ def select_product_axioms(
                     )
                 )
                 continue
-            if category != "target_neutral":
+            if category != selected_category or product_disposition.status != "emitted_unchanged":
                 continue
             if axiom_id in seen_axioms:
                 issues.append(
@@ -442,11 +479,11 @@ def select_product_axioms(
                 )
             )
 
-    if len(selected) != ALIGNMENT_CORE_AXIOM_COUNT:
+    if len(selected) != expected_count:
         issues.append(
             issue(
                 "PRODUCT_AXIOM_COUNT_MISMATCH",
-                f"expected {ALIGNMENT_CORE_AXIOM_COUNT} selected axioms, got {len(selected)}",
+                f"expected {expected_count} selected axioms, got {len(selected)}",
             )
         )
     if issues:
@@ -534,10 +571,30 @@ def _axiom_turtle(value: SelectedProductAxiom) -> list[str]:
     raise ModularProductError([issue("MISSING_TARGET", "selected axiom lacks a structured target", row_id=value.row_id, axiom_id=value.axiom_id)])
 
 
-def _turtle_bytes(metadata: ModularProductMetadata, selected: tuple[SelectedProductAxiom, ...]) -> bytes:
+def _turtle_bytes(
+    metadata: ModularProductMetadata,
+    selected: tuple[SelectedProductAxiom, ...],
+    *,
+    imports: tuple[str, ...] = (),
+    prefixes: tuple[tuple[str, str], ...] = PREFIXES,
+) -> bytes:
     lines = [GENERATED_NOTICE, ""]
-    lines.extend(f"@prefix {prefix}: <{namespace}> ." for prefix, namespace in PREFIXES)
-    lines.extend(["", f"<{metadata.stable_ontology_iri}> rdf:type owl:Ontology .", ""])
+    lines.extend(f"@prefix {prefix}: <{namespace}> ." for prefix, namespace in prefixes)
+    if imports:
+        lines.extend(
+            [
+                "",
+                f"<{metadata.stable_ontology_iri}> rdf:type owl:Ontology ;",
+                *[
+                    f"    owl:imports <{import_iri}>"
+                    + (" ;" if index + 1 < len(imports) else " .")
+                    for index, import_iri in enumerate(imports)
+                ],
+                "",
+            ]
+        )
+    else:
+        lines.extend(["", f"<{metadata.stable_ontology_iri}> rdf:type owl:Ontology .", ""])
     for index, value in enumerate(sorted(selected, key=lambda item: item.axiom_id)):
         lines.extend(_axiom_turtle(value))
         if index + 1 < len(selected):
@@ -557,6 +614,15 @@ def _selected_rows(selected: tuple[SelectedProductAxiom, ...]) -> tuple[Selected
         )
         for row_id, values in sorted(by_row.items())
     )
+
+
+def _expression_kind_count(expression: ExpressionNode | None, kind: str) -> int:
+    if expression is None:
+        return 0
+    count = int(expression.kind == kind)
+    count += sum(_expression_kind_count(child, kind) for child in expression.children)
+    count += _expression_kind_count(expression.filler, kind)
+    return count
 
 
 def build_alignment_core(
@@ -609,6 +675,119 @@ def build_alignment_core(
         range_axiom_count=ranges,
         named_target_count=named,
         union_target_count=unions,
+        subclass_axiom_count=0,
+        equivalent_class_axiom_count=0,
+        direct_subproperty_axiom_count=0,
+        property_chain_axiom_count=0,
+        intersection_expression_count=0,
+        existential_restriction_count=0,
+        rdf_list_count=unions,
+        import_triple_count=0,
+        sha256=hashlib.sha256(serialized).hexdigest(),
+    )
+
+
+def build_strict_bfo_mapping(
+    selected_axioms: Iterable[SelectedProductAxiom],
+    publication_metadata: PublicationMetadata,
+) -> ModularProductResult:
+    selected = tuple(sorted(selected_axioms, key=lambda value: value.axiom_id))
+    metadata = _product_metadata(publication_metadata, STRICT_BFO_MAPPING_KEY)
+    issues: list[ModularProductValidationIssue] = []
+    if len(selected) != STRICT_BFO_AXIOM_COUNT:
+        issues.append(
+            issue(
+                "PRODUCT_AXIOM_COUNT_MISMATCH",
+                f"expected {STRICT_BFO_AXIOM_COUNT} axioms, got {len(selected)}",
+            )
+        )
+    axiom_ids = [value.axiom_id for value in selected]
+    if len(axiom_ids) != len(set(axiom_ids)):
+        issues.append(
+            issue("DUPLICATE_AUTHORITATIVE_AXIOM", "selected axiom IDs must be unique")
+        )
+    row_ids = [value.row_id for value in selected]
+    if len(row_ids) != len(set(row_ids)):
+        issues.append(issue("DUPLICATE_ROW_ID", "selected RowIDs must be unique"))
+
+    subclasses = sum(value.canonical_input.predicate_iri == str(RDFS.subClassOf) for value in selected)
+    equivalents = sum(value.canonical_input.predicate_iri == str(OWL.equivalentClass) for value in selected)
+    direct_subproperties = sum(value.canonical_input.predicate_iri == str(RDFS.subPropertyOf) for value in selected)
+    property_chains = sum(value.canonical_input.mapping_type == "property_chain" for value in selected)
+    domains = sum(value.canonical_input.mapping_type == "domain" for value in selected)
+    ranges = sum(value.canonical_input.mapping_type == "range" for value in selected)
+    unions = sum(_expression_kind_count(value.canonical_input.expression, "union") for value in selected)
+    intersections = sum(
+        _expression_kind_count(value.canonical_input.expression, "intersection")
+        for value in selected
+    )
+    existentials = sum(_expression_kind_count(value.canonical_input.expression, "some") for value in selected)
+    rdf_lists = unions + intersections + property_chains
+    composition = (
+        subclasses,
+        equivalents,
+        direct_subproperties,
+        property_chains,
+        domains,
+        ranges,
+        unions,
+        intersections,
+        existentials,
+        rdf_lists,
+    )
+    expected_composition = (
+        STRICT_BFO_SUBCLASS_COUNT,
+        STRICT_BFO_EQUIVALENT_CLASS_COUNT,
+        STRICT_BFO_DIRECT_SUBPROPERTY_COUNT,
+        STRICT_BFO_PROPERTY_CHAIN_COUNT,
+        STRICT_BFO_DOMAIN_COUNT,
+        STRICT_BFO_RANGE_COUNT,
+        STRICT_BFO_UNION_COUNT,
+        STRICT_BFO_INTERSECTION_COUNT,
+        STRICT_BFO_EXISTENTIAL_COUNT,
+        STRICT_BFO_RDF_LIST_COUNT,
+    )
+    if composition != expected_composition:
+        issues.append(
+            issue(
+                "PRODUCT_COMPOSITION_MISMATCH",
+                f"expected {expected_composition}, got {composition}",
+            )
+        )
+    if any(value.target_category != "bfo_bearing" for value in selected):
+        issues.append(
+            issue("TARGET_CATEGORY_MISMATCH", "all strict-BFO axioms must be BFO-bearing")
+        )
+    if issues:
+        raise ModularProductError(issues)
+
+    serialized = _turtle_bytes(
+        metadata,
+        selected,
+        imports=(ALIGNMENT_CORE_IMPORT_IRI,),
+        prefixes=STRICT_BFO_PREFIXES,
+    )
+    graph = Graph().parse(data=serialized.decode("utf-8"), format="turtle")
+    return ModularProductResult(
+        metadata=metadata,
+        selected_rows=_selected_rows(selected),
+        serialized_bytes=serialized,
+        governed_axiom_count=len(selected),
+        logical_triple_count=len(graph) - 2,
+        ontology_header_triple_count=2,
+        total_triple_count=len(graph),
+        domain_axiom_count=domains,
+        range_axiom_count=ranges,
+        named_target_count=direct_subproperties,
+        union_target_count=unions,
+        subclass_axiom_count=subclasses,
+        equivalent_class_axiom_count=equivalents,
+        direct_subproperty_axiom_count=direct_subproperties,
+        property_chain_axiom_count=property_chains,
+        intersection_expression_count=intersections,
+        existential_restriction_count=existentials,
+        rdf_list_count=rdf_lists,
+        import_triple_count=1,
         sha256=hashlib.sha256(serialized).hexdigest(),
     )
 
@@ -794,16 +973,338 @@ def validate_alignment_core(
     return tuple(sorted(set(issues), key=lambda value: value.sort_key))
 
 
+def validate_strict_bfo_mapping(
+    serialized_bytes: bytes,
+    selected_axioms: Iterable[SelectedProductAxiom],
+    alignment_core_bytes: bytes,
+    alignment_core_selected_axioms: Iterable[SelectedProductAxiom],
+    publication_metadata: PublicationMetadata,
+    integrated_graph: Graph | None = None,
+    fixed_semantic_closure: Graph | None = None,
+) -> tuple[ModularProductValidationIssue, ...]:
+    selected = tuple(sorted(selected_axioms, key=lambda value: value.axiom_id))
+    core_selected = tuple(
+        sorted(alignment_core_selected_axioms, key=lambda value: value.axiom_id)
+    )
+    metadata = _product_metadata(publication_metadata, STRICT_BFO_MAPPING_KEY)
+    issues: list[ModularProductValidationIssue] = []
+    try:
+        graph = Graph().parse(data=serialized_bytes.decode("utf-8"), format="turtle")
+    except Exception as exc:
+        return (issue("TURTLE_PARSE", f"cannot strictly parse UTF-8 Turtle: {exc}"),)
+
+    expected = build_strict_bfo_mapping(selected, publication_metadata)
+    if serialized_bytes != expected.serialized_bytes:
+        issues.append(
+            issue(
+                "NONDETERMINISTIC_SERIALIZATION",
+                "bytes differ from canonical strict-BFO serialization",
+            )
+        )
+    ontology_iri = URIRef(metadata.stable_ontology_iri)
+    expected_import = URIRef(ALIGNMENT_CORE_IMPORT_IRI)
+    declarations = set(graph.subjects(RDF.type, OWL.Ontology))
+    if declarations != {ontology_iri}:
+        issues.append(
+            issue(
+                "ONTOLOGY_DECLARATION_MISMATCH",
+                f"expected only {ontology_iri}, got {sorted(map(str, declarations))}",
+            )
+        )
+    imports = set(graph.triples((None, OWL.imports, None)))
+    expected_imports = {(ontology_iri, OWL.imports, expected_import)}
+    if imports != expected_imports:
+        issues.append(
+            issue(
+                "IMPORT_POLICY_MISMATCH",
+                f"expected only alignment-core import, got {sorted(map(str, imports))}",
+            )
+        )
+    if len(graph) != STRICT_BFO_TOTAL_TRIPLE_COUNT:
+        issues.append(
+            issue(
+                "TOTAL_TRIPLE_COUNT_MISMATCH",
+                f"expected {STRICT_BFO_TOTAL_TRIPLE_COUNT}, got {len(graph)}",
+            )
+        )
+
+    header = {
+        (ontology_iri, RDF.type, OWL.Ontology),
+        (ontology_iri, OWL.imports, expected_import),
+    }
+    logical_graph = Graph()
+    for triple in graph:
+        if triple not in header:
+            logical_graph.add(triple)
+    if len(logical_graph) != STRICT_BFO_LOGICAL_TRIPLE_COUNT:
+        issues.append(
+            issue(
+                "LOGICAL_TRIPLE_COUNT_MISMATCH",
+                f"expected {STRICT_BFO_LOGICAL_TRIPLE_COUNT}, got {len(logical_graph)}",
+            )
+        )
+
+    strict_axioms = _canonical_graph_axioms(graph)
+    selected_by_id = {value.axiom_id: value for value in selected}
+    for axiom_id in sorted(set(selected_by_id) - set(strict_axioms)):
+        issues.append(
+            issue(
+                "MISSING_PRODUCT_AXIOM",
+                "selected axiom is absent from strict BFO mapping",
+                row_id=selected_by_id[axiom_id].row_id,
+                axiom_id=axiom_id,
+            )
+        )
+    for axiom_id in sorted(set(strict_axioms) - set(selected_by_id)):
+        issues.append(
+            issue(
+                "UNEXPECTED_PRODUCT_AXIOM",
+                "strict BFO mapping contains an ungoverned axiom",
+                axiom_id=axiom_id,
+            )
+        )
+    for axiom_id in sorted(set(strict_axioms) & set(selected_by_id)):
+        if strict_axioms[axiom_id][0] != selected_by_id[axiom_id].identity.canonical_axiom:
+            issues.append(
+                issue(
+                    "CANONICAL_EXPRESSION_MISMATCH",
+                    "strict-BFO canonical expression differs",
+                    row_id=selected_by_id[axiom_id].row_id,
+                    axiom_id=axiom_id,
+                )
+            )
+
+    for subject, predicate, target in logical_graph:
+        for value in (subject, predicate, target):
+            if not isinstance(value, URIRef):
+                continue
+            iri = str(value)
+            if iri.startswith(SOURCE_NAMESPACES) or iri.startswith(STRUCTURAL_NAMESPACES):
+                continue
+            if iri.startswith(BFO_NAMESPACE):
+                continue
+            code = (
+                "PROHIBITED_LOGICAL_VOCABULARY"
+                if iri.startswith((CCO_NAMESPACE, RO_NAMESPACE))
+                else "UNEXPECTED_LOGICAL_VOCABULARY"
+            )
+            issues.append(issue(code, f"logical triple contains unapproved IRI {value}"))
+    for subject, _, target in graph.triples((None, RDF.type, None)):
+        if not isinstance(subject, URIRef) or target not in NAMED_DECLARATION_TYPES:
+            continue
+        if str(subject).startswith(SOURCE_NAMESPACES):
+            issues.append(
+                issue(
+                    "COPIED_SOURCE_DECLARATION",
+                    f"named source declaration is prohibited: {subject} rdf:type {target}",
+                )
+            )
+        if str(subject).startswith(BFO_NAMESPACE):
+            issues.append(
+                issue(
+                    "COPIED_BFO_DECLARATION",
+                    f"named BFO declaration is prohibited: {subject} rdf:type {target}",
+                )
+            )
+    if any(True for _ in graph.triples((None, RDF.type, OWL.Axiom))):
+        issues.append(
+            issue("ANNOTATION_ONLY_PSEUDO_MAPPING", "owl:Axiom records are prohibited")
+        )
+
+    unions = set(graph.subjects(OWL.unionOf, None))
+    intersections = set(graph.subjects(OWL.intersectionOf, None))
+    restrictions = set(graph.subjects(OWL.someValuesFrom, None))
+    chains = set(graph.subjects(OWL.propertyChainAxiom, None))
+    list_heads = [
+        value
+        for predicate in (OWL.unionOf, OWL.intersectionOf, OWL.propertyChainAxiom)
+        for value in graph.objects(None, predicate)
+    ]
+    structure = (
+        len(unions),
+        len(intersections),
+        len(restrictions),
+        len(chains),
+        len(list_heads),
+    )
+    expected_structure = (
+        STRICT_BFO_UNION_COUNT,
+        STRICT_BFO_INTERSECTION_COUNT,
+        STRICT_BFO_EXISTENTIAL_COUNT,
+        STRICT_BFO_PROPERTY_CHAIN_COUNT,
+        STRICT_BFO_RDF_LIST_COUNT,
+    )
+    if structure != expected_structure:
+        issues.append(
+            issue(
+                "PRODUCT_STRUCTURE_MISMATCH",
+                f"expected unions/intersections/restrictions/chains/lists "
+                f"{expected_structure}, got {structure}",
+            )
+        )
+    for chain in chains:
+        heads = list(graph.objects(chain, OWL.propertyChainAxiom))
+        if len(heads) != 1 or len(list(Collection(graph, heads[0]))) != 3:
+            issues.append(
+                issue(
+                    "INVALID_RDF_LIST",
+                    f"property chain {chain} must contain exactly three ordered members",
+                )
+            )
+    if any(True for _ in logical_graph.triples((None, OWL.inverseOf, None))):
+        issues.append(issue("UNEXPECTED_INVERSE_EXPRESSION", "inverse expressions are absent"))
+
+    core_issues = validate_alignment_core(
+        alignment_core_bytes,
+        core_selected,
+        publication_metadata,
+    )
+    issues.extend(core_issues)
+    try:
+        core_graph = Graph().parse(
+            data=alignment_core_bytes.decode("utf-8"),
+            format="turtle",
+        )
+    except Exception as exc:
+        issues.append(issue("ALIGNMENT_CORE_PARSE", f"cannot parse alignment core: {exc}"))
+        core_graph = Graph()
+    core_axioms = _canonical_graph_axioms(core_graph) if len(core_graph) else {}
+    core_selected_by_id = {value.axiom_id: value for value in core_selected}
+    overlap = set(strict_axioms) & set(core_axioms)
+    if overlap:
+        issues.append(
+            issue(
+                "DIRECT_CORE_AXIOM_OVERLAP",
+                "strict and alignment-core direct graphs overlap: "
+                + ", ".join(sorted(overlap)),
+            )
+        )
+    expected_closure_ids = set(selected_by_id) | set(core_selected_by_id)
+    actual_closure_ids = set(strict_axioms) | set(core_axioms)
+    if expected_closure_ids != actual_closure_ids:
+        issues.append(
+            issue(
+                "PROJECT_CLOSURE_AXIOM_MISMATCH",
+                "project-module governed axiom IDs do not reconcile",
+            )
+        )
+    if len(actual_closure_ids) != STRICT_BFO_PROJECT_CLOSURE_AXIOM_COUNT:
+        issues.append(
+            issue(
+                "PROJECT_CLOSURE_COUNT_MISMATCH",
+                f"expected {STRICT_BFO_PROJECT_CLOSURE_AXIOM_COUNT}, "
+                f"got {len(actual_closure_ids)}",
+            )
+        )
+    project_graph = Graph()
+    for triple in graph:
+        project_graph.add(triple)
+    for triple in core_graph:
+        project_graph.add(triple)
+    if len(project_graph) != STRICT_BFO_PROJECT_GRAPH_TRIPLE_COUNT:
+        issues.append(
+            issue(
+                "PROJECT_GRAPH_TRIPLE_COUNT_MISMATCH",
+                f"expected {STRICT_BFO_PROJECT_GRAPH_TRIPLE_COUNT}, got {len(project_graph)}",
+            )
+        )
+    for triple in list(project_graph.triples((None, OWL.imports, None))):
+        project_graph.remove(triple)
+    if len(project_graph) != STRICT_BFO_LOCAL_PROJECT_GRAPH_TRIPLE_COUNT:
+        issues.append(
+            issue(
+                "LOCAL_PROJECT_GRAPH_TRIPLE_COUNT_MISMATCH",
+                f"expected {STRICT_BFO_LOCAL_PROJECT_GRAPH_TRIPLE_COUNT}, "
+                f"got {len(project_graph)}",
+            )
+        )
+
+    if integrated_graph is not None:
+        root_axioms = _canonical_graph_axioms(integrated_graph)
+        for axiom_id, value in sorted(
+            {**core_selected_by_id, **selected_by_id}.items()
+        ):
+            root_value = root_axioms.get(axiom_id)
+            if root_value is None:
+                issues.append(
+                    issue(
+                        "MISSING_INTEGRATED_AXIOM",
+                        "project-module axiom is absent from integrated root",
+                        row_id=value.row_id,
+                        axiom_id=axiom_id,
+                    )
+                )
+            elif root_value[0] != value.identity.canonical_axiom:
+                issues.append(
+                    issue(
+                        "INTEGRATED_AXIOM_MISMATCH",
+                        "integrated root canonical expression differs",
+                        row_id=value.row_id,
+                        axiom_id=axiom_id,
+                    )
+                )
+
+    if fixed_semantic_closure is not None:
+        if any(True for _ in fixed_semantic_closure.triples((None, OWL.imports, None))):
+            issues.append(
+                issue("FIXED_CLOSURE_IMPORT", "fixed semantic closure retains imports")
+            )
+        if len(fixed_semantic_closure) != STRICT_BFO_FIXED_CLOSURE_TRIPLE_COUNT:
+            issues.append(
+                issue(
+                    "FIXED_CLOSURE_COUNT_MISMATCH",
+                    f"expected {STRICT_BFO_FIXED_CLOSURE_TRIPLE_COUNT}, "
+                    f"got {len(fixed_semantic_closure)}",
+                )
+            )
+        bfo_iris = {
+            iri
+            for value in selected
+            for iri in axiom_input_from_canonical_row(
+                value.identity,
+                value.canonical_input,
+            ).target_iris
+            if iri.startswith(BFO_NAMESPACE)
+        }
+        unresolved = sorted(
+            iri
+            for iri in bfo_iris
+            if not any(True for _ in fixed_semantic_closure.triples((URIRef(iri), None, None)))
+        )
+        if unresolved:
+            issues.append(
+                issue(
+                    "UNRESOLVED_BFO_IRI",
+                    "BFO IRIs are absent from pinned validation closure: "
+                    + ", ".join(unresolved),
+                )
+            )
+    return tuple(sorted(set(issues), key=lambda value: value.sort_key))
+
+
+def build_fixed_validation_closure(
+    serialized_products: Iterable[bytes],
+    dependency_paths: Iterable[Path],
+    cleanup_triples: Iterable[tuple[URIRef, URIRef, URIRef]] = (),
+) -> Graph:
+    """Build an explicit offline product/dependency closure without imports."""
+
+    graph = Graph()
+    for path in dependency_paths:
+        graph.parse(path, format="turtle")
+    for serialized in serialized_products:
+        graph.parse(data=serialized.decode("utf-8"), format="turtle")
+    for triple in list(graph.triples((None, OWL.imports, None))):
+        graph.remove(triple)
+    for triple in cleanup_triples:
+        graph.remove(triple)
+    return graph
+
+
 def build_fixed_source_closure(
     serialized_bytes: bytes,
     source_paths: Iterable[Path],
 ) -> Graph:
     """Build an offline validation closure and remove all import edges."""
 
-    graph = Graph()
-    for path in source_paths:
-        graph.parse(path, format="turtle")
-    graph.parse(data=serialized_bytes.decode("utf-8"), format="turtle")
-    for triple in list(graph.triples((None, OWL.imports, None))):
-        graph.remove(triple)
-    return graph
+    return build_fixed_validation_closure((serialized_bytes,), source_paths)

--- a/tools/run_validation_suite.py
+++ b/tools/run_validation_suite.py
@@ -70,6 +70,7 @@ def compile_check() -> StepResult:
             "tests/test_coms_row_identity.py",
             "tests/test_product_dispositions.py",
             "tests/test_modular_products.py",
+            "tests/test_strict_bfo_mapping.py",
             "tests/test_publication_metadata.py",
         ],
     )
@@ -170,6 +171,22 @@ def main() -> int:
                     "tests",
                     "-p",
                     "test_modular_products.py",
+                ],
+            )
+        )
+    if results[-1].passed:
+        results.append(
+            run_command(
+                "Strict-BFO modular-product focused tests",
+                [
+                    sys.executable,
+                    "-m",
+                    "unittest",
+                    "discover",
+                    "-s",
+                    "tests",
+                    "-p",
+                    "test_strict_bfo_mapping.py",
                 ],
             )
         )

--- a/tools/watch_coms_mapping.py
+++ b/tools/watch_coms_mapping.py
@@ -24,6 +24,7 @@ MAINTAINED_OUTPUTS = (
     REPO_ROOT / "reports/coms-vs-pre-coms-legacy-diff.md",
     REPO_ROOT / "reports/coms-product-dispositions.json",
     REPO_ROOT / "releases/current-ssn-sosa/ssn-sosa-alignment-core.ttl",
+    REPO_ROOT / "releases/current-ssn-sosa/ssn-sosa-bfo-mapping.ttl",
 )
 POLL_SECONDS = 1.0
 DEBOUNCE_SECONDS = 1.5

--- a/tools/workflow_check.py
+++ b/tools/workflow_check.py
@@ -34,6 +34,7 @@ COMPILE_COMMAND = [
     "tests/test_coms_row_identity.py",
     "tests/test_product_dispositions.py",
     "tests/test_modular_products.py",
+    "tests/test_strict_bfo_mapping.py",
     "tests/test_publication_metadata.py",
     "tools/workflow_check.py",
 ]
@@ -193,6 +194,7 @@ def mapping_change_scope(state: WorkflowState) -> None:
         "reports/elk-instance-mapping-entailments.md",
         "reports/coms-product-dispositions.json",
         "releases/current-ssn-sosa/ssn-sosa-alignment-core.ttl",
+        "releases/current-ssn-sosa/ssn-sosa-bfo-mapping.ttl",
     }
     unexpected = [
         path


### PR DESCRIPTION
# Generate strict BFO mapping

## Changed files

- Makefile
- README.md
- releases/current-ssn-sosa/ssn-sosa-bfo-mapping.ttl
- reports/coms-automatic-validation-setup.md
- reports/coms-generation-validation.md
- reports/coms-product-dispositions.json
- tests/test_generate_mapping_from_coms.py
- tests/test_product_dispositions.py
- tests/test_strict_bfo_mapping.py
- tools/check_coms_mapping.py
- tools/generate_mapping_from_coms.py
- tools/modular_products.py
- tools/run_validation_suite.py
- tools/watch_coms_mapping.py
- tools/workflow_check.py

## Validation

- Human gate required: confirm validation output before merge.
