### PR TITLE
Generate BFO projection

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: validate validate-write audit-write legacy-audit-write compile check check-coms check-coms-row-identities check-coms-product-dispositions check-alignment-core check-strict-bfo-mapping check-cco-extension check-publication-metadata watch-coms coms-status post-merge-check status diffstat
+.PHONY: validate validate-write audit-write legacy-audit-write compile check check-coms check-coms-row-identities check-coms-product-dispositions check-alignment-core check-strict-bfo-mapping check-cco-extension check-bfo-projection check-publication-metadata watch-coms coms-status post-merge-check status diffstat
 
 validate:
 	python tools/run_validation_suite.py
@@ -36,6 +36,7 @@ compile:
 		tests/test_modular_products.py \
 		tests/test_strict_bfo_mapping.py \
 		tests/test_cco_extension.py \
+		tests/test_bfo_projection.py \
 		tests/test_publication_metadata.py \
 		tools/workflow_check.py
 
@@ -65,6 +66,10 @@ check-strict-bfo-mapping:
 
 check-cco-extension:
 	python -m unittest discover -s tests -p 'test_cco_extension.py'
+	python tools/check_coms_mapping.py --check-only
+
+check-bfo-projection:
+	python -m unittest discover -s tests -p 'test_bfo_projection.py'
 	python tools/check_coms_mapping.py --check-only
 
 watch-coms:

--- a/README.md
+++ b/README.md
@@ -49,13 +49,19 @@ The development artifact has only its governed stable ontology IRI and ontology 
 
 `releases/current-ssn-sosa/ssn-sosa-bfo-mapping.ttl` is the maintained authoritative development artifact for the 19 unchanged BFO-bearing governed COMS axioms. It imports only the alignment core, so the locally resolved project-module closure contains 48 governed axioms: 19 direct strict-BFO axioms plus 29 target-neutral core axioms. The 57 CCO-bearing or mixed mappings remain explicitly deferred because no transformation or weakened projection is approved.
 
-The published strict graph contains no CCO or RO logical terms and does not import an external ontology. Validation reasons over an explicit, network-free pinned merged CCO/BFO closure that includes `imports/cco.ttl`; this validation dependency does not make CCO part of the published strict graph and is not mapping authority. Full publication metadata, formal release identity, the BFO projection, and transformation rules remain deferred. The old `releases/current-ssn-sosa/ssn-sosa-bfo-directmappings.ttl` file remains inactive, non-authoritative scaffolding pending complete modular-product migration. Run `make check-strict-bfo-mapping` for the focused tests and shared nonmutating transaction.
+The published strict graph contains no CCO or RO logical terms and does not import an external ontology. Validation reasons over an explicit, network-free pinned merged CCO/BFO closure that includes `imports/cco.ttl`; this validation dependency does not make CCO part of the published strict graph and is not mapping authority. Full publication metadata, formal release identity, and transformation rules remain deferred. The old `releases/current-ssn-sosa/ssn-sosa-bfo-directmappings.ttl` file remains inactive, non-authoritative scaffolding pending complete modular-product migration. Run `make check-strict-bfo-mapping` for the focused tests and shared nonmutating transaction.
+
+### BFO projection
+
+`releases/current-ssn-sosa/ssn-sosa-bfo-projection.ttl` is a maintained authoritative development artifact that imports only the strict BFO mapping. It intentionally asserts zero direct projection axioms because no CCO-to-BFO transformation or weakened-consequence rule is approved. Its locally resolved project-module closure is therefore exactly the 48 governed axioms already provided by strict BFO and the alignment core: 19 through import and 29 transitively.
+
+The direct two-triple graph contains only its ontology declaration and strict-BFO import. It contains no source, BFO, CCO, or RO logical mapping content and is not an incomplete serialization. The generator reconciles all 105 product dispositions, leaving 25 CCO-bearing and 32 mixed axioms explicitly deferred, then reuses the same-transaction strict-BFO pinned merged CCO/BFO reasoning result only after proving exact closure equivalence. Future direct projection axioms require governed transformation rules and proof obligations. Full publication metadata and formal release identity remain deferred. Run `make check-bfo-projection` for the focused tests and shared nonmutating nine-output transaction.
 
 ### CCO extension
 
 `releases/current-ssn-sosa/ssn-sosa-cco-extension.ttl` is the maintained authoritative development artifact for 57 unchanged governed COMS axioms: 25 CCO-bearing and 32 mixed BFO/CCO axioms. It imports only the strict BFO mapping, whose alignment-core import completes a 105-axiom project-module closure without directly duplicating either imported layer.
 
-The published extension contains no RO terms, transformed mappings, weakened projections, or copied dependency declarations. Its fixed semantic validation uses the explicitly listed local source ontologies and the pinned merged CCO/BFO dependency `imports/cco.ttl`; neither CCO nor BFO is imported by the published extension. Full publication metadata, formal release identity, the BFO projection, and transformation rules remain deferred. The old `releases/current-ssn-sosa/ssn-sosa-cco-directmappings.ttl` file remains inactive, non-authoritative scaffolding pending complete modular-product migration. Run `make check-cco-extension` for the focused tests and shared nonmutating eight-output transaction.
+The published extension contains no RO terms, transformed mappings, weakened projections, or copied dependency declarations. Its fixed semantic validation uses the explicitly listed local source ontologies and the pinned merged CCO/BFO dependency `imports/cco.ttl`; neither CCO nor BFO is imported by the published extension. Full publication metadata, formal release identity, and transformation rules remain deferred. The old `releases/current-ssn-sosa/ssn-sosa-cco-directmappings.ttl` file remains inactive, non-authoritative scaffolding pending complete modular-product migration. Run `make check-cco-extension` for the focused tests and shared nonmutating transaction.
 
 ## Validation environment
 
@@ -142,7 +148,7 @@ make -C src artifacts
 
 `unmapped` is scaffolded but disabled by default. It exits successfully with a message until real source imports and final source namespace configuration are added.
 
-Generated build artifacts are ignored by Git. Release-file BFO projection from CCO mappings is not implemented. Root spreadsheets and the root `imports/` directory remain preserved; `SSN2BFO.ttl` is a maintained generated artifact.
+Generated build artifacts are ignored by Git. The maintained BFO-projection module is import-only; projected or weakened mapping content from CCO mappings is not implemented. Root spreadsheets and the root `imports/` directory remain preserved; `SSN2BFO.ttl` is a maintained generated artifact.
 
 ## Current SSN/SOSA CCO mapping and BFO-only projection
 

--- a/releases/current-ssn-sosa/ssn-sosa-bfo-projection.ttl
+++ b/releases/current-ssn-sosa/ssn-sosa-bfo-projection.ttl
@@ -1,0 +1,7 @@
+# GENERATED FILE: produced from mappings/SSN2BFO-COMS.xlsx and governed product dispositions; do not edit directly.
+
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+
+<http://www.sks.ai/SSN2BFO/current-ssn-sosa/bfo-projection> rdf:type owl:Ontology ;
+    owl:imports <http://www.sks.ai/SSN2BFO/current-ssn-sosa/bfo-mapping> .

--- a/reports/coms-automatic-validation-setup.md
+++ b/reports/coms-automatic-validation-setup.md
@@ -78,7 +78,8 @@ Each complete check:
 12. Generates and validates the import-free 29-axiom SSN/SOSA alignment core, including root reconciliation and a fixed local source-ontology HermiT closure.
 13. Generates and validates the 19-axiom strict BFO mapping, its sole alignment-core import, the 48-axiom project-module closure, and the explicit network-free pinned merged CCO/BFO HermiT closure.
 14. Generates and validates the 57-axiom CCO extension, its sole strict-BFO import, the complete 105-axiom project-module closure, and the explicit network-free pinned merged CCO/BFO HermiT closure.
-15. Runs `git diff --check`.
+15. Reconciles all 105 BFO-projection dispositions, generates the intentional zero-direct-axiom import-only module, validates its 48-axiom strict/core project closure, and reuses the same-transaction strict-BFO reasoning result after exact closure-equivalence validation.
+16. Runs `git diff --check`.
 
 The generated validation report records the workbook SHA-256, generator-file SHA-256, UTC generation timestamp, maintained ontology path, and generated ontology SHA-256. Freshness never relies on timestamps alone.
 
@@ -93,11 +94,12 @@ Generation and validation happen under `.cache/coms/`. The maintained files are 
 - `reports/coms-product-dispositions.json`
 - `releases/current-ssn-sosa/ssn-sosa-alignment-core.ttl`
 - `releases/current-ssn-sosa/ssn-sosa-bfo-mapping.ttl`
+- `releases/current-ssn-sosa/ssn-sosa-bfo-projection.ttl`
 - `releases/current-ssn-sosa/ssn-sosa-cco-extension.ttl`
 
 Each replacement is atomic. If any check fails, the maintained last-known-good files remain unchanged. A post-replacement whitespace failure also triggers rollback from temporary backups.
 
-The product-disposition JSON is generated evidence rather than an editable mapping source. The alignment core, strict BFO mapping, and CCO extension are maintained authoritative development artifacts, not frozen formal releases. The strict graph imports only the alignment core, and the CCO extension imports only the strict graph. `imports/cco.ttl` is used solely in pinned merged CCO/BFO validation closures and is not a published modular-product import. All artifacts are published in one eight-output transaction, so no maintained output can become newer or older than its disposition accounting or selected modular content.
+The product-disposition JSON is generated evidence rather than an editable mapping source. The alignment core, strict BFO mapping, import-only BFO projection, and CCO extension are maintained authoritative development artifacts, not frozen formal releases. The strict graph imports only the alignment core, the projection and CCO extension each import only the strict graph, and the projection intentionally asserts zero direct axioms while 57 CCO-bearing or mixed dispositions remain deferred. `imports/cco.ttl` is used solely in pinned merged CCO/BFO validation closures and is not a published modular-product import. All artifacts are published in one nine-output transaction, so no maintained output can become newer or older than its disposition accounting or selected modular content.
 
 `SSN2BFO.ttl` is the authoritative generated publication artifact. `mappings/SSN2BFO-COMS.xlsx` is its sole editable mapping source, and `legacy/SSN2BFO-pre-COMS.ttl` is used only as the frozen informational comparison baseline.
 

--- a/reports/coms-generation-validation.md
+++ b/reports/coms-generation-validation.md
@@ -9,20 +9,22 @@ Freshness is determined from content hashes, not file timestamps.
 | Item | Value |
 |---|---|
 | workbook SHA-256 | `febb8b58b4a701cead90697412a9721112c4e6dfd3af47d3c3a77c93754690e0` |
-| generator SHA-256 | `9e8f7b962dbb15d714d621cd2968a63c9c9b68986cf8777afe10963c6ff37ea3` |
+| generator SHA-256 | `c27277bddc98d0ee84189a260b32805f3b0df73bba2068fd08a448b74e378cfd` |
 | row-identity module SHA-256 | `9af9f9ed5b9321040428960e1293cffe27ebb48cc7a68a71f53f84cf18a60425` |
 | product-disposition module SHA-256 | `987fa4809e5780831f9e50e0b5cacc52888284fc7eae82a0928056c45c14a7d8` |
-| modular-products module SHA-256 | `9533e7746371fa8af6bdabc8eac5a5e2e819ed0d5e033fff9c21bb0995e7b3fb` |
+| modular-products module SHA-256 | `fe48deac6bc9d529ec058564f99da817d520fed03ce96bbcc4563d5a54b1da6d` |
 | publication metadata SHA-256 | `a25196f873bc849a0a5b33012c22312d3ea9e70504219c9e781e77e595993564` |
-| generation timestamp (UTC) | `2026-07-16T00:52:58+00:00` |
+| generation timestamp (UTC) | `2026-07-16T01:47:35+00:00` |
 | maintained ontology path | `SSN2BFO.ttl` |
 | generated ontology SHA-256 | `fd6eadf1bcbd4bfc6dc06df58915116d8f909bc8c3238592b1f13509cec47d16` |
 | maintained product-disposition path | `reports/coms-product-dispositions.json` |
-| product-disposition JSON SHA-256 | `e56f46316513cec96e200efde2108b6f34ca4c02c3d25633b0fd653055355b4b` |
+| product-disposition JSON SHA-256 | `3ab0d1fabd40c0b274b42c53788210a57f8c7d3d4a4fcaa34a63eaa3d54de542` |
 | maintained alignment-core path | `releases/current-ssn-sosa/ssn-sosa-alignment-core.ttl` |
 | alignment-core Turtle SHA-256 | `95f71184b90224906b0ba703d0ea60fd2f8b993b3853b803c66b88b91ba0b01c` |
 | maintained strict-BFO path | `releases/current-ssn-sosa/ssn-sosa-bfo-mapping.ttl` |
 | strict-BFO Turtle SHA-256 | `15f080145c6803d174a00cf9e13c971925b40485049744dba6e0847093016ea7` |
+| maintained BFO-projection path | `releases/current-ssn-sosa/ssn-sosa-bfo-projection.ttl` |
+| BFO-projection Turtle SHA-256 | `7914e0afb6212df20e02686e1b11b71d109e0b81095ddf33ff120b01768cc71c` |
 | maintained CCO-extension path | `releases/current-ssn-sosa/ssn-sosa-cco-extension.ttl` |
 | CCO-extension Turtle SHA-256 | `fe6986d79ec2f5f67553fbee1364fa98ebd7ba3205196f0368ac246646fcdf7c` |
 
@@ -344,6 +346,42 @@ This is the maintained authoritative development artifact at the approved produc
 - The 57 CCO-bearing or mixed mappings remain deferred; no transformation or projection is implemented.
 - Full publication metadata and formal release identity remain deferred.
 
+## BFO Projection
+
+This is the maintained authoritative development artifact at the approved production path; it is not a frozen formal release.
+
+- Path: `releases/current-ssn-sosa/ssn-sosa-bfo-projection.ttl`
+- Stable ontology IRI: `http://www.sks.ai/SSN2BFO/current-ssn-sosa/bfo-projection`
+- Direct governed projection axioms: 0
+- Direct logical mapping triples: 0
+- Ontology declaration triples: 1
+- Import triples: 1
+- Total RDF triples: 2
+- Import: `http://www.sks.ai/SSN2BFO/current-ssn-sosa/bfo-mapping`
+- Target-neutral provided transitively: 29
+- BFO-bearing provided through import: 19
+- CCO-bearing deferred without transformation rule: 25
+- Mixed BFO/CCO deferred without transformation rule: 32
+- Imported strict-BFO governed axioms: 19
+- Transitively imported alignment-core governed axioms: 29
+- Project-module closure governed axioms: 48
+- Project graph triples retaining imports: 183
+- Import-stripped local project graph triples: 181
+- Strict/alignment-core governed overlap: 0
+- CCO-extension governed axioms in projection closure: 0
+- Direct graph and integrated-root/project-module reconciliation: PASS
+- Deterministic serialization: PASS
+- Reused strict-BFO closure triple count: 14972
+- Reused strict-BFO HermiT return code: 0
+- Reused strict-BFO reasoned output produced: yes
+- Reused strict-BFO named unsatisfiable classes: 0
+- Reasoning result: PASS (reused from the same-transaction strict-BFO pinned merged CCO/BFO validation closure after exact project-closure equivalence validation)
+- Projection-specific HermiT invocation: none
+- Zero direct projection axioms is intentional and complete for the current governed policy.
+- No transformation rule, weakened consequence, or projected axiom is approved.
+- Future direct projected axioms require governed transformation rules and proof obligations.
+- Full publication metadata and formal release identity remain deferred.
+
 ## CCO Extension
 
 This is the maintained authoritative development artifact at the approved production path; it is not a frozen formal release.
@@ -547,4 +585,4 @@ This section records mapping and domain/range property-typing rows after parsing
 
 ## Runtime
 
-- Runtime seconds: 9.17
+- Runtime seconds: 9.27

--- a/reports/coms-product-dispositions.json
+++ b/reports/coms-product-dispositions.json
@@ -2,7 +2,7 @@
   "schema_version": 1,
   "canonicalization_version": "coms-row-expression-v1",
   "workbook_sha256": "febb8b58b4a701cead90697412a9721112c4e6dfd3af47d3c3a77c93754690e0",
-  "generator_sha256": "9e8f7b962dbb15d714d621cd2968a63c9c9b68986cf8777afe10963c6ff37ea3",
+  "generator_sha256": "c27277bddc98d0ee84189a260b32805f3b0df73bba2068fd08a448b74e378cfd",
   "row_identity_module_sha256": "9af9f9ed5b9321040428960e1293cffe27ebb48cc7a68a71f53f84cf18a60425",
   "disposition_module_sha256": "987fa4809e5780831f9e50e0b5cacc52888284fc7eae82a0928056c45c14a7d8",
   "publication_metadata_sha256": "a25196f873bc849a0a5b33012c22312d3ea9e70504219c9e781e77e595993564",

--- a/tests/test_bfo_projection.py
+++ b/tests/test_bfo_projection.py
@@ -1,0 +1,495 @@
+#!/usr/bin/env python3
+"""Focused tests for the maintained import-only BFO projection product."""
+
+from __future__ import annotations
+
+import dataclasses
+import hashlib
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+
+from rdflib import BNode, Graph, RDF, OWL, URIRef
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT / "tools"))
+
+import generate_mapping_from_coms as coms  # noqa: E402
+import modular_products as modular  # noqa: E402
+from coms_row_identity import RowLocation  # noqa: E402
+from product_dispositions import ProductDisposition, load_disposition_document  # noqa: E402
+from publication_metadata import load_metadata  # noqa: E402
+
+
+EXPECTED_SHA256 = "7914e0afb6212df20e02686e1b11b71d109e0b81095ddf33ff120b01768cc71c"
+PROJECTION_IRI = URIRef(
+    "http://www.sks.ai/SSN2BFO/current-ssn-sosa/bfo-projection"
+)
+STRICT_IRI = URIRef("http://www.sks.ai/SSN2BFO/current-ssn-sosa/bfo-mapping")
+
+
+class BfoProjectionTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        rows, stats = coms.read_workbook(REPO_ROOT / "mappings/SSN2BFO-COMS.xlsx")
+        cls.processed = coms.validate_and_process_rows(rows, coms.Resolver(), stats)
+        cls.canonical_rows = tuple(
+            coms.canonical_input_for_processed_row(row) for row in cls.processed
+        )
+        cls.audits = tuple(row.identity_audit for row in cls.processed)
+        cls.disposition = load_disposition_document(
+            REPO_ROOT / "reports/coms-product-dispositions.json"
+        )
+        cls.metadata = load_metadata(REPO_ROOT / "config/publication-metadata.toml")
+        cls.reconciliation = modular.reconcile_product_axioms(
+            modular.BFO_PROJECTION_KEY,
+            cls.canonical_rows,
+            cls.audits,
+            cls.disposition,
+        )
+        cls.strict_selected = modular.select_product_axioms(
+            "strict_bfo_mapping",
+            cls.canonical_rows,
+            cls.audits,
+            cls.disposition,
+        )
+        cls.core_selected = modular.select_product_axioms(
+            "alignment_core",
+            cls.canonical_rows,
+            cls.audits,
+            cls.disposition,
+        )
+        cls.strict_bytes = (
+            REPO_ROOT / "releases/current-ssn-sosa/ssn-sosa-bfo-mapping.ttl"
+        ).read_bytes()
+        cls.core_bytes = (
+            REPO_ROOT / "releases/current-ssn-sosa/ssn-sosa-alignment-core.ttl"
+        ).read_bytes()
+        cls.root_graph = Graph().parse(REPO_ROOT / "SSN2BFO.ttl", format="turtle")
+        cls.reasoning = modular.ModularReasoningResult(
+            source_product_key="strict_bfo_mapping",
+            source_product_sha256=hashlib.sha256(cls.strict_bytes).hexdigest(),
+            closure_triple_count=14972,
+            return_code=0,
+            reasoned_output_produced=True,
+            owl_nothing_count=0,
+            named_unsatisfiable_count=0,
+        )
+        cls.result = modular.build_bfo_projection(
+            cls.reconciliation.selected_axioms,
+            cls.metadata,
+        )
+
+    @staticmethod
+    def error_codes(error: modular.ModularProductError) -> set[str]:
+        return {value.code for value in error.issues}
+
+    @staticmethod
+    def issue_codes(issues) -> set[str]:
+        return {value.code for value in issues}
+
+    def replace_disposition_row(self, replacement):
+        return dataclasses.replace(
+            self.disposition,
+            rows=tuple(
+                replacement if row.row_id == replacement.row_id else row
+                for row in self.disposition.rows
+            ),
+        )
+
+    def validate(self, data: bytes, *, reconciliation=None, reasoning=None):
+        return modular.validate_bfo_projection(
+            data,
+            reconciliation or self.reconciliation,
+            self.strict_bytes,
+            self.strict_selected,
+            self.core_bytes,
+            self.core_selected,
+            self.metadata,
+            integrated_graph=self.root_graph,
+            strict_reasoning_result=self.reasoning if reasoning is None else reasoning,
+        )
+
+    def test_exact_disposition_reconciliation_selects_no_direct_axioms(self) -> None:
+        self.assertEqual(self.reconciliation.product_key, "bfo_projection")
+        self.assertEqual(self.reconciliation.governed_axiom_count, 105)
+        self.assertEqual(self.reconciliation.selected_axioms, ())
+        self.assertEqual(
+            tuple(
+                (value.target_category, value.status, value.reason_code, value.count)
+                for value in self.reconciliation.disposition_totals
+            ),
+            (
+                ("target_neutral", "provided_transitively", None, 29),
+                ("bfo_bearing", "provided_through_import", None, 19),
+                ("cco_bearing", "deferred", "NO_APPROVED_TRANSFORMATION_RULE", 25),
+                ("mixed_bfo_cco", "deferred", "NO_APPROVED_TRANSFORMATION_RULE", 32),
+            ),
+        )
+
+    def test_reordered_processed_rows_and_audits_are_stable(self) -> None:
+        reordered = modular.reconcile_product_axioms(
+            "bfo_projection",
+            reversed(self.canonical_rows),
+            reversed(self.audits),
+            self.disposition,
+        )
+        reordered_result = modular.build_bfo_projection(
+            reordered.selected_axioms,
+            self.metadata,
+        )
+        self.assertEqual(reordered, self.reconciliation)
+        self.assertEqual(reordered_result.serialized_bytes, self.result.serialized_bytes)
+
+    def test_identity_reconciliation_rejects_row_and_axiom_substitutions(self) -> None:
+        replacement = dataclasses.replace(
+            self.canonical_rows[0],
+            row_id="urn:uuid:ffffffff-ffff-4fff-8fff-ffffffffffff",
+        )
+        row_cases = (
+            self.canonical_rows[1:],
+            (*self.canonical_rows, self.canonical_rows[0]),
+            (replacement, *self.canonical_rows[1:]),
+        )
+        for values in row_cases:
+            with self.subTest(row_count=len(values)):
+                with self.assertRaises(modular.ModularProductError):
+                    modular.reconcile_product_axioms(
+                        "bfo_projection", values, self.audits, self.disposition
+                    )
+
+        source = self.disposition.rows[0]
+        source_axiom = source.authoritative_axioms[0]
+        axiom_cases = (
+            dataclasses.replace(source, authoritative_axioms=()),
+            dataclasses.replace(
+                source,
+                authoritative_axioms=(
+                    dataclasses.replace(
+                        source_axiom,
+                        axiom_id="sha256:" + "0" * 64,
+                    ),
+                ),
+            ),
+            dataclasses.replace(
+                source,
+                authoritative_axioms=(source_axiom, source_axiom),
+            ),
+        )
+        for replacement_row in axiom_cases:
+            with self.subTest(axiom_count=len(replacement_row.authoritative_axioms)):
+                with self.assertRaises(modular.ModularProductError):
+                    modular.reconcile_product_axioms(
+                        "bfo_projection",
+                        self.canonical_rows,
+                        self.audits,
+                        self.replace_disposition_row(replacement_row),
+                    )
+
+    def test_location_hash_row_and_axiom_mismatches_are_fatal(self) -> None:
+        row = self.canonical_rows[0]
+        moved = dataclasses.replace(
+            row,
+            location=RowLocation("Other", row.location.row_number),
+        )
+        audit_cases = (
+            (moved, self.audits[0]),
+            (
+                row,
+                dataclasses.replace(
+                    self.audits[0], source_expression_sha256="0" * 64
+                ),
+            ),
+            (
+                row,
+                dataclasses.replace(
+                    self.audits[0],
+                    expression=dataclasses.replace(
+                        self.audits[0].expression,
+                        target=(self.audits[0].expression.target or "") + " changed",
+                    ),
+                ),
+            ),
+        )
+        for changed_row, changed_audit in audit_cases:
+            with self.subTest(location=changed_row.location.text):
+                with self.assertRaises(modular.ModularProductError):
+                    modular.reconcile_product_axioms(
+                        "bfo_projection",
+                        (changed_row, *self.canonical_rows[1:]),
+                        (changed_audit, *self.audits[1:]),
+                        self.disposition,
+                    )
+
+        disposition_row = self.disposition.rows[0]
+        axiom = disposition_row.authoritative_axioms[0]
+        changed = dataclasses.replace(
+            disposition_row,
+            authoritative_axioms=(
+                dataclasses.replace(
+                    axiom,
+                    canonical_expression=axiom.canonical_expression + " changed",
+                ),
+            ),
+        )
+        with self.assertRaises(modular.ModularProductError) as raised:
+            modular.reconcile_product_axioms(
+                "bfo_projection",
+                self.canonical_rows,
+                self.audits,
+                self.replace_disposition_row(changed),
+            )
+        self.assertIn("CANONICAL_EXPRESSION_MISMATCH", self.error_codes(raised.exception))
+
+    def test_wrong_status_reason_or_category_is_fatal(self) -> None:
+        cases = []
+        for row in self.disposition.rows[:3]:
+            axiom = row.authoritative_axioms[0]
+            changed_dispositions = tuple(
+                (key, ProductDisposition("emitted_unchanged"))
+                if key == "bfo_projection"
+                else (key, value)
+                for key, value in axiom.product_dispositions
+            )
+            cases.append(
+                dataclasses.replace(
+                    row,
+                    authoritative_axioms=(
+                        dataclasses.replace(
+                            axiom,
+                            product_dispositions=changed_dispositions,
+                        ),
+                    ),
+                )
+            )
+        deferred_row = next(
+            row
+            for row in self.disposition.rows
+            if dict(row.authoritative_axioms[0].product_dispositions)[
+                "bfo_projection"
+            ].status
+            == "deferred"
+        )
+        deferred_axiom = deferred_row.authoritative_axioms[0]
+        changed_reason = tuple(
+            (key, ProductDisposition("deferred", "TARGET_SPECIFIC"))
+            if key == "bfo_projection"
+            else (key, value)
+            for key, value in deferred_axiom.product_dispositions
+        )
+        cases.append(
+            dataclasses.replace(
+                deferred_row,
+                authoritative_axioms=(
+                    dataclasses.replace(
+                        deferred_axiom,
+                        product_dispositions=changed_reason,
+                    ),
+                ),
+            )
+        )
+        cases.append(
+            dataclasses.replace(
+                deferred_row,
+                authoritative_axioms=(
+                    dataclasses.replace(
+                        deferred_axiom,
+                        target_category="target_neutral",
+                    ),
+                ),
+            )
+        )
+        for changed in cases:
+            with self.subTest(row_id=changed.row_id):
+                with self.assertRaises(modular.ModularProductError) as raised:
+                    modular.reconcile_product_axioms(
+                        "bfo_projection",
+                        self.canonical_rows,
+                        self.audits,
+                        self.replace_disposition_row(changed),
+                    )
+                self.assertTrue(
+                    self.error_codes(raised.exception)
+                    & {"WRONG_PRODUCT_DISPOSITION", "TARGET_CATEGORY_MISMATCH"}
+                )
+
+    def test_builder_rejects_any_direct_axiom(self) -> None:
+        with self.assertRaises(modular.ModularProductError) as raised:
+            modular.build_bfo_projection((self.strict_selected[0],), self.metadata)
+        self.assertEqual(self.error_codes(raised.exception), {"UNAPPROVED_PROJECTION_AXIOM"})
+
+    def test_direct_graph_has_only_the_governed_header_and_import(self) -> None:
+        graph = Graph().parse(
+            data=self.result.serialized_bytes.decode("utf-8"), format="turtle"
+        )
+        self.assertEqual(len(graph), 2)
+        self.assertEqual(self.result.governed_axiom_count, 0)
+        self.assertEqual(self.result.logical_triple_count, 0)
+        self.assertEqual(self.result.import_triple_count, 1)
+        self.assertEqual(
+            set(graph),
+            {
+                (PROJECTION_IRI, RDF.type, OWL.Ontology),
+                (PROJECTION_IRI, OWL.imports, STRICT_IRI),
+            },
+        )
+        self.assertFalse(any(isinstance(value, BNode) for value in graph.all_nodes()))
+        text = self.result.serialized_bytes.decode("utf-8")
+        for prohibited in (
+            "http://www.w3.org/ns/sosa/",
+            "http://www.w3.org/ns/ssn/",
+            "http://purl.obolibrary.org/obo/BFO_",
+            "https://www.commoncoreontologies.org/",
+            "http://purl.obolibrary.org/obo/RO_",
+            "owl:Axiom",
+            "rdf:first",
+            "rdf:rest",
+        ):
+            self.assertNotIn(prohibited, text)
+        self.assertEqual(self.validate(self.result.serialized_bytes), ())
+
+    def test_wrong_import_and_unexpected_direct_content_are_rejected(self) -> None:
+        text = self.result.serialized_bytes.decode("utf-8")
+        cases = (
+            text.replace(
+                str(STRICT_IRI),
+                "http://www.sks.ai/SSN2BFO/current-ssn-sosa/alignment-core",
+            ).encode("utf-8"),
+            (
+                text
+                + "<http://www.w3.org/ns/sosa/Observation> "
+                "<http://www.w3.org/2000/01/rdf-schema#subClassOf> "
+                "<http://purl.obolibrary.org/obo/BFO_0000001> .\n"
+            ).encode("utf-8"),
+            (
+                text
+                + "<http://www.w3.org/ns/sosa/Observation> "
+                "<http://www.w3.org/2000/01/rdf-schema#subClassOf> "
+                "<https://www.commoncoreontologies.org/Artifact> .\n"
+            ).encode("utf-8"),
+            (
+                text
+                + "<http://www.w3.org/ns/sosa/Observation> "
+                "<http://www.w3.org/1999/02/22-rdf-syntax-ns#type> "
+                "<http://www.w3.org/2002/07/owl#Class> .\n"
+            ).encode("utf-8"),
+        )
+        for data in cases:
+            with self.subTest(size=len(data)):
+                codes = self.issue_codes(self.validate(data))
+                self.assertTrue(
+                    codes
+                    & {
+                        "IMPORT_POLICY_MISMATCH",
+                        "UNAPPROVED_PROJECTION_AXIOM",
+                        "COPIED_DECLARATION",
+                        "UNEXPECTED_LOGICAL_VOCABULARY",
+                    }
+                )
+
+    def test_project_closure_is_exact_strict_core_set_and_has_no_cco(self) -> None:
+        strict_graph = Graph().parse(data=self.strict_bytes.decode(), format="turtle")
+        core_graph = Graph().parse(data=self.core_bytes.decode(), format="turtle")
+        project = Graph()
+        for source in (
+            Graph().parse(data=self.result.serialized_bytes.decode(), format="turtle"),
+            strict_graph,
+            core_graph,
+        ):
+            for triple in source:
+                project.add(triple)
+        self.assertEqual(len(self.strict_selected), 19)
+        self.assertEqual(len(self.core_selected), 29)
+        self.assertEqual(
+            {value.axiom_id for value in self.strict_selected}
+            & {value.axiom_id for value in self.core_selected},
+            set(),
+        )
+        self.assertEqual(len(project), 183)
+        self.assertEqual(len(list(project.triples((None, OWL.imports, None)))), 2)
+        for triple in list(project.triples((None, OWL.imports, None))):
+            project.remove(triple)
+        self.assertEqual(len(project), 181)
+        self.assertFalse(
+            any(
+                isinstance(value, URIRef)
+                and str(value).startswith("https://www.commoncoreontologies.org/")
+                for value in project.all_nodes()
+            )
+        )
+        self.assertEqual(self.validate(self.result.serialized_bytes), ())
+
+    def test_strict_reasoning_reuse_is_required_and_bound_to_strict_bytes(self) -> None:
+        self.assertIn(
+            "STRICT_REASONING_RESULT_MISSING",
+            self.issue_codes(
+                modular.validate_bfo_projection(
+                    self.result.serialized_bytes,
+                    self.reconciliation,
+                    self.strict_bytes,
+                    self.strict_selected,
+                    self.core_bytes,
+                    self.core_selected,
+                    self.metadata,
+                    integrated_graph=self.root_graph,
+                    strict_reasoning_result=None,
+                )
+            ),
+        )
+        for changed in (
+            dataclasses.replace(self.reasoning, source_product_sha256="0" * 64),
+            dataclasses.replace(self.reasoning, return_code=1),
+            dataclasses.replace(self.reasoning, named_unsatisfiable_count=1),
+        ):
+            with self.subTest(return_code=changed.return_code):
+                self.assertTrue(self.issue_codes(self.validate(self.result.serialized_bytes, reasoning=changed)))
+
+    def test_serialization_is_deterministic_and_fresh_process_stable(self) -> None:
+        repeated = modular.build_bfo_projection((), self.metadata).serialized_bytes
+        self.assertEqual(repeated, self.result.serialized_bytes)
+        self.assertTrue(repeated.endswith(b"\n"))
+        self.assertFalse(repeated.endswith(b"\n\n"))
+        self.assertEqual(hashlib.sha256(repeated).hexdigest(), EXPECTED_SHA256)
+        script = """
+import hashlib, sys
+from pathlib import Path
+root = Path(sys.argv[1])
+sys.path.insert(0, str(root / 'tools'))
+from modular_products import build_bfo_projection
+from publication_metadata import load_metadata
+data = build_bfo_projection((), load_metadata(root / 'config/publication-metadata.toml')).serialized_bytes
+print(hashlib.sha256(data).hexdigest())
+"""
+        completed = subprocess.run(
+            [sys.executable, "-c", script, str(REPO_ROOT)],
+            cwd=REPO_ROOT,
+            text=True,
+            capture_output=True,
+            check=True,
+        )
+        self.assertEqual(completed.stdout.strip(), EXPECTED_SHA256)
+
+    def test_existing_module_bytes_remain_protected(self) -> None:
+        self.assertEqual(
+            hashlib.sha256(self.core_bytes).hexdigest(),
+            "95f71184b90224906b0ba703d0ea60fd2f8b993b3853b803c66b88b91ba0b01c",
+        )
+        self.assertEqual(
+            hashlib.sha256(self.strict_bytes).hexdigest(),
+            "15f080145c6803d174a00cf9e13c971925b40485049744dba6e0847093016ea7",
+        )
+        self.assertEqual(
+            hashlib.sha256(
+                (
+                    REPO_ROOT
+                    / "releases/current-ssn-sosa/ssn-sosa-cco-extension.ttl"
+                ).read_bytes()
+            ).hexdigest(),
+            "fe6986d79ec2f5f67553fbee1364fa98ebd7ba3205196f0368ac246646fcdf7c",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_generate_mapping_from_coms.py
+++ b/tests/test_generate_mapping_from_coms.py
@@ -12,7 +12,7 @@ from types import SimpleNamespace
 from unittest import mock
 
 import openpyxl
-from rdflib import BNode, RDF, RDFS, OWL, URIRef
+from rdflib import BNode, Graph, RDF, RDFS, OWL, URIRef
 from rdflib.collection import Collection
 
 
@@ -121,6 +121,8 @@ class ComsDomainRangeTests(unittest.TestCase):
                 str(self.root / "alignment-core.ttl"),
                 "--strict-bfo-output",
                 str(self.root / "strict-bfo.ttl"),
+                "--bfo-projection-output",
+                str(self.root / "bfo-projection.ttl"),
                 "--cco-extension-output",
                 str(self.root / "cco-extension.ttl"),
                 "--coverage-report",
@@ -145,6 +147,7 @@ class ComsDomainRangeTests(unittest.TestCase):
         self.assertFalse(disposition_path.exists())
         self.assertFalse((self.root / "alignment-core.ttl").exists())
         self.assertFalse((self.root / "strict-bfo.ttl").exists())
+        self.assertFalse((self.root / "bfo-projection.ttl").exists())
         self.assertFalse((self.root / "cco-extension.ttl").exists())
         self.assertTrue(report_path.is_file())
         report = report_path.read_text(encoding="utf-8")
@@ -715,6 +718,9 @@ class ComsGenerationReportTests(unittest.TestCase):
         alignment_core_hermit: object | None = None,
         strict_bfo_result: object | None = None,
         strict_bfo_hermit: object | None = None,
+        bfo_projection_result: object | None = None,
+        bfo_projection_reconciliation: object | None = None,
+        bfo_projection_reasoning: object | None = None,
         cco_extension_result: object | None = None,
         cco_extension_hermit: object | None = None,
     ) -> str:
@@ -755,6 +761,13 @@ class ComsGenerationReportTests(unittest.TestCase):
             ),
             strict_bfo_sha256="strict-bfo-hash",
             strict_bfo_hermit=strict_bfo_hermit,
+            bfo_projection_result=bfo_projection_result,
+            bfo_projection_reconciliation=bfo_projection_reconciliation,
+            bfo_projection_path=Path(
+                "releases/current-ssn-sosa/ssn-sosa-bfo-projection.ttl"
+            ),
+            bfo_projection_sha256="bfo-projection-hash",
+            bfo_projection_reasoning=bfo_projection_reasoning,
             cco_extension_result=cco_extension_result,
             cco_extension_path=Path(
                 "releases/current-ssn-sosa/ssn-sosa-cco-extension.ttl"
@@ -974,6 +987,66 @@ class ComsGenerationReportTests(unittest.TestCase):
         self.assertIn("Project-module closure governed axioms: 105", report)
         self.assertIn("Pinned closure triple count: 15907", report)
 
+    def test_generation_report_includes_import_only_bfo_projection_results(self) -> None:
+        result = SimpleNamespace(
+            metadata=SimpleNamespace(
+                stable_ontology_iri=(
+                    "http://www.sks.ai/SSN2BFO/current-ssn-sosa/bfo-projection"
+                )
+            ),
+            governed_axiom_count=0,
+            logical_triple_count=0,
+            import_triple_count=1,
+            total_triple_count=2,
+        )
+        reconciliation = modular.ProductDispositionReconciliation(
+            product_key="bfo_projection",
+            governed_axiom_count=105,
+            selected_axioms=(),
+            disposition_totals=(
+                modular.ProductDispositionTotal(
+                    "target_neutral", "provided_transitively", None, 29
+                ),
+                modular.ProductDispositionTotal(
+                    "bfo_bearing", "provided_through_import", None, 19
+                ),
+                modular.ProductDispositionTotal(
+                    "cco_bearing", "deferred", "NO_APPROVED_TRANSFORMATION_RULE", 25
+                ),
+                modular.ProductDispositionTotal(
+                    "mixed_bfo_cco", "deferred", "NO_APPROVED_TRANSFORMATION_RULE", 32
+                ),
+            ),
+        )
+        reasoning = modular.ModularReasoningResult(
+            source_product_key="strict_bfo_mapping",
+            source_product_sha256="strict-bfo-hash",
+            closure_triple_count=14972,
+            return_code=0,
+            reasoned_output_produced=True,
+            owl_nothing_count=0,
+            named_unsatisfiable_count=0,
+        )
+        report = self.render_report(
+            "bfo-projection",
+            "/opt/robot",
+        )
+        self.assertIn("## BFO Projection", report)
+        report = self.render_report(
+            "bfo-projection-populated",
+            "/opt/robot",
+            bfo_projection_result=result,
+            bfo_projection_reconciliation=reconciliation,
+            bfo_projection_reasoning=reasoning,
+        )
+        self.assertIn("Direct governed projection axioms: 0", report)
+        self.assertIn("Direct logical mapping triples: 0", report)
+        self.assertIn("Total RDF triples: 2", report)
+        self.assertIn("Project-module closure governed axioms: 48", report)
+        self.assertIn("Reused strict-BFO closure triple count: 14972", report)
+        self.assertIn("Projection-specific HermiT invocation: none", report)
+        self.assertIn("Zero direct projection axioms is intentional", report)
+
 
 class ComsAuthorityMigrationTests(unittest.TestCase):
     def setUp(self) -> None:
@@ -990,6 +1063,7 @@ class ComsAuthorityMigrationTests(unittest.TestCase):
             "disposition_report": self.root / "reports/coms-product-dispositions.json",
             "alignment_core": self.root / "releases/current-ssn-sosa/ssn-sosa-alignment-core.ttl",
             "strict_bfo_mapping": self.root / "releases/current-ssn-sosa/ssn-sosa-bfo-mapping.ttl",
+            "bfo_projection": self.root / "releases/current-ssn-sosa/ssn-sosa-bfo-projection.ttl",
             "cco_extension": self.root / "releases/current-ssn-sosa/ssn-sosa-cco-extension.ttl",
         }
 
@@ -1015,6 +1089,11 @@ class ComsAuthorityMigrationTests(unittest.TestCase):
         )
         return modular.build_cco_extension(selected, metadata).serialized_bytes
 
+    @staticmethod
+    def generated_bfo_projection_bytes() -> bytes:
+        metadata = load_metadata(REPO_ROOT / "config/publication-metadata.toml")
+        return modular.build_bfo_projection((), metadata).serialized_bytes
+
     def test_root_ontology_is_the_maintained_output(self) -> None:
         self.assertEqual(checker.MAINTAINED_OUTPUTS["candidate"], REPO_ROOT / "SSN2BFO.ttl")
         self.assertEqual(
@@ -1032,6 +1111,10 @@ class ComsAuthorityMigrationTests(unittest.TestCase):
         self.assertEqual(
             checker.MAINTAINED_OUTPUTS["strict_bfo_mapping"],
             REPO_ROOT / "releases/current-ssn-sosa/ssn-sosa-bfo-mapping.ttl",
+        )
+        self.assertEqual(
+            checker.MAINTAINED_OUTPUTS["bfo_projection"],
+            REPO_ROOT / "releases/current-ssn-sosa/ssn-sosa-bfo-projection.ttl",
         )
         self.assertEqual(
             checker.MAINTAINED_OUTPUTS["cco_extension"],
@@ -1070,6 +1153,7 @@ class ComsAuthorityMigrationTests(unittest.TestCase):
         publication_metadata_hash = checker.sha256_file(checker.PUBLICATION_METADATA)
         alignment_core_hash = checker.sha256_file(outputs["alignment_core"])
         strict_bfo_hash = checker.sha256_file(outputs["strict_bfo_mapping"])
+        bfo_projection_hash = checker.sha256_file(outputs["bfo_projection"])
         cco_extension_hash = checker.sha256_file(outputs["cco_extension"])
         self.write(
             outputs["generation_report"],
@@ -1089,6 +1173,8 @@ class ComsAuthorityMigrationTests(unittest.TestCase):
                     f"| alignment-core Turtle SHA-256 | `{alignment_core_hash}` |",
                     "| maintained strict-BFO path | `releases/current-ssn-sosa/ssn-sosa-bfo-mapping.ttl` |",
                     f"| strict-BFO Turtle SHA-256 | `{strict_bfo_hash}` |",
+                    "| maintained BFO-projection path | `releases/current-ssn-sosa/ssn-sosa-bfo-projection.ttl` |",
+                    f"| BFO-projection Turtle SHA-256 | `{bfo_projection_hash}` |",
                     "| maintained CCO-extension path | `releases/current-ssn-sosa/ssn-sosa-cco-extension.ttl` |",
                     f"| CCO-extension Turtle SHA-256 | `{cco_extension_hash}` |",
                 ]
@@ -1136,6 +1222,7 @@ class ComsAuthorityMigrationTests(unittest.TestCase):
         publication_metadata_hash = checker.sha256_file(checker.PUBLICATION_METADATA)
         alignment_core_hash = checker.sha256_file(outputs["alignment_core"])
         strict_bfo_hash = checker.sha256_file(outputs["strict_bfo_mapping"])
+        bfo_projection_hash = checker.sha256_file(outputs["bfo_projection"])
         cco_extension_hash = checker.sha256_file(outputs["cco_extension"])
         self.write(
             outputs["generation_report"],
@@ -1155,6 +1242,8 @@ class ComsAuthorityMigrationTests(unittest.TestCase):
                     f"| alignment-core Turtle SHA-256 | `{alignment_core_hash}` |",
                     "| maintained strict-BFO path | `releases/current-ssn-sosa/ssn-sosa-bfo-mapping.ttl` |",
                     f"| strict-BFO Turtle SHA-256 | `{strict_bfo_hash}` |",
+                    "| maintained BFO-projection path | `releases/current-ssn-sosa/ssn-sosa-bfo-projection.ttl` |",
+                    f"| BFO-projection Turtle SHA-256 | `{bfo_projection_hash}` |",
                     "| maintained CCO-extension path | `releases/current-ssn-sosa/ssn-sosa-cco-extension.ttl` |",
                     f"| CCO-extension Turtle SHA-256 | `{cco_extension_hash}` |",
                 ]
@@ -1241,6 +1330,8 @@ class ComsAuthorityMigrationTests(unittest.TestCase):
                     f"| alignment-core Turtle SHA-256 | `{hashes['alignment_core']}` |",
                     "| maintained strict-BFO path | `releases/current-ssn-sosa/ssn-sosa-bfo-mapping.ttl` |",
                     f"| strict-BFO Turtle SHA-256 | `{hashes['strict_bfo_mapping']}` |",
+                    "| maintained BFO-projection path | `releases/current-ssn-sosa/ssn-sosa-bfo-projection.ttl` |",
+                    f"| BFO-projection Turtle SHA-256 | `{hashes['bfo_projection']}` |",
                     "| maintained CCO-extension path | `releases/current-ssn-sosa/ssn-sosa-cco-extension.ttl` |",
                     f"| CCO-extension Turtle SHA-256 | `{hashes['cco_extension']}` |",
                 ]
@@ -1314,6 +1405,8 @@ class ComsAuthorityMigrationTests(unittest.TestCase):
                     f"| alignment-core Turtle SHA-256 | `{hashes['alignment_core']}` |",
                     "| maintained strict-BFO path | `releases/current-ssn-sosa/ssn-sosa-bfo-mapping.ttl` |",
                     f"| strict-BFO Turtle SHA-256 | `{hashes['strict_bfo_mapping']}` |",
+                    "| maintained BFO-projection path | `releases/current-ssn-sosa/ssn-sosa-bfo-projection.ttl` |",
+                    f"| BFO-projection Turtle SHA-256 | `{hashes['bfo_projection']}` |",
                     "| maintained CCO-extension path | `releases/current-ssn-sosa/ssn-sosa-cco-extension.ttl` |",
                     f"| CCO-extension Turtle SHA-256 | `{hashes['cco_extension']}` |",
                 ]
@@ -1359,6 +1452,197 @@ class ComsAuthorityMigrationTests(unittest.TestCase):
         run_generator.assert_not_called()
         for path, content in expected.items():
             self.assertEqual(path.read_bytes(), content)
+        self.assertEqual(list(cache_dir.glob("run-*")), [])
+
+    def test_stale_bfo_projection_hash_fails_check_only_without_rewriting_outputs(self) -> None:
+        outputs = self.maintained_outputs()
+        for name, path in outputs.items():
+            self.write(path, f"maintained-{name}\n")
+        hashes = {name: checker.sha256_file(path) for name, path in outputs.items()}
+        disposition_module_hash = checker.sha256_file(checker.DISPOSITION_MODULE)
+        modular_products_module_hash = checker.sha256_file(checker.MODULAR_PRODUCTS_MODULE)
+        publication_metadata_hash = checker.sha256_file(checker.PUBLICATION_METADATA)
+        self.write(
+            outputs["generation_report"],
+            "\n".join(
+                [
+                    "| workbook SHA-256 | `workbook-hash` |",
+                    "| generator SHA-256 | `generator-hash` |",
+                    f"| product-disposition module SHA-256 | `{disposition_module_hash}` |",
+                    f"| modular-products module SHA-256 | `{modular_products_module_hash}` |",
+                    f"| publication metadata SHA-256 | `{publication_metadata_hash}` |",
+                    "| generation timestamp (UTC) | `2026-01-01T00:00:00+00:00` |",
+                    "| maintained ontology path | `SSN2BFO.ttl` |",
+                    f"| generated ontology SHA-256 | `{hashes['candidate']}` |",
+                    "| maintained product-disposition path | `reports/coms-product-dispositions.json` |",
+                    f"| product-disposition JSON SHA-256 | `{hashes['disposition_report']}` |",
+                    "| maintained alignment-core path | `releases/current-ssn-sosa/ssn-sosa-alignment-core.ttl` |",
+                    f"| alignment-core Turtle SHA-256 | `{hashes['alignment_core']}` |",
+                    "| maintained strict-BFO path | `releases/current-ssn-sosa/ssn-sosa-bfo-mapping.ttl` |",
+                    f"| strict-BFO Turtle SHA-256 | `{hashes['strict_bfo_mapping']}` |",
+                    "| maintained BFO-projection path | `releases/current-ssn-sosa/ssn-sosa-bfo-projection.ttl` |",
+                    f"| BFO-projection Turtle SHA-256 | `{hashes['bfo_projection']}` |",
+                    "| maintained CCO-extension path | `releases/current-ssn-sosa/ssn-sosa-cco-extension.ttl` |",
+                    f"| CCO-extension Turtle SHA-256 | `{hashes['cco_extension']}` |",
+                ]
+            ),
+        )
+        fake_disposition = SimpleNamespace(
+            input_hashes=SimpleNamespace(
+                workbook_sha256="workbook-hash",
+                generator_sha256="generator-hash",
+                row_identity_module_sha256=checker.sha256_file(
+                    checker.ROW_IDENTITY_MODULE
+                ),
+                disposition_module_sha256=disposition_module_hash,
+                publication_metadata_sha256=publication_metadata_hash,
+            ),
+            product_order=tuple(
+                product.key
+                for product in load_metadata(checker.PUBLICATION_METADATA).products
+            ),
+        )
+        self.write(outputs["bfo_projection"], "modified maintained BFO projection\n")
+        expected = {path: path.read_bytes() for path in outputs.values()}
+        cache_dir = self.root / ".cache/coms"
+        run_generator = mock.Mock()
+        with (
+            mock.patch.object(checker, "REPO_ROOT", self.root),
+            mock.patch.object(checker, "CACHE_DIR", cache_dir),
+            mock.patch.object(checker, "LAST_SUCCESS", cache_dir / "last-success.json"),
+            mock.patch.object(checker, "LAST_FAILURE", cache_dir / "last-failure.log"),
+            mock.patch.object(checker, "MAINTAINED_OUTPUTS", outputs),
+            mock.patch.object(checker, "verify_workbook", return_value="workbook-hash"),
+            mock.patch.object(checker, "compile_generator", return_value="generator-hash"),
+            mock.patch.object(checker, "run_generator", run_generator),
+            mock.patch.object(
+                checker, "load_disposition_document", return_value=fake_disposition
+            ),
+            mock.patch.object(
+                checker,
+                "serialize_disposition_document",
+                return_value=outputs["disposition_report"].read_bytes(),
+            ),
+            mock.patch.object(checker, "write_failure_log"),
+        ):
+            errors = checker.freshness_errors("workbook-hash", "generator-hash")
+            self.assertEqual(
+                errors, ["BFO-projection hash differs from the generated report"]
+            )
+            self.assertNotIn(
+                "generated candidate hash differs from the generated report", errors
+            )
+            self.assertEqual(checker.main(["--check-only"]), 1)
+        run_generator.assert_not_called()
+        for path, content in expected.items():
+            self.assertEqual(path.read_bytes(), content)
+        self.assertEqual(list(cache_dir.glob("run-*")), [])
+
+    def test_first_successful_update_creates_initially_absent_bfo_projection(self) -> None:
+        outputs = self.maintained_outputs()
+        existing = {
+            name: path for name, path in outputs.items() if name != "bfo_projection"
+        }
+        for name, path in existing.items():
+            self.write(path, f"old-{name}\n")
+        self.assertFalse(outputs["bfo_projection"].exists())
+        expected_generated = {
+            name: f"new-{name}\n".encode("utf-8") for name in existing
+        }
+        projection_bytes = self.generated_bfo_projection_bytes()
+        cache_dir = self.root / ".cache/coms"
+        transaction_dirs: list[Path] = []
+        events: list[str] = []
+        validated = False
+
+        def fake_run_generator(paths: dict[str, Path], _log: list[str]) -> None:
+            self.assertFalse(outputs["bfo_projection"].exists())
+            transaction_dirs.append(paths["candidate"].parents[1])
+            for name, content in expected_generated.items():
+                paths[name].parent.mkdir(parents=True, exist_ok=True)
+                paths[name].write_bytes(content)
+            paths["bfo_projection"].parent.mkdir(parents=True, exist_ok=True)
+            paths["bfo_projection"].write_bytes(projection_bytes)
+            self.write(paths["summary"], "{}\n")
+            events.append("generated")
+
+        def fake_validate(paths: dict[str, Path], *_args, **_kwargs):
+            nonlocal validated
+            self.assertFalse(outputs["bfo_projection"].exists())
+            graph = coms.Graph().parse(paths["bfo_projection"], format="turtle")
+            self.assertEqual(
+                set(graph),
+                {
+                    (
+                        URIRef(
+                            "http://www.sks.ai/SSN2BFO/current-ssn-sosa/bfo-projection"
+                        ),
+                        RDF.type,
+                        OWL.Ontology,
+                    ),
+                    (
+                        URIRef(
+                            "http://www.sks.ai/SSN2BFO/current-ssn-sosa/bfo-projection"
+                        ),
+                        OWL.imports,
+                        URIRef(
+                            "http://www.sks.ai/SSN2BFO/current-ssn-sosa/bfo-mapping"
+                        ),
+                    ),
+                },
+            )
+            validated = True
+            events.append("validated")
+            return {}
+
+        production_replace = checker.replace_outputs_atomically
+
+        def observe_replace(
+            paths: dict[str, Path], transaction_dir: Path, log: list[str]
+        ) -> None:
+            self.assertTrue(validated)
+            self.assertFalse(outputs["bfo_projection"].exists())
+            events.append("replace-start")
+            production_replace(paths, transaction_dir, log)
+            self.assertTrue(outputs["bfo_projection"].exists())
+            events.append("replace-complete")
+
+        with (
+            mock.patch.object(checker, "REPO_ROOT", self.root),
+            mock.patch.object(checker, "CACHE_DIR", cache_dir),
+            mock.patch.object(checker, "LAST_SUCCESS", cache_dir / "last-success.json"),
+            mock.patch.object(checker, "LAST_FAILURE", cache_dir / "last-failure.log"),
+            mock.patch.object(checker, "MAINTAINED_OUTPUTS", outputs),
+            mock.patch.object(checker, "verify_workbook", return_value="workbook-hash"),
+            mock.patch.object(checker, "compile_generator", return_value="generator-hash"),
+            mock.patch.object(
+                checker,
+                "freshness_errors",
+                return_value=["missing BFO projection"],
+            ),
+            mock.patch.object(checker, "run_generator", side_effect=fake_run_generator),
+            mock.patch.object(
+                checker, "validate_temporary_outputs", side_effect=fake_validate
+            ),
+            mock.patch.object(checker, "git_diff_check"),
+            mock.patch.object(
+                checker, "output_differences", return_value=list(outputs)
+            ),
+            mock.patch.object(
+                checker, "replace_outputs_atomically", side_effect=observe_replace
+            ),
+            mock.patch.object(checker, "record_success"),
+            mock.patch.object(checker, "write_failure_log"),
+        ):
+            self.assertEqual(checker.main([]), 0)
+        self.assertEqual(
+            events, ["generated", "validated", "replace-start", "replace-complete"]
+        )
+        self.assertEqual(outputs["bfo_projection"].read_bytes(), projection_bytes)
+        self.assertEqual(len(Graph().parse(outputs["bfo_projection"], format="turtle")), 2)
+        self.assertTrue(all(path.is_file() for path in outputs.values()))
+        self.assertEqual(len(transaction_dirs), 1)
+        self.assertFalse(transaction_dirs[0].exists())
         self.assertEqual(list(cache_dir.glob("run-*")), [])
 
     def test_first_successful_update_creates_initially_absent_alignment_core(self) -> None:
@@ -1663,7 +1947,7 @@ class ComsAuthorityMigrationTests(unittest.TestCase):
 
         self.assertEqual(outputs["candidate"].read_text(encoding="utf-8"), "new-candidate\n")
 
-    def test_check_only_preserves_all_eight_outputs_and_workbook(self) -> None:
+    def test_check_only_preserves_all_nine_outputs_and_workbook(self) -> None:
         outputs = self.maintained_outputs()
         workbook = self.root / "mappings/SSN2BFO-COMS.xlsx"
         self.write(workbook, "workbook-bytes\n")
@@ -1867,6 +2151,57 @@ class ComsAuthorityMigrationTests(unittest.TestCase):
         for path, expected in before.items():
             self.assertEqual(path.read_bytes(), expected)
         self.assertFalse(outputs["strict_bfo_mapping"].exists())
+        self.assertEqual(len(transaction_dirs), 1)
+        self.assertFalse(transaction_dirs[0].exists())
+
+    def test_rollback_removes_new_bfo_projection_when_it_was_initially_absent(self) -> None:
+        outputs = self.maintained_outputs()
+        existing = {
+            name: path for name, path in outputs.items() if name != "bfo_projection"
+        }
+        for name, path in existing.items():
+            self.write(path, f"old-{name}\n")
+        before = {path: path.read_bytes() for path in existing.values()}
+        cache_dir = self.root / ".cache/coms"
+        transaction_dirs: list[Path] = []
+
+        def fake_run_generator(paths: dict[str, Path], _log: list[str]) -> None:
+            transaction_dirs.append(paths["candidate"].parents[1])
+            for name in outputs:
+                self.write(paths[name], f"new-{name}\n")
+            self.write(paths["summary"], "{}\n")
+
+        diff_checks = 0
+
+        def fail_post_update(_log: list[str], _label: str) -> None:
+            nonlocal diff_checks
+            diff_checks += 1
+            if diff_checks == 2:
+                raise checker.CheckFailure("post-update failure")
+
+        with (
+            mock.patch.object(checker, "REPO_ROOT", self.root),
+            mock.patch.object(checker, "CACHE_DIR", cache_dir),
+            mock.patch.object(checker, "LAST_SUCCESS", cache_dir / "last-success.json"),
+            mock.patch.object(checker, "LAST_FAILURE", cache_dir / "last-failure.log"),
+            mock.patch.object(checker, "MAINTAINED_OUTPUTS", outputs),
+            mock.patch.object(checker, "verify_workbook", return_value="workbook-hash"),
+            mock.patch.object(checker, "compile_generator", return_value="generator-hash"),
+            mock.patch.object(checker, "freshness_errors", return_value=["stale"]),
+            mock.patch.object(checker, "run_generator", side_effect=fake_run_generator),
+            mock.patch.object(checker, "validate_temporary_outputs", return_value={}),
+            mock.patch.object(checker, "git_diff_check", side_effect=fail_post_update),
+            mock.patch.object(
+                checker, "output_differences", return_value=list(outputs)
+            ),
+            mock.patch.object(checker, "record_success"),
+            mock.patch.object(checker, "write_failure_log"),
+        ):
+            self.assertEqual(checker.main([]), 1)
+        self.assertEqual(diff_checks, 2)
+        for path, expected in before.items():
+            self.assertEqual(path.read_bytes(), expected)
+        self.assertFalse(outputs["bfo_projection"].exists())
         self.assertEqual(len(transaction_dirs), 1)
         self.assertFalse(transaction_dirs[0].exists())
 
@@ -2180,6 +2515,141 @@ class ComsAuthorityMigrationTests(unittest.TestCase):
         self.assertEqual(len(transaction_dirs), 1)
         self.assertFalse(transaction_dirs[0].exists())
 
+    def test_invalid_bfo_projection_candidates_fail_before_replacement(self) -> None:
+        rows, stats = coms.read_workbook(
+            REPO_ROOT / "mappings/SSN2BFO-COMS.xlsx"
+        )
+        processed = coms.validate_and_process_rows(rows, coms.Resolver(), stats)
+        canonical_rows = tuple(
+            coms.canonical_input_for_processed_row(row) for row in processed
+        )
+        audits = tuple(row.identity_audit for row in processed)
+        disposition = checker.load_disposition_document(
+            REPO_ROOT / "reports/coms-product-dispositions.json"
+        )
+        metadata = load_metadata(REPO_ROOT / "config/publication-metadata.toml")
+        reconciliation = modular.reconcile_product_axioms(
+            "bfo_projection", canonical_rows, audits, disposition
+        )
+        strict_selected = modular.select_product_axioms(
+            "strict_bfo_mapping", canonical_rows, audits, disposition
+        )
+        core_selected = modular.select_product_axioms(
+            "alignment_core", canonical_rows, audits, disposition
+        )
+        strict_bytes = (
+            REPO_ROOT / "releases/current-ssn-sosa/ssn-sosa-bfo-mapping.ttl"
+        ).read_bytes()
+        core_bytes = (
+            REPO_ROOT / "releases/current-ssn-sosa/ssn-sosa-alignment-core.ttl"
+        ).read_bytes()
+        valid = self.generated_bfo_projection_bytes()
+        valid_text = valid.decode("utf-8")
+        reasoning = modular.ModularReasoningResult(
+            source_product_key="strict_bfo_mapping",
+            source_product_sha256=checker.sha256_file(
+                REPO_ROOT / "releases/current-ssn-sosa/ssn-sosa-bfo-mapping.ttl"
+            ),
+            closure_triple_count=14972,
+            return_code=0,
+            reasoned_output_produced=True,
+            owl_nothing_count=0,
+            named_unsatisfiable_count=0,
+        )
+        root_graph = Graph().parse(REPO_ROOT / "SSN2BFO.ttl", format="turtle")
+        cases = {
+            "malformed Turtle": b"@prefix owl: <http://www.w3.org/2002/07/owl#> .\n[\n",
+            "wrong import": valid_text.replace(
+                "http://www.sks.ai/SSN2BFO/current-ssn-sosa/bfo-mapping",
+                "http://www.sks.ai/SSN2BFO/current-ssn-sosa/cco-extension",
+            ).encode("utf-8"),
+            "unexpected direct axiom": (
+                valid_text
+                + "<http://www.w3.org/ns/sosa/Observation> "
+                "<http://www.w3.org/2000/01/rdf-schema#subClassOf> "
+                "<http://purl.obolibrary.org/obo/BFO_0000001> .\n"
+            ).encode("utf-8"),
+            "unexpected CCO axiom": (
+                valid_text
+                + "<http://www.w3.org/ns/sosa/Observation> "
+                "<http://www.w3.org/2000/01/rdf-schema#subClassOf> "
+                "<https://www.commoncoreontologies.org/Artifact> .\n"
+            ).encode("utf-8"),
+        }
+
+        for label, candidate_bytes in cases.items():
+            with self.subTest(label=label):
+                outputs = self.maintained_outputs()
+                for name, path in outputs.items():
+                    self.write(path, f"old-{name}\n")
+                before = {path: path.read_bytes() for path in outputs.values()}
+                cache_dir = self.root / f".cache/coms-{label.replace(' ', '-')}"
+                transaction_dirs: list[Path] = []
+                observed: list[bytes] = []
+
+                def fake_run_generator(paths: dict[str, Path], _log: list[str]) -> None:
+                    transaction_dirs.append(paths["candidate"].parents[1])
+                    for name in outputs:
+                        self.write(paths[name], f"temporary-{name}\n")
+                    paths["bfo_projection"].write_bytes(candidate_bytes)
+                    self.write(paths["summary"], "{}\n")
+
+                def validate_written_candidate(
+                    paths: dict[str, Path], *_args, **_kwargs
+                ):
+                    observed.append(paths["bfo_projection"].read_bytes())
+                    issues = modular.validate_bfo_projection(
+                        observed[-1],
+                        reconciliation,
+                        strict_bytes,
+                        strict_selected,
+                        core_bytes,
+                        core_selected,
+                        metadata,
+                        integrated_graph=root_graph,
+                        strict_reasoning_result=reasoning,
+                    )
+                    self.assertTrue(issues)
+                    raise checker.CheckFailure(
+                        "; ".join(value.code for value in issues)
+                    )
+
+                with (
+                    mock.patch.object(checker, "REPO_ROOT", self.root),
+                    mock.patch.object(checker, "CACHE_DIR", cache_dir),
+                    mock.patch.object(
+                        checker, "LAST_SUCCESS", cache_dir / "last-success.json"
+                    ),
+                    mock.patch.object(
+                        checker, "LAST_FAILURE", cache_dir / "last-failure.log"
+                    ),
+                    mock.patch.object(checker, "MAINTAINED_OUTPUTS", outputs),
+                    mock.patch.object(
+                        checker, "verify_workbook", return_value="workbook-hash"
+                    ),
+                    mock.patch.object(
+                        checker, "compile_generator", return_value="generator-hash"
+                    ),
+                    mock.patch.object(checker, "freshness_errors", return_value=["stale"]),
+                    mock.patch.object(
+                        checker, "run_generator", side_effect=fake_run_generator
+                    ),
+                    mock.patch.object(
+                        checker,
+                        "validate_temporary_outputs",
+                        side_effect=validate_written_candidate,
+                    ),
+                    mock.patch.object(checker, "record_success"),
+                    mock.patch.object(checker, "write_failure_log"),
+                ):
+                    self.assertEqual(checker.main([]), 1)
+                self.assertEqual(observed, [candidate_bytes])
+                for path, expected in before.items():
+                    self.assertEqual(path.read_bytes(), expected)
+                self.assertEqual(len(transaction_dirs), 1)
+                self.assertFalse(transaction_dirs[0].exists())
+                self.assertEqual(list(cache_dir.glob("run-*")), [])
+
     def test_written_malformed_cco_extension_fails_before_replacement(self) -> None:
         outputs = self.maintained_outputs()
         for name, path in outputs.items():
@@ -2197,6 +2667,7 @@ class ComsAuthorityMigrationTests(unittest.TestCase):
         strict_bytes = (
             REPO_ROOT / "releases/current-ssn-sosa/ssn-sosa-bfo-mapping.ttl"
         ).read_bytes()
+        projection_bytes = self.generated_bfo_projection_bytes()
         workbook_hash = disposition.input_hashes.workbook_sha256
         generator_hash = disposition.input_hashes.generator_sha256
 
@@ -2207,6 +2678,7 @@ class ComsAuthorityMigrationTests(unittest.TestCase):
             paths["disposition_report"].write_bytes(disposition_bytes)
             paths["alignment_core"].write_bytes(alignment_bytes)
             paths["strict_bfo_mapping"].write_bytes(strict_bytes)
+            paths["bfo_projection"].write_bytes(projection_bytes)
             malformed_cco = b"@prefix owl: <http://www.w3.org/2002/07/owl#> .\n[\n"
             paths["cco_extension"].write_bytes(malformed_cco)
             summary = {
@@ -2267,6 +2739,33 @@ class ComsAuthorityMigrationTests(unittest.TestCase):
                     "hermit_result": "PASS",
                     "closure_triple_count": 14972,
                     "named_unsat_count": 0,
+                },
+                "bfo_projection_sha256": checker.sha256_file(
+                    paths["bfo_projection"]
+                ),
+                "bfo_projection": {
+                    "product_key": "bfo_projection",
+                    "stable_ontology_iri": "http://www.sks.ai/SSN2BFO/current-ssn-sosa/bfo-projection",
+                    "governed_axiom_count": 0,
+                    "logical_triple_count": 0,
+                    "ontology_declaration_triple_count": 1,
+                    "import_triple_count": 1,
+                    "total_triple_count": 2,
+                    "provided_transitively_count": 29,
+                    "provided_through_import_count": 19,
+                    "deferred_no_transformation_rule_count": 57,
+                    "project_closure_governed_axiom_count": 48,
+                    "project_graph_triple_count": 183,
+                    "local_project_graph_triple_count": 181,
+                    "reasoning_reused_from": "strict_bfo_mapping",
+                    "reasoning_source_sha256": checker.sha256_file(
+                        paths["strict_bfo_mapping"]
+                    ),
+                    "reasoning_closure_triple_count": 14972,
+                    "reasoning_return_code": 0,
+                    "reasoned_output_produced": True,
+                    "named_unsat_count": 0,
+                    "projection_specific_hermit_invoked": False,
                 },
                 "cco_extension_sha256": checker.sha256_file(paths["cco_extension"]),
                 "cco_extension": {

--- a/tests/test_product_dispositions.py
+++ b/tests/test_product_dispositions.py
@@ -672,14 +672,30 @@ class ProductDispositionTests(unittest.TestCase):
                     code,
                 )
 
-    def test_disposition_build_does_not_require_unimplemented_bfo_projection_ttl(self) -> None:
+    def test_disposition_build_does_not_read_modular_ttl_mapping_authorities(self) -> None:
         products = {product.key: product for product in self.metadata.products}
-        self.assertTrue((REPO_ROOT / products["alignment_core"].path).is_file())
-        self.assertTrue((REPO_ROOT / products["strict_bfo_mapping"].path).is_file())
-        self.assertTrue((REPO_ROOT / products["cco_extension"].path).is_file())
-        self.assertFalse((REPO_ROOT / products["bfo_projection"].path).is_file())
+        modular_paths = {
+            (REPO_ROOT / products[key].path).resolve()
+            for key in (
+                "alignment_core",
+                "strict_bfo_mapping",
+                "bfo_projection",
+                "cco_extension",
+            )
+        }
+        original_open = Path.open
 
-        self.assertEqual(self.build(row_input()).summary.governed_row_count, 1)
+        def reject_modular_read(path: Path, *args, **kwargs):
+            if path.resolve() in modular_paths:
+                raise AssertionError(f"disposition construction read modular TTL {path}")
+            return original_open(path, *args, **kwargs)
+
+        with mock.patch.object(Path, "open", new=reject_modular_read):
+            document = self.build(row_input())
+
+        self.assertEqual(document.summary.governed_row_count, 1)
+        self.assertEqual(document.summary.authoritative_axiom_count, 1)
+        self.assertEqual(document.product_order, tuple(products))
 
 
 if __name__ == "__main__":

--- a/tools/check_coms_mapping.py
+++ b/tools/check_coms_mapping.py
@@ -61,6 +61,7 @@ MAINTAINED_OUTPUTS = {
     "disposition_report": REPO_ROOT / "reports/coms-product-dispositions.json",
     "alignment_core": REPO_ROOT / "releases/current-ssn-sosa/ssn-sosa-alignment-core.ttl",
     "strict_bfo_mapping": REPO_ROOT / "releases/current-ssn-sosa/ssn-sosa-bfo-mapping.ttl",
+    "bfo_projection": REPO_ROOT / "releases/current-ssn-sosa/ssn-sosa-bfo-projection.ttl",
     "cco_extension": REPO_ROOT / "releases/current-ssn-sosa/ssn-sosa-cco-extension.ttl",
 }
 
@@ -79,6 +80,8 @@ METADATA_LABELS = {
     "alignment-core Turtle SHA-256": "alignment_core_sha256",
     "maintained strict-BFO path": "strict_bfo_mapping_path",
     "strict-BFO Turtle SHA-256": "strict_bfo_mapping_sha256",
+    "maintained BFO-projection path": "bfo_projection_path",
+    "BFO-projection Turtle SHA-256": "bfo_projection_sha256",
     "maintained CCO-extension path": "cco_extension_path",
     "CCO-extension Turtle SHA-256": "cco_extension_sha256",
 }
@@ -180,6 +183,7 @@ def transaction_paths(transaction_dir: Path) -> dict[str, Path]:
         "disposition_report": transaction_dir / "reports/coms-product-dispositions.json",
         "alignment_core": transaction_dir / "releases/current-ssn-sosa/ssn-sosa-alignment-core.ttl",
         "strict_bfo_mapping": transaction_dir / "releases/current-ssn-sosa/ssn-sosa-bfo-mapping.ttl",
+        "bfo_projection": transaction_dir / "releases/current-ssn-sosa/ssn-sosa-bfo-projection.ttl",
         "cco_extension": transaction_dir / "releases/current-ssn-sosa/ssn-sosa-cco-extension.ttl",
         "summary": transaction_dir / "summary.json",
         "hermit": transaction_dir / "hermit",
@@ -203,6 +207,8 @@ def run_generator(paths: dict[str, Path], log: list[str]) -> None:
         str(paths["alignment_core"]),
         "--strict-bfo-output",
         str(paths["strict_bfo_mapping"]),
+        "--bfo-projection-output",
+        str(paths["bfo_projection"]),
         "--cco-extension-output",
         str(paths["cco_extension"]),
         "--coverage-report",
@@ -221,6 +227,8 @@ def run_generator(paths: dict[str, Path], log: list[str]) -> None:
         relative(MAINTAINED_OUTPUTS["alignment_core"]),
         "--report-strict-bfo-path",
         relative(MAINTAINED_OUTPUTS["strict_bfo_mapping"]),
+        "--report-bfo-projection-path",
+        relative(MAINTAINED_OUTPUTS["bfo_projection"]),
         "--report-cco-extension-path",
         relative(MAINTAINED_OUTPUTS["cco_extension"]),
         "--summary-json",
@@ -422,6 +430,73 @@ def validate_temporary_outputs(
         log,
     )
 
+    projection_path = paths["bfo_projection"]
+    projection_hash = sha256_file(projection_path)
+    projection_summary = summary.get("bfo_projection")
+    if not isinstance(projection_summary, dict):
+        raise CheckFailure("generator summary is missing BFO-projection results")
+    projection_metadata = next(
+        product
+        for product in publication_metadata.products
+        if product.key == "bfo_projection"
+    )
+    expected_projection = {
+        "product_key": "bfo_projection",
+        "stable_ontology_iri": projection_metadata.stable_ontology_iri,
+        "governed_axiom_count": 0,
+        "logical_triple_count": 0,
+        "ontology_declaration_triple_count": 1,
+        "import_triple_count": 1,
+        "total_triple_count": 2,
+        "provided_transitively_count": 29,
+        "provided_through_import_count": 19,
+        "deferred_no_transformation_rule_count": 57,
+        "project_closure_governed_axiom_count": 48,
+        "project_graph_triple_count": 183,
+        "local_project_graph_triple_count": 181,
+        "reasoning_reused_from": "strict_bfo_mapping",
+        "reasoning_source_sha256": strict_hash,
+        "reasoning_closure_triple_count": 14972,
+        "reasoning_return_code": 0,
+        "reasoned_output_produced": True,
+        "named_unsat_count": 0,
+        "projection_specific_hermit_invoked": False,
+    }
+    for field, expected in expected_projection.items():
+        if projection_summary.get(field) != expected:
+            raise CheckFailure(
+                f"BFO-projection summary mismatch for {field}: "
+                f"expected {expected!r}, got {projection_summary.get(field)!r}"
+            )
+    if summary.get("bfo_projection_sha256") != projection_hash:
+        raise CheckFailure("BFO-projection hash does not match generator summary")
+    projection_graph = Graph()
+    try:
+        projection_graph.parse(projection_path, format="turtle")
+    except Exception as exc:
+        raise CheckFailure(
+            f"BFO-projection parse failed: {type(exc).__name__}: {exc}"
+        ) from exc
+    projection_ontology_iri = URIRef(projection_metadata.stable_ontology_iri)
+    if set(projection_graph.subjects(RDF.type, OWL.Ontology)) != {
+        projection_ontology_iri
+    }:
+        raise CheckFailure("BFO projection has an incorrect ontology declaration")
+    if set(projection_graph.triples((None, OWL.imports, None))) != {
+        (projection_ontology_iri, OWL.imports, strict_ontology_iri)
+    }:
+        raise CheckFailure("BFO projection must import only the strict BFO mapping")
+    if len(projection_graph) != 2:
+        raise CheckFailure(
+            f"BFO-projection parsed triple count is {len(projection_graph)}, expected 2"
+        )
+    emit(
+        "BFO projection: PASS "
+        "(0 direct governed axioms; 0 logical triples; 2 total triples; "
+        "strict reasoning reused)",
+        log,
+    )
+
     cco_path = paths["cco_extension"]
     cco_hash = sha256_file(cco_path)
     cco_summary = summary.get("cco_extension")
@@ -555,6 +630,8 @@ def validate_temporary_outputs(
         "alignment_core_sha256": alignment_hash,
         "strict_bfo_mapping_path": relative(MAINTAINED_OUTPUTS["strict_bfo_mapping"]),
         "strict_bfo_mapping_sha256": strict_hash,
+        "bfo_projection_path": relative(MAINTAINED_OUTPUTS["bfo_projection"]),
+        "bfo_projection_sha256": projection_hash,
         "cco_extension_path": relative(MAINTAINED_OUTPUTS["cco_extension"]),
         "cco_extension_sha256": cco_hash,
     }
@@ -569,6 +646,7 @@ def validate_temporary_outputs(
         paths["diff_report"],
         paths["alignment_core"],
         paths["strict_bfo_mapping"],
+        paths["bfo_projection"],
         paths["cco_extension"],
     ):
         assert_no_trailing_whitespace(path)
@@ -645,6 +723,12 @@ def freshness_errors(workbook_hash: str, generator_hash: str) -> list[str]:
         errors.append("strict-BFO path differs from the generated report")
     if metadata.get("strict_bfo_mapping_sha256") != strict_hash:
         errors.append("strict-BFO hash differs from the generated report")
+    projection_path = MAINTAINED_OUTPUTS["bfo_projection"]
+    projection_hash = sha256_file(projection_path)
+    if metadata.get("bfo_projection_path") != relative(projection_path):
+        errors.append("BFO-projection path differs from the generated report")
+    if metadata.get("bfo_projection_sha256") != projection_hash:
+        errors.append("BFO-projection hash differs from the generated report")
     cco_path = MAINTAINED_OUTPUTS["cco_extension"]
     cco_hash = sha256_file(cco_path)
     if metadata.get("cco_extension_path") != relative(cco_path):
@@ -693,6 +777,7 @@ def output_differences(paths: dict[str, Path]) -> list[str]:
         "disposition_report",
         "alignment_core",
         "strict_bfo_mapping",
+        "bfo_projection",
         "cco_extension",
     ):
         current = MAINTAINED_OUTPUTS[name]
@@ -775,6 +860,9 @@ def record_success(summary: dict[str, object], workbook_hash: str, generator_has
         "strict_bfo_mapping_path": summary.get("strict_bfo_mapping_path"),
         "strict_bfo_mapping_sha256": summary.get("strict_bfo_mapping_sha256"),
         "strict_bfo_mapping": summary.get("strict_bfo_mapping"),
+        "bfo_projection_path": summary.get("bfo_projection_path"),
+        "bfo_projection_sha256": summary.get("bfo_projection_sha256"),
+        "bfo_projection": summary.get("bfo_projection"),
         "cco_extension_path": summary.get("cco_extension_path"),
         "cco_extension_sha256": summary.get("cco_extension_sha256"),
         "cco_extension": summary.get("cco_extension"),

--- a/tools/generate_mapping_from_coms.py
+++ b/tools/generate_mapping_from_coms.py
@@ -42,16 +42,22 @@ from product_dispositions import (
     validate_disposition_file,
 )
 from modular_products import (
+    BFO_PROJECTION_KEY,
+    ModularReasoningResult,
     ModularProductError,
     ModularProductResult,
+    ProductDispositionReconciliation,
     build_alignment_core,
+    build_bfo_projection,
     build_cco_extension,
     build_fixed_source_closure,
     build_fixed_validation_closure,
     build_strict_bfo_mapping,
+    reconcile_product_axioms,
     select_product_axioms,
     serialize_modular_product,
     validate_alignment_core,
+    validate_bfo_projection,
     validate_cco_extension,
     validate_strict_bfo_mapping,
 )
@@ -1670,6 +1676,72 @@ def build_and_write_strict_bfo_mapping(
     return result, hermit
 
 
+def build_and_write_bfo_projection(
+    processed_rows: list[ProcessedRow],
+    identity_audits: list[CanonicalRowAudit],
+    disposition_document: DispositionDocument,
+    integrated_graph: Graph,
+    alignment_core_result: ModularProductResult,
+    strict_bfo_result: ModularProductResult,
+    strict_bfo_hermit: HermitResult,
+    output_path: Path,
+) -> tuple[
+    ModularProductResult,
+    ProductDispositionReconciliation,
+    ModularReasoningResult,
+]:
+    """Build the import-only projection after exact disposition reconciliation."""
+
+    try:
+        metadata = load_metadata(PUBLICATION_METADATA)
+        canonical_rows = [canonical_input_for_processed_row(item) for item in processed_rows]
+        reconciliation = reconcile_product_axioms(
+            BFO_PROJECTION_KEY,
+            canonical_rows,
+            identity_audits,
+            disposition_document,
+        )
+        alignment_selected = tuple(
+            axiom
+            for row in alignment_core_result.selected_rows
+            for axiom in row.axioms
+        )
+        strict_selected = tuple(
+            axiom
+            for row in strict_bfo_result.selected_rows
+            for axiom in row.axioms
+        )
+        reasoning_result = ModularReasoningResult(
+            source_product_key="strict_bfo_mapping",
+            source_product_sha256=strict_bfo_result.sha256,
+            closure_triple_count=strict_bfo_hermit.closure_triple_count,
+            return_code=strict_bfo_hermit.return_code,
+            reasoned_output_produced=strict_bfo_hermit.reasoned_output_produced,
+            owl_nothing_count=strict_bfo_hermit.owl_nothing_count,
+            named_unsatisfiable_count=len(strict_bfo_hermit.unsat_classes),
+        )
+        result = build_bfo_projection(reconciliation.selected_axioms, metadata)
+        structural_issues = validate_bfo_projection(
+            result.serialized_bytes,
+            reconciliation,
+            strict_bfo_result.serialized_bytes,
+            strict_selected,
+            alignment_core_result.serialized_bytes,
+            alignment_selected,
+            metadata,
+            integrated_graph=integrated_graph,
+            strict_reasoning_result=reasoning_result,
+        )
+        if structural_issues:
+            raise ModularProductError(structural_issues)
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_bytes(serialize_modular_product(result))
+    except (ModularProductError, PublicationMetadataError) as exc:
+        output_path.unlink(missing_ok=True)
+        raise GenerationError(str(exc)) from exc
+    return result, reconciliation, reasoning_result
+
+
 def build_and_write_cco_extension(
     processed_rows: list[ProcessedRow],
     identity_audits: list[CanonicalRowAudit],
@@ -2184,6 +2256,11 @@ def write_generation_report(
     strict_bfo_path: Path | None = None,
     strict_bfo_sha256: str = "unavailable",
     strict_bfo_hermit: HermitResult | None = None,
+    bfo_projection_result: ModularProductResult | None = None,
+    bfo_projection_reconciliation: ProductDispositionReconciliation | None = None,
+    bfo_projection_path: Path | None = None,
+    bfo_projection_sha256: str = "unavailable",
+    bfo_projection_reasoning: ModularReasoningResult | None = None,
     cco_extension_result: ModularProductResult | None = None,
     cco_extension_path: Path | None = None,
     cco_extension_sha256: str = "unavailable",
@@ -2223,6 +2300,8 @@ def write_generation_report(
         f"| alignment-core Turtle SHA-256 | `{alignment_core_sha256}` |",
         f"| maintained strict-BFO path | `{strict_bfo_path or 'unavailable'}` |",
         f"| strict-BFO Turtle SHA-256 | `{strict_bfo_sha256}` |",
+        f"| maintained BFO-projection path | `{bfo_projection_path or 'unavailable'}` |",
+        f"| BFO-projection Turtle SHA-256 | `{bfo_projection_sha256}` |",
         f"| maintained CCO-extension path | `{cco_extension_path or 'unavailable'}` |",
         f"| CCO-extension Turtle SHA-256 | `{cco_extension_sha256}` |",
         "",
@@ -2390,6 +2469,55 @@ def write_generation_report(
             "- Full publication metadata and formal release identity remain deferred.",
         ]
 
+    if bfo_projection_result is None or bfo_projection_reconciliation is None:
+        bfo_projection_lines = [
+            "## BFO Projection",
+            "",
+            "- Generation and validation: unavailable",
+        ]
+    else:
+        totals = {
+            (value.target_category, value.status, value.reason_code): value.count
+            for value in bfo_projection_reconciliation.disposition_totals
+        }
+        bfo_projection_lines = [
+            "## BFO Projection",
+            "",
+            "This is the maintained authoritative development artifact at the approved production path; it is not a frozen formal release.",
+            "",
+            f"- Path: `{bfo_projection_path}`",
+            f"- Stable ontology IRI: `{bfo_projection_result.metadata.stable_ontology_iri}`",
+            f"- Direct governed projection axioms: {bfo_projection_result.governed_axiom_count}",
+            f"- Direct logical mapping triples: {bfo_projection_result.logical_triple_count}",
+            "- Ontology declaration triples: 1",
+            f"- Import triples: {bfo_projection_result.import_triple_count}",
+            f"- Total RDF triples: {bfo_projection_result.total_triple_count}",
+            "- Import: `http://www.sks.ai/SSN2BFO/current-ssn-sosa/bfo-mapping`",
+            f"- Target-neutral provided transitively: {totals.get(('target_neutral', 'provided_transitively', None), 0)}",
+            f"- BFO-bearing provided through import: {totals.get(('bfo_bearing', 'provided_through_import', None), 0)}",
+            f"- CCO-bearing deferred without transformation rule: {totals.get(('cco_bearing', 'deferred', 'NO_APPROVED_TRANSFORMATION_RULE'), 0)}",
+            f"- Mixed BFO/CCO deferred without transformation rule: {totals.get(('mixed_bfo_cco', 'deferred', 'NO_APPROVED_TRANSFORMATION_RULE'), 0)}",
+            "- Imported strict-BFO governed axioms: 19",
+            "- Transitively imported alignment-core governed axioms: 29",
+            "- Project-module closure governed axioms: 48",
+            "- Project graph triples retaining imports: 183",
+            "- Import-stripped local project graph triples: 181",
+            "- Strict/alignment-core governed overlap: 0",
+            "- CCO-extension governed axioms in projection closure: 0",
+            "- Direct graph and integrated-root/project-module reconciliation: PASS",
+            "- Deterministic serialization: PASS",
+            f"- Reused strict-BFO closure triple count: {'n/a' if bfo_projection_reasoning is None else bfo_projection_reasoning.closure_triple_count}",
+            f"- Reused strict-BFO HermiT return code: {'n/a' if bfo_projection_reasoning is None else bfo_projection_reasoning.return_code}",
+            f"- Reused strict-BFO reasoned output produced: {'no' if bfo_projection_reasoning is None else 'yes' if bfo_projection_reasoning.reasoned_output_produced else 'no'}",
+            f"- Reused strict-BFO named unsatisfiable classes: {'n/a' if bfo_projection_reasoning is None else bfo_projection_reasoning.named_unsatisfiable_count}",
+            "- Reasoning result: PASS (reused from the same-transaction strict-BFO pinned merged CCO/BFO validation closure after exact project-closure equivalence validation)",
+            "- Projection-specific HermiT invocation: none",
+            "- Zero direct projection axioms is intentional and complete for the current governed policy.",
+            "- No transformation rule, weakened consequence, or projected axiom is approved.",
+            "- Future direct projected axioms require governed transformation rules and proof obligations.",
+            "- Full publication metadata and formal release identity remain deferred.",
+        ]
+
     if cco_extension_result is None:
         cco_extension_lines = [
             "## CCO Extension",
@@ -2518,6 +2646,8 @@ def write_generation_report(
             *alignment_core_lines,
             "",
             *strict_bfo_lines,
+            "",
+            *bfo_projection_lines,
             "",
             *cco_extension_lines,
             "",
@@ -2724,6 +2854,11 @@ def write_summary_json(
     strict_bfo_path: Path | None = None,
     strict_bfo_sha256: str = "unavailable",
     strict_bfo_hermit: HermitResult | None = None,
+    bfo_projection_result: ModularProductResult | None = None,
+    bfo_projection_reconciliation: ProductDispositionReconciliation | None = None,
+    bfo_projection_path: Path | None = None,
+    bfo_projection_sha256: str = "unavailable",
+    bfo_projection_reasoning: ModularReasoningResult | None = None,
     cco_extension_result: ModularProductResult | None = None,
     cco_extension_path: Path | None = None,
     cco_extension_sha256: str = "unavailable",
@@ -2792,6 +2927,44 @@ def write_summary_json(
             "hermit_result": "FAIL" if strict_bfo_hermit is None else "PASS" if strict_bfo_hermit.passed else "FAIL",
             "closure_triple_count": None if strict_bfo_hermit is None else strict_bfo_hermit.closure_triple_count,
             "named_unsat_count": None if strict_bfo_hermit is None else len(strict_bfo_hermit.unsat_classes),
+        },
+        "bfo_projection_path": None if bfo_projection_path is None else str(bfo_projection_path),
+        "bfo_projection_sha256": bfo_projection_sha256,
+        "bfo_projection": None
+        if bfo_projection_result is None or bfo_projection_reconciliation is None
+        else {
+            "product_key": bfo_projection_result.metadata.product_key,
+            "stable_ontology_iri": bfo_projection_result.metadata.stable_ontology_iri,
+            "governed_axiom_count": bfo_projection_result.governed_axiom_count,
+            "logical_triple_count": bfo_projection_result.logical_triple_count,
+            "ontology_declaration_triple_count": 1,
+            "import_triple_count": bfo_projection_result.import_triple_count,
+            "total_triple_count": bfo_projection_result.total_triple_count,
+            "provided_transitively_count": 29,
+            "provided_through_import_count": 19,
+            "deferred_no_transformation_rule_count": 57,
+            "project_closure_governed_axiom_count": 48,
+            "project_graph_triple_count": 183,
+            "local_project_graph_triple_count": 181,
+            "reasoning_reused_from": None
+            if bfo_projection_reasoning is None
+            else bfo_projection_reasoning.source_product_key,
+            "reasoning_source_sha256": None
+            if bfo_projection_reasoning is None
+            else bfo_projection_reasoning.source_product_sha256,
+            "reasoning_closure_triple_count": None
+            if bfo_projection_reasoning is None
+            else bfo_projection_reasoning.closure_triple_count,
+            "reasoning_return_code": None
+            if bfo_projection_reasoning is None
+            else bfo_projection_reasoning.return_code,
+            "reasoned_output_produced": False
+            if bfo_projection_reasoning is None
+            else bfo_projection_reasoning.reasoned_output_produced,
+            "named_unsat_count": None
+            if bfo_projection_reasoning is None
+            else bfo_projection_reasoning.named_unsatisfiable_count,
+            "projection_specific_hermit_invoked": False,
         },
         "cco_extension_path": None if cco_extension_path is None else str(cco_extension_path),
         "cco_extension_sha256": cco_extension_sha256,
@@ -2935,6 +3108,11 @@ def main(argv: list[str] | None = None) -> int:
         help="Generated strict SSN/SOSA-to-BFO mapping Turtle path.",
     )
     parser.add_argument(
+        "--bfo-projection-output",
+        required=True,
+        help="Generated import-only SSN/SOSA BFO-projection Turtle path.",
+    )
+    parser.add_argument(
         "--cco-extension-output",
         required=True,
         help="Generated SSN/SOSA CCO-extension Turtle path.",
@@ -2975,6 +3153,10 @@ def main(argv: list[str] | None = None) -> int:
         help="Strict-BFO path displayed in reports. Defaults to the actual --strict-bfo-output path.",
     )
     parser.add_argument(
+        "--report-bfo-projection-path",
+        help="BFO-projection path displayed in reports. Defaults to the actual --bfo-projection-output path.",
+    )
+    parser.add_argument(
         "--report-cco-extension-path",
         help="CCO-extension path displayed in reports. Defaults to the actual --cco-extension-output path.",
     )
@@ -2991,6 +3173,7 @@ def main(argv: list[str] | None = None) -> int:
     disposition_report_path = REPO_ROOT / args.disposition_report if not Path(args.disposition_report).is_absolute() else Path(args.disposition_report)
     alignment_core_output_path = REPO_ROOT / args.alignment_core_output if not Path(args.alignment_core_output).is_absolute() else Path(args.alignment_core_output)
     strict_bfo_output_path = REPO_ROOT / args.strict_bfo_output if not Path(args.strict_bfo_output).is_absolute() else Path(args.strict_bfo_output)
+    bfo_projection_output_path = REPO_ROOT / args.bfo_projection_output if not Path(args.bfo_projection_output).is_absolute() else Path(args.bfo_projection_output)
     cco_extension_output_path = REPO_ROOT / args.cco_extension_output if not Path(args.cco_extension_output).is_absolute() else Path(args.cco_extension_output)
     coverage_report_path = REPO_ROOT / args.coverage_report if not Path(args.coverage_report).is_absolute() else Path(args.coverage_report)
     diff_report_path = REPO_ROOT / args.diff_report if not Path(args.diff_report).is_absolute() else Path(args.diff_report)
@@ -2999,6 +3182,7 @@ def main(argv: list[str] | None = None) -> int:
     report_disposition_path = Path(args.report_disposition_path) if args.report_disposition_path else disposition_report_path
     report_alignment_core_path = Path(args.report_alignment_core_path) if args.report_alignment_core_path else alignment_core_output_path
     report_strict_bfo_path = Path(args.report_strict_bfo_path) if args.report_strict_bfo_path else strict_bfo_output_path
+    report_bfo_projection_path = Path(args.report_bfo_projection_path) if args.report_bfo_projection_path else bfo_projection_output_path
     report_cco_extension_path = Path(args.report_cco_extension_path) if args.report_cco_extension_path else cco_extension_output_path
     summary_json_path = None
     if args.summary_json:
@@ -3014,6 +3198,7 @@ def main(argv: list[str] | None = None) -> int:
     disposition_sha256 = "unavailable"
     alignment_core_sha256 = "unavailable"
     strict_bfo_sha256 = "unavailable"
+    bfo_projection_sha256 = "unavailable"
     cco_extension_sha256 = "unavailable"
 
     stats = WorkbookStats()
@@ -3029,6 +3214,9 @@ def main(argv: list[str] | None = None) -> int:
     alignment_core_hermit: HermitResult | None = None
     strict_bfo_result: ModularProductResult | None = None
     strict_bfo_hermit: HermitResult | None = None
+    bfo_projection_result: ModularProductResult | None = None
+    bfo_projection_reconciliation: ProductDispositionReconciliation | None = None
+    bfo_projection_reasoning: ModularReasoningResult | None = None
     cco_extension_result: ModularProductResult | None = None
     cco_extension_hermit: HermitResult | None = None
 
@@ -3073,6 +3261,21 @@ def main(argv: list[str] | None = None) -> int:
             Path(args.tmp_dir) / "strict-bfo",
         )
         strict_bfo_sha256 = sha256_file(strict_bfo_output_path)
+        (
+            bfo_projection_result,
+            bfo_projection_reconciliation,
+            bfo_projection_reasoning,
+        ) = build_and_write_bfo_projection(
+            processed,
+            identity_audits,
+            disposition_document,
+            graph,
+            alignment_core_result,
+            strict_bfo_result,
+            strict_bfo_hermit,
+            bfo_projection_output_path,
+        )
+        bfo_projection_sha256 = sha256_file(bfo_projection_output_path)
         cco_extension_result, cco_extension_hermit = build_and_write_cco_extension(
             processed,
             identity_audits,
@@ -3133,6 +3336,11 @@ def main(argv: list[str] | None = None) -> int:
         strict_bfo_path=report_strict_bfo_path,
         strict_bfo_sha256=strict_bfo_sha256,
         strict_bfo_hermit=strict_bfo_hermit,
+        bfo_projection_result=bfo_projection_result,
+        bfo_projection_reconciliation=bfo_projection_reconciliation,
+        bfo_projection_path=report_bfo_projection_path,
+        bfo_projection_sha256=bfo_projection_sha256,
+        bfo_projection_reasoning=bfo_projection_reasoning,
         cco_extension_result=cco_extension_result,
         cco_extension_path=report_cco_extension_path,
         cco_extension_sha256=cco_extension_sha256,
@@ -3169,6 +3377,11 @@ def main(argv: list[str] | None = None) -> int:
             strict_bfo_path=report_strict_bfo_path,
             strict_bfo_sha256=strict_bfo_sha256,
             strict_bfo_hermit=strict_bfo_hermit,
+            bfo_projection_result=bfo_projection_result,
+            bfo_projection_reconciliation=bfo_projection_reconciliation,
+            bfo_projection_path=report_bfo_projection_path,
+            bfo_projection_sha256=bfo_projection_sha256,
+            bfo_projection_reasoning=bfo_projection_reasoning,
             cco_extension_result=cco_extension_result,
             cco_extension_path=report_cco_extension_path,
             cco_extension_sha256=cco_extension_sha256,
@@ -3188,6 +3401,8 @@ def main(argv: list[str] | None = None) -> int:
         print(f"Wrote {alignment_core_output_path}")
     if strict_bfo_output_path.exists():
         print(f"Wrote {strict_bfo_output_path}")
+    if bfo_projection_output_path.exists():
+        print(f"Wrote {bfo_projection_output_path}")
     if cco_extension_output_path.exists():
         print(f"Wrote {cco_extension_output_path}")
     print(f"Worksheets read: {', '.join(stats.worksheets_read) or 'none'}")
@@ -3229,6 +3444,13 @@ def main(argv: list[str] | None = None) -> int:
             "Strict-BFO pinned merged CCO/BFO closure HermiT: "
             f"{'PASS' if strict_bfo_hermit.passed else 'FAIL'}"
         )
+    if bfo_projection_result is not None:
+        print(f"BFO-projection governed axioms: {bfo_projection_result.governed_axiom_count}")
+        print(f"BFO-projection logical triples: {bfo_projection_result.logical_triple_count}")
+        print(f"BFO-projection total triples: {bfo_projection_result.total_triple_count}")
+        print(f"BFO-projection SHA-256: {bfo_projection_result.sha256}")
+    if bfo_projection_reasoning is not None:
+        print("BFO-projection strict-BFO reasoning reuse: PASS")
     if cco_extension_result is not None:
         print(f"CCO-extension governed axioms: {cco_extension_result.governed_axiom_count}")
         print(f"CCO-extension logical triples: {cco_extension_result.logical_triple_count}")

--- a/tools/modular_products.py
+++ b/tools/modular_products.py
@@ -128,12 +128,25 @@ CCO_EXTENSION_PREFIXES = (
     *STRICT_BFO_PREFIXES,
 )
 
+BFO_PROJECTION_KEY = "bfo_projection"
+BFO_PROJECTION_AXIOM_COUNT = 0
+BFO_PROJECTION_LOGICAL_TRIPLE_COUNT = 0
+BFO_PROJECTION_TOTAL_TRIPLE_COUNT = 2
+BFO_PROJECTION_PROJECT_CLOSURE_AXIOM_COUNT = 48
+BFO_PROJECTION_PROJECT_GRAPH_TRIPLE_COUNT = 183
+BFO_PROJECTION_LOCAL_PROJECT_GRAPH_TRIPLE_COUNT = 181
+BFO_PROJECTION_PREFIXES = (
+    ("owl", str(OWL)),
+    ("rdf", str(RDF)),
+)
+
 
 @dataclass(frozen=True)
 class ProductSelectionPolicy:
     categories: tuple[str, ...]
     expected_count: int
     expected_category_counts: tuple[tuple[str, int], ...]
+    expected_disposition_totals: tuple[tuple[str, str, str | None, int], ...]
 
 
 PRODUCT_SELECTION = {
@@ -141,11 +154,23 @@ PRODUCT_SELECTION = {
         ("target_neutral",),
         ALIGNMENT_CORE_AXIOM_COUNT,
         (("target_neutral", ALIGNMENT_CORE_AXIOM_COUNT),),
+        (
+            ("target_neutral", "emitted_unchanged", None, 29),
+            ("bfo_bearing", "not_applicable", "TARGET_SPECIFIC", 19),
+            ("cco_bearing", "not_applicable", "TARGET_SPECIFIC", 25),
+            ("mixed_bfo_cco", "not_applicable", "TARGET_SPECIFIC", 32),
+        ),
     ),
     STRICT_BFO_MAPPING_KEY: ProductSelectionPolicy(
         ("bfo_bearing",),
         STRICT_BFO_AXIOM_COUNT,
         (("bfo_bearing", STRICT_BFO_AXIOM_COUNT),),
+        (
+            ("target_neutral", "provided_through_import", None, 29),
+            ("bfo_bearing", "emitted_unchanged", None, 19),
+            ("cco_bearing", "deferred", "NO_APPROVED_TRANSFORMATION_RULE", 25),
+            ("mixed_bfo_cco", "deferred", "NO_APPROVED_TRANSFORMATION_RULE", 32),
+        ),
     ),
     CCO_EXTENSION_KEY: ProductSelectionPolicy(
         ("cco_bearing", "mixed_bfo_cco"),
@@ -153,6 +178,23 @@ PRODUCT_SELECTION = {
         (
             ("cco_bearing", CCO_EXTENSION_CCO_BEARING_COUNT),
             ("mixed_bfo_cco", CCO_EXTENSION_MIXED_COUNT),
+        ),
+        (
+            ("target_neutral", "provided_transitively", None, 29),
+            ("bfo_bearing", "provided_through_import", None, 19),
+            ("cco_bearing", "emitted_unchanged", None, 25),
+            ("mixed_bfo_cco", "emitted_unchanged", None, 32),
+        ),
+    ),
+    BFO_PROJECTION_KEY: ProductSelectionPolicy(
+        (),
+        BFO_PROJECTION_AXIOM_COUNT,
+        (),
+        (
+            ("target_neutral", "provided_transitively", None, 29),
+            ("bfo_bearing", "provided_through_import", None, 19),
+            ("cco_bearing", "deferred", "NO_APPROVED_TRANSFORMATION_RULE", 25),
+            ("mixed_bfo_cco", "deferred", "NO_APPROVED_TRANSFORMATION_RULE", 32),
         ),
     ),
 }
@@ -229,6 +271,33 @@ class SelectedProductRow:
     row_id: str
     location: RowLocation
     axioms: tuple[SelectedProductAxiom, ...]
+
+
+@dataclass(frozen=True)
+class ProductDispositionTotal:
+    target_category: str
+    status: str
+    reason_code: str | None
+    count: int
+
+
+@dataclass(frozen=True)
+class ProductDispositionReconciliation:
+    product_key: str
+    governed_axiom_count: int
+    selected_axioms: tuple[SelectedProductAxiom, ...]
+    disposition_totals: tuple[ProductDispositionTotal, ...]
+
+
+@dataclass(frozen=True)
+class ModularReasoningResult:
+    source_product_key: str
+    source_product_sha256: str
+    closure_triple_count: int
+    return_code: int | None
+    reasoned_output_produced: bool
+    owl_nothing_count: int | None
+    named_unsatisfiable_count: int
 
 
 @dataclass(frozen=True)
@@ -328,13 +397,13 @@ def _single_product_disposition(
     return matches[0]
 
 
-def select_product_axioms(
+def reconcile_product_axioms(
     product_key: str,
     processed_rows: Iterable[CanonicalRowInput],
     canonical_audits: Iterable[CanonicalRowAudit],
     disposition_document: DispositionDocument,
-) -> tuple[SelectedProductAxiom, ...]:
-    """Reconcile governed identities and select unchanged product axioms."""
+) -> ProductDispositionReconciliation:
+    """Reconcile every governed identity and derive a product selection."""
 
     issues: list[ModularProductValidationIssue] = []
     selection_policy = PRODUCT_SELECTION.get(product_key)
@@ -381,6 +450,7 @@ def select_product_axioms(
 
     selected: list[SelectedProductAxiom] = []
     seen_axioms: set[str] = set()
+    disposition_counts: dict[tuple[str, str, str | None], int] = {}
     for row_id in sorted(processed_ids & audit_ids & disposition_ids):
         canonical_input = processed_by_id[row_id]
         audit = audit_by_id[row_id]
@@ -510,6 +580,14 @@ def select_product_axioms(
                     )
                 )
                 continue
+            disposition_key = (
+                category,
+                product_disposition.status,
+                product_disposition.reason_code,
+            )
+            disposition_counts[disposition_key] = (
+                disposition_counts.get(disposition_key, 0) + 1
+            )
             if category not in selected_categories or product_disposition.status != "emitted_unchanged":
                 continue
             if axiom_id in seen_axioms:
@@ -555,9 +633,47 @@ def select_product_axioms(
                 f"expected category counts {expected_category_counts}, got {category_counts}",
             )
         )
+    expected_disposition_counts = {
+        (category, status, reason): count
+        for category, status, reason, count in selection_policy.expected_disposition_totals
+    }
+    if disposition_counts != expected_disposition_counts:
+        issues.append(
+            issue(
+                "PRODUCT_DISPOSITION_COUNT_MISMATCH",
+                f"expected disposition totals {expected_disposition_counts}, "
+                f"got {disposition_counts}",
+            )
+        )
     if issues:
         raise ModularProductError(issues)
-    return tuple(sorted(selected, key=lambda value: value.axiom_id))
+    selected_values = tuple(sorted(selected, key=lambda value: value.axiom_id))
+    totals = tuple(
+        ProductDispositionTotal(category, status, reason, count)
+        for category, status, reason, count in selection_policy.expected_disposition_totals
+    )
+    return ProductDispositionReconciliation(
+        product_key=product_key,
+        governed_axiom_count=sum(value.count for value in totals),
+        selected_axioms=selected_values,
+        disposition_totals=totals,
+    )
+
+
+def select_product_axioms(
+    product_key: str,
+    processed_rows: Iterable[CanonicalRowInput],
+    canonical_audits: Iterable[CanonicalRowAudit],
+    disposition_document: DispositionDocument,
+) -> tuple[SelectedProductAxiom, ...]:
+    """Compatibility wrapper returning directly emitted unchanged axioms."""
+
+    return reconcile_product_axioms(
+        product_key,
+        processed_rows,
+        canonical_audits,
+        disposition_document,
+    ).selected_axioms
 
 
 def _iri(value: str) -> str:
@@ -856,6 +972,53 @@ def build_strict_bfo_mapping(
         intersection_expression_count=intersections,
         existential_restriction_count=existentials,
         rdf_list_count=rdf_lists,
+        import_triple_count=1,
+        sha256=hashlib.sha256(serialized).hexdigest(),
+    )
+
+
+def build_bfo_projection(
+    selected_axioms: Iterable[SelectedProductAxiom],
+    publication_metadata: PublicationMetadata,
+) -> ModularProductResult:
+    selected = tuple(sorted(selected_axioms, key=lambda value: value.axiom_id))
+    metadata = _product_metadata(publication_metadata, BFO_PROJECTION_KEY)
+    if selected:
+        raise ModularProductError(
+            [
+                issue(
+                    "UNAPPROVED_PROJECTION_AXIOM",
+                    f"expected zero direct projection axioms, got {len(selected)}",
+                )
+            ]
+        )
+
+    serialized = _turtle_bytes(
+        metadata,
+        (),
+        imports=(STRICT_BFO_IMPORT_IRI,),
+        prefixes=BFO_PROJECTION_PREFIXES,
+    )
+    graph = Graph().parse(data=serialized.decode("utf-8"), format="turtle")
+    return ModularProductResult(
+        metadata=metadata,
+        selected_rows=(),
+        serialized_bytes=serialized,
+        governed_axiom_count=0,
+        logical_triple_count=0,
+        ontology_header_triple_count=2,
+        total_triple_count=len(graph),
+        domain_axiom_count=0,
+        range_axiom_count=0,
+        named_target_count=0,
+        union_target_count=0,
+        subclass_axiom_count=0,
+        equivalent_class_axiom_count=0,
+        direct_subproperty_axiom_count=0,
+        property_chain_axiom_count=0,
+        intersection_expression_count=0,
+        existential_restriction_count=0,
+        rdf_list_count=0,
         import_triple_count=1,
         sha256=hashlib.sha256(serialized).hexdigest(),
     )
@@ -1505,6 +1668,321 @@ def validate_strict_bfo_mapping(
                     "UNRESOLVED_BFO_IRI",
                     "BFO IRIs are absent from pinned validation closure: "
                     + ", ".join(unresolved),
+                )
+            )
+    return tuple(sorted(set(issues), key=lambda value: value.sort_key))
+
+
+def validate_bfo_projection(
+    serialized_bytes: bytes,
+    disposition_reconciliation: ProductDispositionReconciliation,
+    strict_bfo_bytes: bytes,
+    strict_selected_axioms: Iterable[SelectedProductAxiom],
+    alignment_core_bytes: bytes,
+    alignment_core_selected_axioms: Iterable[SelectedProductAxiom],
+    publication_metadata: PublicationMetadata,
+    integrated_graph: Graph | None = None,
+    strict_reasoning_result: ModularReasoningResult | None = None,
+) -> tuple[ModularProductValidationIssue, ...]:
+    strict_selected = tuple(
+        sorted(strict_selected_axioms, key=lambda value: value.axiom_id)
+    )
+    core_selected = tuple(
+        sorted(alignment_core_selected_axioms, key=lambda value: value.axiom_id)
+    )
+    metadata = _product_metadata(publication_metadata, BFO_PROJECTION_KEY)
+    issues: list[ModularProductValidationIssue] = []
+    try:
+        graph = Graph().parse(data=serialized_bytes.decode("utf-8"), format="turtle")
+    except Exception as exc:
+        return (issue("TURTLE_PARSE", f"cannot strictly parse UTF-8 Turtle: {exc}"),)
+
+    expected = build_bfo_projection((), publication_metadata)
+    if serialized_bytes != expected.serialized_bytes:
+        issues.append(
+            issue(
+                "NONDETERMINISTIC_SERIALIZATION",
+                "bytes differ from canonical BFO-projection serialization",
+            )
+        )
+
+    ontology_iri = URIRef(metadata.stable_ontology_iri)
+    expected_import = URIRef(STRICT_BFO_IMPORT_IRI)
+    expected_header = {
+        (ontology_iri, RDF.type, OWL.Ontology),
+        (ontology_iri, OWL.imports, expected_import),
+    }
+    declarations = set(graph.subjects(RDF.type, OWL.Ontology))
+    if declarations != {ontology_iri}:
+        issues.append(
+            issue(
+                "ONTOLOGY_DECLARATION_MISMATCH",
+                f"expected only {ontology_iri}, got {sorted(map(str, declarations))}",
+            )
+        )
+    imports = set(graph.triples((None, OWL.imports, None)))
+    expected_imports = {(ontology_iri, OWL.imports, expected_import)}
+    if imports != expected_imports:
+        issues.append(
+            issue(
+                "IMPORT_POLICY_MISMATCH",
+                f"expected only strict-BFO import, got {sorted(map(str, imports))}",
+            )
+        )
+    if len(graph) != BFO_PROJECTION_TOTAL_TRIPLE_COUNT:
+        issues.append(
+            issue(
+                "TOTAL_TRIPLE_COUNT_MISMATCH",
+                f"expected {BFO_PROJECTION_TOTAL_TRIPLE_COUNT}, got {len(graph)}",
+            )
+        )
+    logical_graph = Graph()
+    for triple in graph:
+        if triple not in expected_header:
+            logical_graph.add(triple)
+    if len(logical_graph) != BFO_PROJECTION_LOGICAL_TRIPLE_COUNT:
+        issues.append(
+            issue(
+                "LOGICAL_TRIPLE_COUNT_MISMATCH",
+                f"expected zero direct logical triples, got {len(logical_graph)}",
+            )
+        )
+    projection_axioms = _canonical_graph_axioms(graph)
+    if projection_axioms:
+        issues.append(
+            issue(
+                "UNAPPROVED_PROJECTION_AXIOM",
+                "BFO projection contains direct governed or transformed axioms: "
+                + ", ".join(sorted(projection_axioms)),
+            )
+        )
+    if any(isinstance(value, BNode) for value in graph.all_nodes()):
+        issues.append(issue("UNEXPECTED_BLANK_NODE", "BFO projection must not contain blank nodes"))
+    if any(True for _ in graph.triples((None, RDF.first, None))) or any(
+        True for _ in graph.triples((None, RDF.rest, None))
+    ):
+        issues.append(issue("UNEXPECTED_RDF_LIST", "BFO projection must not contain RDF lists"))
+    allowed_direct_iris = {
+        str(ontology_iri),
+        str(expected_import),
+        str(RDF.type),
+        str(OWL.Ontology),
+        str(OWL.imports),
+    }
+    unexpected_direct_iris = sorted(
+        {
+            str(value)
+            for value in graph.all_nodes()
+            if isinstance(value, URIRef) and str(value) not in allowed_direct_iris
+        }
+    )
+    if unexpected_direct_iris:
+        issues.append(
+            issue(
+                "UNEXPECTED_LOGICAL_VOCABULARY",
+                "projection graph contains unapproved IRIs: "
+                + ", ".join(unexpected_direct_iris),
+            )
+        )
+    declaration_triples = set(graph.triples((None, RDF.type, None)))
+    if declaration_triples != {(ontology_iri, RDF.type, OWL.Ontology)}:
+        issues.append(
+            issue(
+                "COPIED_DECLARATION",
+                "projection graph contains a declaration other than its ontology declaration",
+            )
+        )
+    if any(True for _ in graph.triples((None, RDF.type, OWL.Axiom))):
+        issues.append(
+            issue("ANNOTATION_ONLY_PSEUDO_MAPPING", "owl:Axiom records are prohibited")
+        )
+
+    expected_totals = tuple(
+        ProductDispositionTotal(category, status, reason, count)
+        for category, status, reason, count in PRODUCT_SELECTION[
+            BFO_PROJECTION_KEY
+        ].expected_disposition_totals
+    )
+    if disposition_reconciliation.product_key != BFO_PROJECTION_KEY:
+        issues.append(
+            issue(
+                "PRODUCT_RECONCILIATION_MISMATCH",
+                f"expected {BFO_PROJECTION_KEY!r}, got "
+                f"{disposition_reconciliation.product_key!r}",
+            )
+        )
+    if disposition_reconciliation.governed_axiom_count != 105:
+        issues.append(
+            issue(
+                "PRODUCT_RECONCILIATION_MISMATCH",
+                f"expected 105 governed axioms, got "
+                f"{disposition_reconciliation.governed_axiom_count}",
+            )
+        )
+    if disposition_reconciliation.selected_axioms:
+        issues.append(
+            issue(
+                "UNAPPROVED_PROJECTION_AXIOM",
+                f"expected zero selected projection axioms, got "
+                f"{len(disposition_reconciliation.selected_axioms)}",
+            )
+        )
+    if disposition_reconciliation.disposition_totals != expected_totals:
+        issues.append(
+            issue(
+                "PRODUCT_DISPOSITION_COUNT_MISMATCH",
+                f"expected {expected_totals}, got "
+                f"{disposition_reconciliation.disposition_totals}",
+            )
+        )
+
+    try:
+        issues.extend(
+            validate_strict_bfo_mapping(
+                strict_bfo_bytes,
+                strict_selected,
+                alignment_core_bytes,
+                core_selected,
+                publication_metadata,
+                integrated_graph=integrated_graph,
+            )
+        )
+    except ModularProductError as exc:
+        issues.extend(exc.issues)
+
+    try:
+        strict_graph = Graph().parse(
+            data=strict_bfo_bytes.decode("utf-8"), format="turtle"
+        )
+    except Exception as exc:
+        issues.append(issue("STRICT_BFO_PARSE", f"cannot parse strict BFO mapping: {exc}"))
+        strict_graph = Graph()
+    try:
+        core_graph = Graph().parse(
+            data=alignment_core_bytes.decode("utf-8"), format="turtle"
+        )
+    except Exception as exc:
+        issues.append(issue("ALIGNMENT_CORE_PARSE", f"cannot parse alignment core: {exc}"))
+        core_graph = Graph()
+
+    strict_axioms = _canonical_graph_axioms(strict_graph) if len(strict_graph) else {}
+    core_axioms = _canonical_graph_axioms(core_graph) if len(core_graph) else {}
+    strict_selected_ids = {value.axiom_id for value in strict_selected}
+    core_selected_ids = {value.axiom_id for value in core_selected}
+    overlap = set(strict_axioms) & set(core_axioms)
+    if overlap:
+        issues.append(
+            issue(
+                "DIRECT_CORE_AXIOM_OVERLAP",
+                "strict and alignment-core direct graphs overlap: "
+                + ", ".join(sorted(overlap)),
+            )
+        )
+    expected_closure_ids = strict_selected_ids | core_selected_ids
+    actual_closure_ids = set(strict_axioms) | set(core_axioms)
+    if actual_closure_ids != expected_closure_ids:
+        issues.append(
+            issue(
+                "PROJECT_CLOSURE_AXIOM_MISMATCH",
+                "projection closure does not equal the selected strict/core axiom set",
+            )
+        )
+    if len(actual_closure_ids) != BFO_PROJECTION_PROJECT_CLOSURE_AXIOM_COUNT:
+        issues.append(
+            issue(
+                "PROJECT_CLOSURE_COUNT_MISMATCH",
+                f"expected {BFO_PROJECTION_PROJECT_CLOSURE_AXIOM_COUNT}, "
+                f"got {len(actual_closure_ids)}",
+            )
+        )
+
+    project_graph = Graph()
+    for source_graph in (graph, strict_graph, core_graph):
+        for triple in source_graph:
+            project_graph.add(triple)
+    if len(project_graph) != BFO_PROJECTION_PROJECT_GRAPH_TRIPLE_COUNT:
+        issues.append(
+            issue(
+                "PROJECT_GRAPH_TRIPLE_COUNT_MISMATCH",
+                f"expected {BFO_PROJECTION_PROJECT_GRAPH_TRIPLE_COUNT}, "
+                f"got {len(project_graph)}",
+            )
+        )
+    cco_iris = sorted(
+        {
+            str(value)
+            for value in project_graph.all_nodes()
+            if isinstance(value, URIRef) and str(value).startswith(CCO_NAMESPACE)
+        }
+    )
+    if cco_iris:
+        issues.append(
+            issue(
+                "PROHIBITED_LOGICAL_VOCABULARY",
+                "projection project closure contains CCO IRIs: " + ", ".join(cco_iris),
+            )
+        )
+    for triple in list(project_graph.triples((None, OWL.imports, None))):
+        project_graph.remove(triple)
+    if len(project_graph) != BFO_PROJECTION_LOCAL_PROJECT_GRAPH_TRIPLE_COUNT:
+        issues.append(
+            issue(
+                "LOCAL_PROJECT_GRAPH_TRIPLE_COUNT_MISMATCH",
+                f"expected {BFO_PROJECTION_LOCAL_PROJECT_GRAPH_TRIPLE_COUNT}, "
+                f"got {len(project_graph)}",
+            )
+        )
+
+    strict_sha256 = hashlib.sha256(strict_bfo_bytes).hexdigest()
+    if strict_reasoning_result is None:
+        issues.append(
+            issue(
+                "STRICT_REASONING_RESULT_MISSING",
+                "same-transaction strict-BFO reasoning result is required",
+            )
+        )
+    else:
+        if strict_reasoning_result.source_product_key != STRICT_BFO_MAPPING_KEY:
+            issues.append(
+                issue(
+                    "STRICT_REASONING_RESULT_MISMATCH",
+                    f"unexpected reasoning source "
+                    f"{strict_reasoning_result.source_product_key!r}",
+                )
+            )
+        if strict_reasoning_result.source_product_sha256 != strict_sha256:
+            issues.append(
+                issue(
+                    "STRICT_REASONING_RESULT_MISMATCH",
+                    "strict reasoning result does not belong to supplied strict bytes",
+                )
+            )
+        if strict_reasoning_result.closure_triple_count != STRICT_BFO_FIXED_CLOSURE_TRIPLE_COUNT:
+            issues.append(
+                issue(
+                    "STRICT_REASONING_RESULT_MISMATCH",
+                    f"expected strict closure count {STRICT_BFO_FIXED_CLOSURE_TRIPLE_COUNT}, "
+                    f"got {strict_reasoning_result.closure_triple_count}",
+                )
+            )
+        if strict_reasoning_result.return_code != 0:
+            issues.append(issue("STRICT_REASONING_FAILED", "strict HermiT return code is not zero"))
+        if not strict_reasoning_result.reasoned_output_produced:
+            issues.append(issue("STRICT_REASONING_FAILED", "strict reasoned output was not produced"))
+        if strict_reasoning_result.owl_nothing_count != 0:
+            issues.append(
+                issue(
+                    "STRICT_REASONING_FAILED",
+                    f"strict owl:Nothing-derived named-class count is "
+                    f"{strict_reasoning_result.owl_nothing_count}",
+                )
+            )
+        if strict_reasoning_result.named_unsatisfiable_count != 0:
+            issues.append(
+                issue(
+                    "STRICT_REASONING_FAILED",
+                    f"strict named-unsatisfiable count is "
+                    f"{strict_reasoning_result.named_unsatisfiable_count}",
                 )
             )
     return tuple(sorted(set(issues), key=lambda value: value.sort_key))

--- a/tools/run_validation_suite.py
+++ b/tools/run_validation_suite.py
@@ -72,6 +72,7 @@ def compile_check() -> StepResult:
             "tests/test_modular_products.py",
             "tests/test_strict_bfo_mapping.py",
             "tests/test_cco_extension.py",
+            "tests/test_bfo_projection.py",
             "tests/test_publication_metadata.py",
         ],
     )
@@ -204,6 +205,22 @@ def main() -> int:
                     "tests",
                     "-p",
                     "test_cco_extension.py",
+                ],
+            )
+        )
+    if results[-1].passed:
+        results.append(
+            run_command(
+                "BFO-projection modular-product focused tests",
+                [
+                    sys.executable,
+                    "-m",
+                    "unittest",
+                    "discover",
+                    "-s",
+                    "tests",
+                    "-p",
+                    "test_bfo_projection.py",
                 ],
             )
         )

--- a/tools/watch_coms_mapping.py
+++ b/tools/watch_coms_mapping.py
@@ -25,6 +25,7 @@ MAINTAINED_OUTPUTS = (
     REPO_ROOT / "reports/coms-product-dispositions.json",
     REPO_ROOT / "releases/current-ssn-sosa/ssn-sosa-alignment-core.ttl",
     REPO_ROOT / "releases/current-ssn-sosa/ssn-sosa-bfo-mapping.ttl",
+    REPO_ROOT / "releases/current-ssn-sosa/ssn-sosa-bfo-projection.ttl",
     REPO_ROOT / "releases/current-ssn-sosa/ssn-sosa-cco-extension.ttl",
 )
 POLL_SECONDS = 1.0

--- a/tools/workflow_check.py
+++ b/tools/workflow_check.py
@@ -36,6 +36,7 @@ COMPILE_COMMAND = [
     "tests/test_modular_products.py",
     "tests/test_strict_bfo_mapping.py",
     "tests/test_cco_extension.py",
+    "tests/test_bfo_projection.py",
     "tests/test_publication_metadata.py",
     "tools/workflow_check.py",
 ]
@@ -196,6 +197,7 @@ def mapping_change_scope(state: WorkflowState) -> None:
         "reports/coms-product-dispositions.json",
         "releases/current-ssn-sosa/ssn-sosa-alignment-core.ttl",
         "releases/current-ssn-sosa/ssn-sosa-bfo-mapping.ttl",
+        "releases/current-ssn-sosa/ssn-sosa-bfo-projection.ttl",
         "releases/current-ssn-sosa/ssn-sosa-cco-extension.ttl",
     }
     unexpected = [


### PR DESCRIPTION
# Generate BFO projection

## Changed files

- Makefile
- README.md
- releases/current-ssn-sosa/ssn-sosa-bfo-projection.ttl
- reports/coms-automatic-validation-setup.md
- reports/coms-generation-validation.md
- reports/coms-product-dispositions.json
- tests/test_bfo_projection.py
- tests/test_generate_mapping_from_coms.py
- tests/test_product_dispositions.py
- tools/check_coms_mapping.py
- tools/generate_mapping_from_coms.py
- tools/modular_products.py
- tools/run_validation_suite.py
- tools/watch_coms_mapping.py
- tools/workflow_check.py

## Validation

- Human gate required: confirm validation output before merge.
