### PR TITLE
Emit deterministic publication metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,25 +43,25 @@ The artifact classifies axioms as target-neutral, BFO-bearing, CCO-bearing, or m
 
 `releases/current-ssn-sosa/ssn-sosa-alignment-core.ttl` is the maintained authoritative development artifact for the 29 target-neutral governed COMS axioms. It is generated from the same in-memory COMS identities and product dispositions as the integrated root, contains 15 domain and 14 range axioms, and imports no source, target, or project ontology. The integrated `SSN2BFO.ttl` remains the complete standalone authoritative product; the alignment core does not replace it.
 
-The development artifact currently has only its governed stable ontology IRI and ontology declaration. Schema-2 publication values are governed and validated, while their RDF emission and formal release identity remain deferred. Run its focused tests and the shared nonmutating transaction with `make check-alignment-core`.
+Like every maintained ontology product, the development artifact emits the seven governed schema-2 annotations for label, description, product type, development authority status, CC0 license, repository reference, and generated-file warning. Formal-release identity remains deferred. Run its focused tests and the shared nonmutating transaction with `make check-alignment-core`.
 
 ### Strict BFO mapping
 
 `releases/current-ssn-sosa/ssn-sosa-bfo-mapping.ttl` is the maintained authoritative development artifact for the 19 unchanged BFO-bearing governed COMS axioms. It imports only the alignment core, so the locally resolved project-module closure contains 48 governed axioms: 19 direct strict-BFO axioms plus 29 target-neutral core axioms. The 57 CCO-bearing or mixed mappings remain explicitly deferred because no transformation or weakened projection is approved.
 
-The published strict graph contains no CCO or RO logical terms and does not import an external ontology. Validation reasons over an explicit, network-free pinned merged CCO/BFO closure that includes `imports/cco.ttl`; this validation dependency does not make CCO part of the published strict graph and is not mapping authority. Publication-metadata RDF emission, formal release identity, and transformation rules remain deferred. The old `releases/current-ssn-sosa/ssn-sosa-bfo-directmappings.ttl` file remains inactive, non-authoritative scaffolding pending complete modular-product migration. Run `make check-strict-bfo-mapping` for the focused tests and shared nonmutating transaction.
+The published strict graph contains no CCO or RO logical terms and does not import an external ontology. Validation reasons over an explicit, network-free pinned merged CCO/BFO closure that includes `imports/cco.ttl`; this validation dependency does not make CCO part of the published strict graph and is not mapping authority. The graph emits the seven governed development annotations; formal release identity and transformation rules remain deferred. The old `releases/current-ssn-sosa/ssn-sosa-bfo-directmappings.ttl` file remains inactive, non-authoritative scaffolding pending complete modular-product migration. Run `make check-strict-bfo-mapping` for the focused tests and shared nonmutating transaction.
 
 ### BFO projection
 
 `releases/current-ssn-sosa/ssn-sosa-bfo-projection.ttl` is a maintained authoritative development artifact that imports only the strict BFO mapping. It intentionally asserts zero direct projection axioms because no CCO-to-BFO transformation or weakened-consequence rule is approved. Its locally resolved project-module closure is therefore exactly the 48 governed axioms already provided by strict BFO and the alignment core: 19 through import and 29 transitively.
 
-The direct two-triple graph contains only its ontology declaration and strict-BFO import. It contains no source, BFO, CCO, or RO logical mapping content and is not an incomplete serialization. The BFO projection is the designated product for approved weaker but sound BFO consequences, but no direct projection axiom is currently approved. The generator reconciles all 105 product dispositions, leaving 25 CCO-bearing and 32 mixed axioms explicitly deferred, then reuses the same-transaction strict-BFO pinned merged CCO/BFO reasoning result only after proving exact closure equivalence. Future direct projection axioms require governed transformation rules and proof obligations. Publication-metadata RDF emission and formal release identity remain deferred. Run `make check-bfo-projection` for the focused tests and shared nonmutating nine-output transaction.
+The direct nine-triple graph contains one ontology declaration, one strict-BFO import, and the seven governed development annotations; it contains zero logical mapping triples. It contains no source, BFO, CCO, or RO logical mapping content and is not an incomplete serialization. The BFO projection is the designated product for approved weaker but sound BFO consequences, but no direct projection axiom is currently approved. The generator reconciles all 105 product dispositions, leaving 25 CCO-bearing and 32 mixed axioms explicitly deferred, then reuses the same-transaction strict-BFO pinned merged CCO/BFO reasoning result only after proving exact closure equivalence. Future direct projection axioms require governed transformation rules and proof obligations. Formal release identity remains deferred. Run `make check-bfo-projection` for the focused tests and shared nonmutating nine-output transaction.
 
 ### CCO extension
 
 `releases/current-ssn-sosa/ssn-sosa-cco-extension.ttl` is the maintained authoritative development artifact for 57 unchanged governed COMS axioms: 25 CCO-bearing and 32 mixed BFO/CCO axioms. It imports only the strict BFO mapping, whose alignment-core import completes a 105-axiom project-module closure without directly duplicating either imported layer.
 
-The published extension contains no RO terms, transformed mappings, weakened projections, or copied dependency declarations. Its fixed semantic validation uses the explicitly listed local source ontologies and the pinned merged CCO/BFO dependency `imports/cco.ttl`; neither CCO nor BFO is imported by the published extension. Publication-metadata RDF emission, formal release identity, and transformation rules remain deferred. The old `releases/current-ssn-sosa/ssn-sosa-cco-directmappings.ttl` file remains inactive, non-authoritative scaffolding pending complete modular-product migration. Run `make check-cco-extension` for the focused tests and shared nonmutating transaction.
+The published extension contains no RO terms, transformed mappings, weakened projections, or copied dependency declarations. Its fixed semantic validation uses the explicitly listed local source ontologies and the pinned merged CCO/BFO dependency `imports/cco.ttl`; neither CCO nor BFO is imported by the published extension. The graph emits the seven governed development annotations; formal release identity and transformation rules remain deferred. The old `releases/current-ssn-sosa/ssn-sosa-cco-directmappings.ttl` file remains inactive, non-authoritative scaffolding pending complete modular-product migration. Run `make check-cco-extension` for the focused tests and shared nonmutating transaction.
 
 ## Validation environment
 
@@ -87,7 +87,7 @@ make check
 
 ### Publication metadata validation
 
-`config/publication-metadata.toml` is the sole editable publication-metadata source. Schema version 2 governs the five product paths, stable ontology IRIs, release suffixes, English labels, lifecycle-neutral descriptions, CC0 license IRI, repository IRI, product-type IRIs, development authority status, and generated-file warning. These exact values are validated now; their RDF emission belongs to the next implementation PR, so this change does not alter metadata in any maintained TTL file.
+`config/publication-metadata.toml` is the sole editable publication-metadata source. Schema version 2 governs the five product paths, stable ontology IRIs, release suffixes, English labels, lifecycle-neutral descriptions, CC0 license IRI, repository IRI, product-type IRIs, development authority status, and generated-file warning. Every maintained ontology deterministically emits exactly seven annotations in this order: `rdfs:label`, `dcterms:description`, `dcterms:type`, `adms:status`, `dcterms:license`, `rdfs:seeAlso`, and `rdfs:comment`. Labels, descriptions, and warnings use `@en`; the remaining values are IRIs.
 
 Run the focused tests and development-mode validation with:
 
@@ -96,7 +96,7 @@ make check-publication-metadata
 python tools/check_publication_metadata.py
 ```
 
-Development mode validates the governed static values and does not claim immutable release version IRIs. Creator and contributor records, provenance, dependency RDF, release dates, Git and commit bindings, artifact hashes, and other formal-release fields remain deferred. Validate the existing pure release-IRI construction helpers with an explicit formal-release context using:
+Development mode validates and emits the governed static annotations without claiming immutable release version IRIs. Creator and contributor records, provenance, dependency RDF, release dates, Git and commit bindings, artifact hashes, and other formal-release fields remain deferred. Validate the existing pure release-IRI construction helpers with an explicit formal-release context using:
 
 ```bash
 python tools/check_publication_metadata.py \
@@ -105,7 +105,7 @@ python tools/check_publication_metadata.py \
   --git-tag v2026-07-14
 ```
 
-Formal release version IRIs are derived from the configured release base, supplied release identifier, and each product's release suffix. This validator does not inspect Git tags or tag-to-commit binding, emit ontology metadata, create release manifests, compare cross-artifact hashes, or prove that a version IRI has never identified different bytes.
+Formal release version IRIs are derived from the configured release base, supplied release identifier, and each product's release suffix. The metadata checker does not write ontologies, inspect Git tags or tag-to-commit binding, create release manifests, compare cross-artifact hashes, or prove that a version IRI has never identified different bytes; ontology emission occurs only inside the shared COMS transaction.
 
 The four new release files under `releases/` are placeholders until completed mapping content is inserted:
 

--- a/SSN2BFO.ttl
+++ b/SSN2BFO.ttl
@@ -1,5 +1,7 @@
 # GENERATED FILE: produced from mappings/SSN2BFO-COMS.xlsx; do not edit SSN2BFO.ttl directly.
 
+@prefix adms: <http://www.w3.org/ns/adms#> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
 @prefix bfo: <http://purl.obolibrary.org/obo/> .
 @prefix cco: <https://www.commoncoreontologies.org/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
@@ -11,513 +13,1231 @@
 @prefix ssn-system: <http://www.w3.org/ns/ssn/systems/> .
 
 <http://www.sks.ai/SSN2BFO/> a owl:Ontology ;
+    rdfs:label "SSN-to-BFO Integrated Mapping"@en ;
+    dcterms:description "Directly asserts the complete governed COMS axiom set for the SSN/SOSA alignment with BFO and CCO."@en ;
+    dcterms:type <http://www.sks.ai/SSN2BFO/product-type/integrated> ;
+    adms:status <http://www.sks.ai/SSN2BFO/authority-status/maintained-authoritative-development> ;
+    dcterms:license <https://creativecommons.org/publicdomain/zero/1.0/> ;
+    rdfs:seeAlso <https://github.com/BFO-Mappings/SSN-to-BFO> ;
+    rdfs:comment "Generated from governed COMS and publication metadata; do not edit this ontology directly."@en ;
     owl:imports sampling:,
         ssn:,
         ssn-system:,
         <https://www.commoncoreontologies.org/2024-11-06/CommonCoreOntologiesMerged> .
 
-sosa:Platform owl:equivalentClass [ a owl:Class ;
-            owl:intersectionOf ( bfo:BFO_0000040 [ a owl:Restriction ;
-                        owl:onProperty sosa:hosts ;
-                        owl:someValuesFrom ssn:System ] ) ] .
-
-sosa:Result owl:equivalentClass [ a owl:Class ;
-            owl:intersectionOf ( [ a owl:Class ;
-                        owl:unionOf ( cco:ont00000958 bfo:BFO_0000040 ) ] [ a owl:Restriction ;
-                        owl:onProperty cco:ont00001816 ;
-                        owl:someValuesFrom [ a owl:Class ;
-                                owl:unionOf ( sosa:Observation sosa:Actuation sosa:Sampling ) ] ] ) ] .
-
-sosa:Sampler owl:equivalentClass [ a owl:Class ;
-            owl:intersectionOf ( bfo:BFO_0000040 [ a owl:Restriction ;
-                        owl:onProperty bfo:BFO_0000196 ;
-                        owl:someValuesFrom [ a owl:Class ;
-                                owl:intersectionOf ( bfo:BFO_0000017 [ a owl:Restriction ;
-                                            owl:onProperty bfo:BFO_0000054 ;
-                                            owl:someValuesFrom sosa:Sampling ] ) ] ] [ a owl:Restriction ;
-                        owl:onProperty cco:ont00001787 ;
-                        owl:someValuesFrom sosa:Sampling ] ) ] .
-
-sosa:hasFeatureOfInterest rdfs:domain [ a owl:Class ;
-            owl:unionOf ( sosa:Observation sosa:Actuation sosa:Sampling ) ] ;
-    rdfs:range sosa:FeatureOfInterest .
-
-sosa:hasResult rdfs:subPropertyOf cco:ont00001986 .
-
-sosa:hasSample owl:propertyChainAxiom ( cco:ont00001873 bfo:BFO_0000084 ) .
-
-sosa:isActedOnBy rdfs:subPropertyOf cco:ont00001886 .
-
-sosa:isFeatureOfInterestOf rdfs:domain sosa:FeatureOfInterest ;
-    rdfs:range [ a owl:Class ;
-            owl:unionOf ( sosa:Observation sosa:Actuation sosa:Sampling ) ] .
-
-sosa:isHostedBy owl:propertyChainAxiom ( bfo:BFO_0000056 bfo:BFO_0000055 bfo:BFO_0000197 ) .
-
-sosa:isObservedBy rdfs:domain sosa:ObservableProperty ;
-    rdfs:range sosa:Sensor .
-
-sosa:isResultOf rdfs:subPropertyOf cco:ont00001816 .
-
-sosa:isSampleOf owl:propertyChainAxiom ( bfo:BFO_0000101 cco:ont00001938 ) .
-
-sosa:madeActuation rdfs:domain sosa:Actuator ;
-    rdfs:range sosa:Actuation .
-
-sosa:madeByActuator rdfs:domain sosa:Actuation ;
-    rdfs:range sosa:Actuator .
-
-sosa:madeBySampler rdfs:subPropertyOf cco:ont00001833 .
-
-sosa:madeBySensor rdfs:domain sosa:Observation ;
-    rdfs:range sosa:Sensor .
-
-sosa:madeObservation rdfs:domain sosa:Sensor ;
-    rdfs:range sosa:Observation .
-
-sosa:madeSampling rdfs:subPropertyOf cco:ont00001787 .
-
-sosa:observedProperty rdfs:subPropertyOf cco:ont00001921 .
-
-sosa:observes rdfs:domain sosa:Sensor ;
-    rdfs:range sosa:ObservableProperty .
-
-sosa:phenomenonTime rdfs:subPropertyOf bfo:BFO_0000199 .
-
-sampling:RelationshipNature rdfs:subClassOf cco:ont00000958 .
-
-sampling:SampleRelationship rdfs:subClassOf cco:ont00000958 .
-
-sampling:hasSampleRelationship rdfs:subPropertyOf cco:ont00001801 .
-
-sampling:natureOfRelationship rdfs:subPropertyOf cco:ont00001808 .
-
-sampling:relatedSample rdfs:subPropertyOf cco:ont00001808 .
-
-sosa:usedProcedure rdfs:subPropertyOf cco:ont00001920 .
-
-ssn:Deployment owl:equivalentClass [ a owl:Class ;
-            owl:intersectionOf ( cco:ont00000228 [ a owl:Restriction ;
-                        owl:onProperty ssn:deployedSystem ;
-                        owl:someValuesFrom ssn:System ] [ a owl:Restriction ;
-                        owl:onProperty ssn:deployedOnPlatform ;
-                        owl:someValuesFrom bfo:BFO_0000040 ] ) ] .
-
-ssn:detects rdfs:subPropertyOf cco:ont00001886 .
-
-ssn:forProperty owl:propertyChainAxiom ( cco:ont00001917 cco:ont00001808 ) .
-
-ssn:hasDeployment rdfs:subPropertyOf bfo:BFO_0000056 .
-
-ssn:hasInput rdfs:domain sosa:Procedure ;
-    rdfs:range ssn:Input .
-
-ssn:hasOutput rdfs:domain sosa:Procedure ;
-    rdfs:range ssn:Output .
-
-ssn:hasProperty rdfs:range [ a owl:Class ;
-            owl:unionOf ( bfo:BFO_0000020 bfo:BFO_0000144 ) ] .
-
-ssn:hasSubSystem rdfs:subPropertyOf bfo:BFO_0000178 .
-
-ssn:implementedBy rdfs:subPropertyOf cco:ont00001942 .
-
-ssn:inDeployment rdfs:subPropertyOf bfo:BFO_0000056 .
-
-ssn:isPropertyOf rdfs:domain [ a owl:Class ;
-            owl:unionOf ( bfo:BFO_0000020 bfo:BFO_0000144 ) ] .
-
-ssn:isProxyFor rdfs:domain ssn:Stimulus ;
-    rdfs:range ssn:Property .
-
-ssn-system:Accuracy rdfs:subClassOf [ a owl:Class ;
-            owl:intersectionOf ( bfo:BFO_0000034 [ a owl:Restriction ;
-                        owl:onProperty bfo:BFO_0000054 ;
-                        owl:someValuesFrom [ a owl:Class ;
-                                owl:intersectionOf ( bfo:BFO_0000015 [ a owl:Restriction ;
-                                            owl:onProperty cco:ont00001801 ;
-                                            owl:someValuesFrom [ a owl:Class ;
-                                                    owl:intersectionOf ( cco:ont00000853 [ a owl:Restriction ;
-                                                                owl:onProperty cco:ont00001904 ;
-                                                                owl:someValuesFrom [ a owl:Class ;
-                                                                        owl:intersectionOf ( cco:ont00000592 [ a owl:Restriction ;
-                                                                                    owl:onProperty cco:ont00001920 ;
-                                                                                    owl:someValuesFrom cco:ont00000118 ] ) ] ] ) ] ] ) ] ] ) ] .
-
-ssn-system:ActuationRange rdfs:subClassOf [ a owl:Class ;
-            owl:intersectionOf ( bfo:BFO_0000034 [ a owl:Restriction ;
-                        owl:onProperty bfo:BFO_0000054 ;
-                        owl:someValuesFrom [ a owl:Class ;
-                                owl:intersectionOf ( sosa:Actuation [ a owl:Class ;
-                                            owl:intersectionOf ( [ a owl:Restriction ;
-                                                        owl:onProperty cco:ont00001986 ;
-                                                        owl:someValuesFrom bfo:BFO_0000020 ] [ a owl:Restriction ;
-                                                        owl:onProperty cco:ont00001920 ;
-                                                        owl:someValuesFrom cco:ont00000118 ] ) ] ) ] ] ) ] .
-
-ssn-system:BatteryLifetime rdfs:subClassOf [ a owl:Class ;
-            owl:intersectionOf ( bfo:BFO_0000034 [ a owl:Restriction ;
-                        owl:onProperty bfo:BFO_0000054 ;
-                        owl:someValuesFrom [ a owl:Class ;
-                                owl:intersectionOf ( cco:ont00001213 [ a owl:Restriction ;
-                                            owl:onProperty bfo:BFO_0000117 ;
-                                            owl:someValuesFrom cco:ont00000503 ] [ a owl:Restriction ;
-                                            owl:onProperty cco:ont00001819 ;
-                                            owl:someValuesFrom [ a owl:Class ;
-                                                    owl:intersectionOf ( bfo:BFO_0000015 [ a owl:Restriction ;
-                                                                owl:onProperty bfo:BFO_0000055 ;
-                                                                owl:someValuesFrom [ a owl:Class ;
-                                                                        owl:intersectionOf ( cco:ont00000177 [ a owl:Restriction ;
-                                                                                    owl:onProperty cco:ont00001920 ;
-                                                                                    owl:someValuesFrom cco:ont00000319 ] ) ] ] ) ] ] ) ] ] ) ] .
-
-ssn-system:Condition rdfs:subClassOf [ a owl:Class ;
-            owl:intersectionOf ( [ a owl:Class ;
-                        owl:unionOf ( bfo:BFO_0000020 bfo:BFO_0000144 ) ] [ a owl:Restriction ;
-                        owl:onProperty cco:ont00001884 ;
-                        owl:someValuesFrom cco:ont00000127 ] ) ] .
-
-ssn-system:DetectionLimit rdfs:subClassOf [ a owl:Class ;
-            owl:intersectionOf ( bfo:BFO_0000034 [ a owl:Restriction ;
-                        owl:onProperty bfo:BFO_0000054 ;
-                        owl:someValuesFrom [ a owl:Class ;
-                                owl:intersectionOf ( bfo:BFO_0000015 [ a owl:Restriction ;
-                                            owl:onProperty cco:ont00001801 ;
-                                            owl:someValuesFrom [ a owl:Class ;
-                                                    owl:intersectionOf ( cco:ont00000853 [ a owl:Restriction ;
-                                                                owl:onProperty cco:ont00001904 ;
-                                                                owl:someValuesFrom [ a owl:Class ;
-                                                                        owl:intersectionOf ( cco:ont00000592 [ a owl:Restriction ;
-                                                                                    owl:onProperty cco:ont00001920 ;
-                                                                                    owl:someValuesFrom cco:ont00000118 ] ) ] ] ) ] ] ) ] ] ) ] .
-
-ssn-system:Drift rdfs:subClassOf [ a owl:Class ;
-            owl:intersectionOf ( bfo:BFO_0000034 [ a owl:Restriction ;
-                        owl:onProperty bfo:BFO_0000054 ;
-                        owl:someValuesFrom [ a owl:Class ;
-                                owl:intersectionOf ( bfo:BFO_0000015 [ a owl:Restriction ;
-                                            owl:onProperty cco:ont00001801 ;
-                                            owl:someValuesFrom [ a owl:Class ;
-                                                    owl:intersectionOf ( cco:ont00000853 [ a owl:Restriction ;
-                                                                owl:onProperty cco:ont00001904 ;
-                                                                owl:someValuesFrom [ a owl:Class ;
-                                                                        owl:intersectionOf ( cco:ont00000731 [ a owl:Restriction ;
-                                                                                    owl:onProperty cco:ont00001920 ;
-                                                                                    owl:someValuesFrom cco:ont00000118 ] ) ] ] ) ] ] ) ] ] ) ] .
-
-ssn-system:Frequency rdfs:subClassOf [ a owl:Class ;
-            owl:intersectionOf ( bfo:BFO_0000034 [ a owl:Restriction ;
-                        owl:onProperty bfo:BFO_0000054 ;
-                        owl:someValuesFrom [ a owl:Class ;
-                                owl:intersectionOf ( cco:ont00000228 [ a owl:Restriction ;
-                                            owl:onProperty bfo:BFO_0000117 ;
-                                            owl:someValuesFrom [ a owl:Class ;
-                                                    owl:intersectionOf ( cco:ont00001047 [ a owl:Restriction ;
-                                                                owl:onProperty cco:ont00001920 ;
-                                                                owl:someValuesFrom cco:ont00000118 ] ) ] ] ) ] ] ) ] .
-
-ssn-system:Latency rdfs:subClassOf [ a owl:Class ;
-            owl:intersectionOf ( bfo:BFO_0000034 [ a owl:Restriction ;
-                        owl:onProperty bfo:BFO_0000054 ;
-                        owl:someValuesFrom [ a owl:Class ;
-                                owl:intersectionOf ( cco:ont00000228 [ a owl:Restriction ;
-                                            owl:onProperty cco:ont00001777 ;
-                                            owl:someValuesFrom cco:ont00000978 ] [ a owl:Restriction ;
-                                            owl:onProperty cco:ont00001777 ;
-                                            owl:someValuesFrom cco:ont00000660 ] [ a owl:Restriction ;
-                                            owl:onProperty bfo:BFO_0000199 ;
-                                            owl:someValuesFrom [ a owl:Class ;
-                                                    owl:intersectionOf ( bfo:BFO_0000008 [ a owl:Restriction ;
-                                                                owl:onProperty cco:ont00001920 ;
-                                                                owl:someValuesFrom cco:ont00000118 ] ) ] ] ) ] ] ) ] .
-
-ssn-system:MaintenanceSchedule rdfs:subClassOf [ a owl:Class ;
-            owl:intersectionOf ( bfo:BFO_0000016 [ a owl:Restriction ;
-                        owl:onProperty bfo:BFO_0000054 ;
-                        owl:someValuesFrom [ a owl:Class ;
-                                owl:intersectionOf ( cco:ont00000004 [ a owl:Restriction ;
-                                            owl:onProperty cco:ont00001834 ;
-                                            owl:someValuesFrom [ a owl:Class ;
-                                                    owl:intersectionOf ( bfo:BFO_0000020 [ a owl:Restriction ;
-                                                                owl:onProperty bfo:BFO_0000056 ;
-                                                                owl:someValuesFrom [ a owl:Class ;
-                                                                        owl:intersectionOf ( cco:ont00000950 [ a owl:Restriction ;
-                                                                                    owl:onProperty bfo:BFO_0000117 ;
-                                                                                    owl:someValuesFrom [ a owl:Class ;
-                                                                                            owl:intersectionOf ( cco:ont00001047 [ a owl:Restriction ;
-                                                                                                        owl:onProperty cco:ont00001920 ;
-                                                                                                        owl:someValuesFrom cco:ont00000319 ] ) ] ] ) ] ] ) ] ] ) ] ] ) ] .
-
-ssn-system:MeasurementRange rdfs:subClassOf [ a owl:Class ;
-            owl:intersectionOf ( bfo:BFO_0000034 [ a owl:Restriction ;
-                        owl:onProperty bfo:BFO_0000054 ;
-                        owl:someValuesFrom [ a owl:Class ;
-                                owl:intersectionOf ( sosa:Observation [ a owl:Restriction ;
-                                            owl:onProperty cco:ont00001819 ;
-                                            owl:someValuesFrom [ a owl:Class ;
-                                                    owl:intersectionOf ( ssn:Stimulus [ a owl:Restriction ;
-                                                                owl:onProperty cco:ont00001920 ;
-                                                                owl:someValuesFrom cco:ont00000118 ] ) ] ] ) ] ] ) ] .
-
-ssn-system:OperatingPowerRange rdfs:subClassOf [ a owl:Class ;
-            owl:intersectionOf ( bfo:BFO_0000034 [ a owl:Restriction ;
-                        owl:onProperty bfo:BFO_0000054 ;
-                        owl:someValuesFrom [ a owl:Class ;
-                                owl:intersectionOf ( bfo:BFO_0000015 [ a owl:Restriction ;
-                                            owl:onProperty bfo:BFO_0000117 ;
-                                            owl:someValuesFrom [ a owl:Class ;
-                                                    owl:intersectionOf ( cco:ont00000503 [ a owl:Restriction ;
-                                                                owl:onProperty cco:ont00001920 ;
-                                                                owl:someValuesFrom cco:ont00000319 ] ) ] ] ) ] ] ) ] .
-
-ssn-system:OperatingProperty rdfs:subClassOf [ a owl:Class ;
-            owl:intersectionOf ( [ a owl:Class ;
-                        owl:unionOf ( bfo:BFO_0000020 bfo:BFO_0000144 ) ] [ a owl:Restriction ;
-                        owl:onProperty cco:ont00001920 ;
-                        owl:someValuesFrom cco:ont00000319 ] ) ] .
-
-ssn-system:Precision rdfs:subClassOf [ a owl:Class ;
-            owl:intersectionOf ( bfo:BFO_0000034 [ a owl:Restriction ;
-                        owl:onProperty bfo:BFO_0000054 ;
-                        owl:someValuesFrom [ a owl:Class ;
-                                owl:intersectionOf ( bfo:BFO_0000015 [ a owl:Restriction ;
-                                            owl:onProperty cco:ont00001801 ;
-                                            owl:someValuesFrom [ a owl:Class ;
-                                                    owl:intersectionOf ( cco:ont00000853 [ a owl:Restriction ;
-                                                                owl:onProperty cco:ont00001904 ;
-                                                                owl:someValuesFrom [ a owl:Class ;
-                                                                        owl:intersectionOf ( cco:ont00001256 [ a owl:Restriction ;
-                                                                                    owl:onProperty cco:ont00001920 ;
-                                                                                    owl:someValuesFrom cco:ont00000118 ] ) ] ] ) ] ] ) ] ] ) ] .
-
-ssn-system:Resolution rdfs:subClassOf [ a owl:Class ;
-            owl:intersectionOf ( bfo:BFO_0000034 [ a owl:Restriction ;
-                        owl:onProperty bfo:BFO_0000054 ;
-                        owl:someValuesFrom [ a owl:Class ;
-                                owl:intersectionOf ( bfo:BFO_0000015 [ a owl:Restriction ;
-                                            owl:onProperty cco:ont00001801 ;
-                                            owl:someValuesFrom [ a owl:Class ;
-                                                    owl:intersectionOf ( cco:ont00000853 [ a owl:Restriction ;
-                                                                owl:onProperty cco:ont00001904 ;
-                                                                owl:someValuesFrom [ a owl:Class ;
-                                                                        owl:intersectionOf ( cco:ont00000731 [ a owl:Restriction ;
-                                                                                    owl:onProperty cco:ont00001920 ;
-                                                                                    owl:someValuesFrom cco:ont00000118 ] ) ] ] ) ] ] ) ] ] ) ] .
-
-ssn-system:ResponseTime rdfs:subClassOf [ a owl:Class ;
-            owl:intersectionOf ( bfo:BFO_0000034 [ a owl:Restriction ;
-                        owl:onProperty bfo:BFO_0000054 ;
-                        owl:someValuesFrom [ a owl:Class ;
-                                owl:intersectionOf ( cco:ont00000228 [ a owl:Restriction ;
-                                            owl:onProperty cco:ont00001777 ;
-                                            owl:someValuesFrom cco:ont00000978 ] [ a owl:Restriction ;
-                                            owl:onProperty cco:ont00001777 ;
-                                            owl:someValuesFrom cco:ont00000660 ] [ a owl:Restriction ;
-                                            owl:onProperty bfo:BFO_0000199 ;
-                                            owl:someValuesFrom [ a owl:Class ;
-                                                    owl:intersectionOf ( bfo:BFO_0000008 [ a owl:Restriction ;
-                                                                owl:onProperty cco:ont00001920 ;
-                                                                owl:someValuesFrom cco:ont00000118 ] ) ] ] ) ] ] ) ] .
-
-ssn-system:Selectivity rdfs:subClassOf [ a owl:Class ;
-            owl:intersectionOf ( bfo:BFO_0000034 [ a owl:Restriction ;
-                        owl:onProperty bfo:BFO_0000054 ;
-                        owl:someValuesFrom [ a owl:Class ;
-                                owl:intersectionOf ( cco:ont00000228 [ a owl:Restriction ;
-                                            owl:onProperty bfo:BFO_0000057 ;
-                                            owl:someValuesFrom [ a owl:Class ;
-                                                    owl:intersectionOf ( bfo:BFO_0000002 [ a owl:Restriction ;
-                                                                owl:onProperty cco:ont00001920 ;
-                                                                owl:someValuesFrom cco:ont00000118 ] ) ] ] ) ] ] ) ] .
-
-ssn-system:Sensitivity rdfs:subClassOf [ a owl:Class ;
-            owl:intersectionOf ( bfo:BFO_0000034 [ a owl:Restriction ;
-                        owl:onProperty bfo:BFO_0000054 ;
-                        owl:someValuesFrom [ a owl:Class ;
-                                owl:intersectionOf ( bfo:BFO_0000015 [ a owl:Restriction ;
-                                            owl:onProperty cco:ont00001801 ;
-                                            owl:someValuesFrom [ a owl:Class ;
-                                                    owl:intersectionOf ( cco:ont00000853 [ a owl:Restriction ;
-                                                                owl:onProperty cco:ont00001904 ;
-                                                                owl:someValuesFrom [ a owl:Class ;
-                                                                        owl:intersectionOf ( cco:ont00001022 [ a owl:Restriction ;
-                                                                                    owl:onProperty cco:ont00001920 ;
-                                                                                    owl:someValuesFrom cco:ont00000118 ] ) ] ] ) ] ] ) ] ] ) ] .
-
-ssn-system:SurvivalProperty rdfs:subClassOf [ a owl:Class ;
-            owl:intersectionOf ( bfo:BFO_0000034 [ a owl:Restriction ;
-                        owl:onProperty bfo:BFO_0000054 ;
-                        owl:someValuesFrom [ a owl:Class ;
-                                owl:intersectionOf ( bfo:BFO_0000015 [ a owl:Restriction ;
-                                            owl:onProperty cco:ont00001819 ;
-                                            owl:someValuesFrom [ a owl:Class ;
-                                                    owl:intersectionOf ( bfo:BFO_0000015 [ a owl:Restriction ;
-                                                                owl:onProperty bfo:BFO_0000055 ;
-                                                                owl:someValuesFrom [ a owl:Class ;
-                                                                        owl:intersectionOf ( cco:ont00000177 [ a owl:Restriction ;
-                                                                                    owl:onProperty cco:ont00001920 ;
-                                                                                    owl:someValuesFrom cco:ont00000319 ] ) ] ] ) ] ] ) ] ] ) ] .
-
-ssn-system:SystemLifetime rdfs:subClassOf [ a owl:Class ;
-            owl:intersectionOf ( bfo:BFO_0000034 [ a owl:Restriction ;
-                        owl:onProperty bfo:BFO_0000054 ;
-                        owl:someValuesFrom [ a owl:Class ;
-                                owl:intersectionOf ( cco:ont00001213 [ a owl:Restriction ;
-                                            owl:onProperty cco:ont00001819 ;
-                                            owl:someValuesFrom [ a owl:Class ;
-                                                    owl:intersectionOf ( bfo:BFO_0000015 [ a owl:Restriction ;
-                                                                owl:onProperty bfo:BFO_0000055 ;
-                                                                owl:someValuesFrom [ a owl:Class ;
-                                                                        owl:intersectionOf ( cco:ont00000177 [ a owl:Restriction ;
-                                                                                    owl:onProperty cco:ont00001920 ;
-                                                                                    owl:someValuesFrom cco:ont00000319 ] ) ] ] ) ] ] ) ] ] ) ] .
-
-ssn-system:SystemProperty rdfs:subClassOf [ a owl:Class ;
-            owl:intersectionOf ( [ a owl:Class ;
-                        owl:unionOf ( bfo:BFO_0000020 bfo:BFO_0000144 ) ] [ a owl:Restriction ;
-                        owl:onProperty cco:ont00001920 ;
-                        owl:someValuesFrom cco:ont00000118 ] ) ] .
-
-ssn-system:hasOperatingProperty rdfs:subPropertyOf bfo:BFO_0000194 .
-
-ssn-system:hasOperatingRange rdfs:domain ssn:System ;
-    rdfs:range ssn-system:OperatingRange .
-
-ssn-system:hasSurvivalProperty rdfs:subPropertyOf bfo:BFO_0000194 .
-
-ssn-system:hasSurvivalRange rdfs:domain ssn:System ;
-    rdfs:range ssn-system:SurvivalRange .
-
-ssn-system:hasSystemCapability rdfs:domain ssn:System ;
-    rdfs:range ssn-system:SystemCapability .
-
-ssn-system:hasSystemProperty rdfs:subPropertyOf bfo:BFO_0000194 .
-
-ssn-system:inCondition rdfs:domain [ a owl:Class ;
-            owl:unionOf ( ssn-system:SystemCapability ssn-system:OperatingRange ssn-system:SurvivalRange ) ] .
-
-ssn-system:qualityOfObservation rdfs:subPropertyOf cco:ont00001986 .
-
-ssn:wasOriginatedBy rdfs:subPropertyOf cco:ont00001962 .
-
-sosa:ActuatableProperty rdfs:subClassOf [ a owl:Class ;
-            owl:unionOf ( [ a owl:Class ;
-                        owl:intersectionOf ( bfo:BFO_0000020 [ a owl:Restriction ;
-                                    owl:onProperty bfo:BFO_0000197 ;
-                                    owl:someValuesFrom sosa:FeatureOfInterest ] ) ] [ a owl:Class ;
-                        owl:intersectionOf ( bfo:BFO_0000144 [ a owl:Restriction ;
-                                    owl:onProperty bfo:BFO_0000132 ;
-                                    owl:someValuesFrom sosa:FeatureOfInterest ] ) ] ) ] .
-
-sosa:Sample owl:equivalentClass [ a owl:Class ;
-            owl:intersectionOf ( bfo:BFO_0000040 [ a owl:Restriction ;
-                        owl:onProperty cco:ont00001936 ;
-                        owl:someValuesFrom sosa:Sampling ] ) ] .
-
-sosa:actsOnProperty rdfs:subPropertyOf cco:ont00001834 .
-
-sosa:hosts owl:propertyChainAxiom ( bfo:BFO_0000196 bfo:BFO_0000054 bfo:BFO_0000057 ) .
-
-ssn:Input rdfs:subClassOf cco:ont00000958 .
-
-ssn:Output rdfs:subClassOf cco:ont00000958 .
-
-ssn:Property owl:equivalentClass [ a owl:Class ;
-            owl:unionOf ( bfo:BFO_0000020 bfo:BFO_0000144 ) ] .
-
-ssn:deployedOnPlatform rdfs:subPropertyOf bfo:BFO_0000057 .
-
-ssn:deployedSystem rdfs:subPropertyOf bfo:BFO_0000057 .
-
-ssn:implements rdfs:subPropertyOf cco:ont00001920 .
-
-sosa:Actuator rdfs:subClassOf [ a owl:Class ;
-            owl:intersectionOf ( bfo:BFO_0000040 [ a owl:Restriction ;
-                        owl:onProperty bfo:BFO_0000196 ;
-                        owl:someValuesFrom [ a owl:Class ;
-                                owl:intersectionOf ( bfo:BFO_0000017 [ a owl:Restriction ;
-                                            owl:onProperty bfo:BFO_0000054 ;
-                                            owl:someValuesFrom sosa:Actuation ] ) ] ] [ a owl:Restriction ;
-                        owl:onProperty cco:ont00001787 ;
-                        owl:someValuesFrom sosa:Actuation ] ) ] .
-
-sosa:ObservableProperty rdfs:subClassOf [ a owl:Class ;
-            owl:unionOf ( [ a owl:Class ;
-                        owl:intersectionOf ( bfo:BFO_0000020 [ a owl:Restriction ;
-                                    owl:onProperty bfo:BFO_0000197 ;
-                                    owl:someValuesFrom sosa:FeatureOfInterest ] ) ] [ a owl:Class ;
-                        owl:intersectionOf ( bfo:BFO_0000144 [ a owl:Restriction ;
-                                    owl:onProperty bfo:BFO_0000132 ;
-                                    owl:someValuesFrom sosa:FeatureOfInterest ] ) ] ) ] .
-
-ssn:Stimulus owl:equivalentClass [ a owl:Class ;
-            owl:intersectionOf ( cco:ont00000978 [ a owl:Restriction ;
-                        owl:onProperty cco:ont00001803 ;
-                        owl:someValuesFrom sosa:Observation ] ) ] .
-
-ssn-system:OperatingRange rdfs:subClassOf [ a owl:Class ;
-            owl:intersectionOf ( [ a owl:Class ;
-                        owl:unionOf ( bfo:BFO_0000020 bfo:BFO_0000144 ) ] [ a owl:Restriction ;
-                        owl:onProperty cco:ont00001920 ;
-                        owl:someValuesFrom cco:ont00000319 ] ) ] .
-
-ssn-system:SurvivalRange rdfs:subClassOf [ a owl:Class ;
-            owl:intersectionOf ( bfo:BFO_0000034 [ a owl:Restriction ;
-                        owl:onProperty bfo:BFO_0000054 ;
-                        owl:someValuesFrom [ a owl:Class ;
-                                owl:intersectionOf ( bfo:BFO_0000015 [ a owl:Restriction ;
-                                            owl:onProperty cco:ont00001819 ;
-                                            owl:someValuesFrom [ a owl:Class ;
-                                                    owl:intersectionOf ( bfo:BFO_0000015 [ a owl:Restriction ;
-                                                                owl:onProperty bfo:BFO_0000055 ;
-                                                                owl:someValuesFrom [ a owl:Class ;
-                                                                        owl:intersectionOf ( cco:ont00000177 [ a owl:Restriction ;
-                                                                                    owl:onProperty cco:ont00001920 ;
-                                                                                    owl:someValuesFrom cco:ont00000319 ] ) ] ] ) ] ] ) ] ] ) ] .
-
-ssn-system:SystemCapability rdfs:subClassOf [ a owl:Class ;
-            owl:intersectionOf ( [ a owl:Class ;
-                        owl:unionOf ( bfo:BFO_0000020 bfo:BFO_0000144 ) ] [ a owl:Restriction ;
-                        owl:onProperty cco:ont00001884 ;
-                        owl:someValuesFrom cco:ont00000127 ] ) ] .
-
-sosa:Procedure rdfs:subClassOf [ a owl:Class ;
-            owl:intersectionOf ( cco:ont00000965 [ a owl:Restriction ;
-                        owl:onProperty cco:ont00001942 ;
-                        owl:someValuesFrom bfo:BFO_0000015 ] ) ] .
-
-sosa:Sensor rdfs:subClassOf [ a owl:Class ;
-            owl:intersectionOf ( bfo:BFO_0000040 [ a owl:Restriction ;
-                        owl:onProperty bfo:BFO_0000196 ;
-                        owl:someValuesFrom [ a owl:Class ;
-                                owl:intersectionOf ( bfo:BFO_0000017 [ a owl:Restriction ;
-                                            owl:onProperty bfo:BFO_0000054 ;
-                                            owl:someValuesFrom sosa:Observation ] ) ] ] [ a owl:Restriction ;
-                        owl:onProperty cco:ont00001787 ;
-                        owl:someValuesFrom sosa:Observation ] ) ] .
-
-ssn:System owl:equivalentClass [ a owl:Class ;
-            owl:intersectionOf ( bfo:BFO_0000040 [ a owl:Restriction ;
-                        owl:onProperty ssn:implements ;
-                        owl:someValuesFrom sosa:Procedure ] ) ] .
-
-sosa:FeatureOfInterest rdfs:subClassOf [ a owl:Class ;
-            owl:unionOf ( bfo:BFO_0000020 bfo:BFO_0000144 bfo:BFO_0000040 bfo:BFO_0000015 ) ] .
-
-sosa:Sampling owl:equivalentClass [ a owl:Class ;
-            owl:intersectionOf ( cco:ont00000228 [ a owl:Restriction ;
-                        owl:onProperty cco:ont00001920 ;
-                        owl:someValuesFrom sosa:Procedure ] [ a owl:Restriction ;
-                        owl:onProperty cco:ont00001986 ;
-                        owl:someValuesFrom sosa:Sample ] ) ] .
-
-sosa:Actuation owl:equivalentClass [ a owl:Class ;
-            owl:intersectionOf ( cco:ont00000228 [ a owl:Restriction ;
-                        owl:onProperty sosa:actsOnProperty ;
-                        owl:someValuesFrom sosa:ActuatableProperty ] ) ] .
-
-sosa:Observation rdfs:subClassOf [ a owl:Class ;
-            owl:intersectionOf ( cco:ont00000228 [ a owl:Restriction ;
-                        owl:onProperty cco:ont00001777 ;
-                        owl:someValuesFrom [ a owl:Class ;
-                                owl:intersectionOf ( cco:ont00000345 cco:ont00000037 ) ] ] ) ] .
+<http://www.w3.org/ns/sosa/ActuatableProperty> rdfs:subClassOf _:af0ed25535d9f911882545913dac2c83339346e2ca16a5e939b2a2e27cd5f1c4e_target .
+_:af0ed25535d9f911882545913dac2c83339346e2ca16a5e939b2a2e27cd5f1c4e_target rdf:type owl:Class .
+_:af0ed25535d9f911882545913dac2c83339346e2ca16a5e939b2a2e27cd5f1c4e_target owl:unionOf _:af0ed25535d9f911882545913dac2c83339346e2ca16a5e939b2a2e27cd5f1c4e_target_list_0 .
+_:af0ed25535d9f911882545913dac2c83339346e2ca16a5e939b2a2e27cd5f1c4e_target_list_0 rdf:first _:af0ed25535d9f911882545913dac2c83339346e2ca16a5e939b2a2e27cd5f1c4e_target_child_0 .
+_:af0ed25535d9f911882545913dac2c83339346e2ca16a5e939b2a2e27cd5f1c4e_target_list_0 rdf:rest _:af0ed25535d9f911882545913dac2c83339346e2ca16a5e939b2a2e27cd5f1c4e_target_list_1 .
+_:af0ed25535d9f911882545913dac2c83339346e2ca16a5e939b2a2e27cd5f1c4e_target_list_1 rdf:first _:af0ed25535d9f911882545913dac2c83339346e2ca16a5e939b2a2e27cd5f1c4e_target_child_1 .
+_:af0ed25535d9f911882545913dac2c83339346e2ca16a5e939b2a2e27cd5f1c4e_target_list_1 rdf:rest rdf:nil .
+_:af0ed25535d9f911882545913dac2c83339346e2ca16a5e939b2a2e27cd5f1c4e_target_child_0 rdf:type owl:Class .
+_:af0ed25535d9f911882545913dac2c83339346e2ca16a5e939b2a2e27cd5f1c4e_target_child_0 owl:intersectionOf _:af0ed25535d9f911882545913dac2c83339346e2ca16a5e939b2a2e27cd5f1c4e_target_child_0_list_0 .
+_:af0ed25535d9f911882545913dac2c83339346e2ca16a5e939b2a2e27cd5f1c4e_target_child_0_list_0 rdf:first <http://purl.obolibrary.org/obo/BFO_0000020> .
+_:af0ed25535d9f911882545913dac2c83339346e2ca16a5e939b2a2e27cd5f1c4e_target_child_0_list_0 rdf:rest _:af0ed25535d9f911882545913dac2c83339346e2ca16a5e939b2a2e27cd5f1c4e_target_child_0_list_1 .
+_:af0ed25535d9f911882545913dac2c83339346e2ca16a5e939b2a2e27cd5f1c4e_target_child_0_list_1 rdf:first _:af0ed25535d9f911882545913dac2c83339346e2ca16a5e939b2a2e27cd5f1c4e_target_child_0_child_1 .
+_:af0ed25535d9f911882545913dac2c83339346e2ca16a5e939b2a2e27cd5f1c4e_target_child_0_list_1 rdf:rest rdf:nil .
+_:af0ed25535d9f911882545913dac2c83339346e2ca16a5e939b2a2e27cd5f1c4e_target_child_0_child_1 rdf:type owl:Restriction .
+_:af0ed25535d9f911882545913dac2c83339346e2ca16a5e939b2a2e27cd5f1c4e_target_child_0_child_1 owl:onProperty <http://purl.obolibrary.org/obo/BFO_0000197> .
+_:af0ed25535d9f911882545913dac2c83339346e2ca16a5e939b2a2e27cd5f1c4e_target_child_0_child_1 owl:someValuesFrom <http://www.w3.org/ns/sosa/FeatureOfInterest> .
+_:af0ed25535d9f911882545913dac2c83339346e2ca16a5e939b2a2e27cd5f1c4e_target_child_1 rdf:type owl:Class .
+_:af0ed25535d9f911882545913dac2c83339346e2ca16a5e939b2a2e27cd5f1c4e_target_child_1 owl:intersectionOf _:af0ed25535d9f911882545913dac2c83339346e2ca16a5e939b2a2e27cd5f1c4e_target_child_1_list_0 .
+_:af0ed25535d9f911882545913dac2c83339346e2ca16a5e939b2a2e27cd5f1c4e_target_child_1_list_0 rdf:first <http://purl.obolibrary.org/obo/BFO_0000144> .
+_:af0ed25535d9f911882545913dac2c83339346e2ca16a5e939b2a2e27cd5f1c4e_target_child_1_list_0 rdf:rest _:af0ed25535d9f911882545913dac2c83339346e2ca16a5e939b2a2e27cd5f1c4e_target_child_1_list_1 .
+_:af0ed25535d9f911882545913dac2c83339346e2ca16a5e939b2a2e27cd5f1c4e_target_child_1_list_1 rdf:first _:af0ed25535d9f911882545913dac2c83339346e2ca16a5e939b2a2e27cd5f1c4e_target_child_1_child_1 .
+_:af0ed25535d9f911882545913dac2c83339346e2ca16a5e939b2a2e27cd5f1c4e_target_child_1_list_1 rdf:rest rdf:nil .
+_:af0ed25535d9f911882545913dac2c83339346e2ca16a5e939b2a2e27cd5f1c4e_target_child_1_child_1 rdf:type owl:Restriction .
+_:af0ed25535d9f911882545913dac2c83339346e2ca16a5e939b2a2e27cd5f1c4e_target_child_1_child_1 owl:onProperty <http://purl.obolibrary.org/obo/BFO_0000132> .
+_:af0ed25535d9f911882545913dac2c83339346e2ca16a5e939b2a2e27cd5f1c4e_target_child_1_child_1 owl:someValuesFrom <http://www.w3.org/ns/sosa/FeatureOfInterest> .
+
+<http://www.w3.org/ns/sosa/Actuation> owl:equivalentClass _:ac65595bd49e621675a797ec88f0bed32696c176393221adaae8b1a9192cdd842_target .
+_:ac65595bd49e621675a797ec88f0bed32696c176393221adaae8b1a9192cdd842_target rdf:type owl:Class .
+_:ac65595bd49e621675a797ec88f0bed32696c176393221adaae8b1a9192cdd842_target owl:intersectionOf _:ac65595bd49e621675a797ec88f0bed32696c176393221adaae8b1a9192cdd842_target_list_0 .
+_:ac65595bd49e621675a797ec88f0bed32696c176393221adaae8b1a9192cdd842_target_list_0 rdf:first <https://www.commoncoreontologies.org/ont00000228> .
+_:ac65595bd49e621675a797ec88f0bed32696c176393221adaae8b1a9192cdd842_target_list_0 rdf:rest _:ac65595bd49e621675a797ec88f0bed32696c176393221adaae8b1a9192cdd842_target_list_1 .
+_:ac65595bd49e621675a797ec88f0bed32696c176393221adaae8b1a9192cdd842_target_list_1 rdf:first _:ac65595bd49e621675a797ec88f0bed32696c176393221adaae8b1a9192cdd842_target_child_1 .
+_:ac65595bd49e621675a797ec88f0bed32696c176393221adaae8b1a9192cdd842_target_list_1 rdf:rest rdf:nil .
+_:ac65595bd49e621675a797ec88f0bed32696c176393221adaae8b1a9192cdd842_target_child_1 rdf:type owl:Restriction .
+_:ac65595bd49e621675a797ec88f0bed32696c176393221adaae8b1a9192cdd842_target_child_1 owl:onProperty <http://www.w3.org/ns/sosa/actsOnProperty> .
+_:ac65595bd49e621675a797ec88f0bed32696c176393221adaae8b1a9192cdd842_target_child_1 owl:someValuesFrom <http://www.w3.org/ns/sosa/ActuatableProperty> .
+
+<http://www.w3.org/ns/sosa/Actuator> rdfs:subClassOf _:a21d7cb7ddce4687296139d1e503435b53404810ecba690267188a7a6082659b0_target .
+_:a21d7cb7ddce4687296139d1e503435b53404810ecba690267188a7a6082659b0_target rdf:type owl:Class .
+_:a21d7cb7ddce4687296139d1e503435b53404810ecba690267188a7a6082659b0_target owl:intersectionOf _:a21d7cb7ddce4687296139d1e503435b53404810ecba690267188a7a6082659b0_target_list_0 .
+_:a21d7cb7ddce4687296139d1e503435b53404810ecba690267188a7a6082659b0_target_list_0 rdf:first <http://purl.obolibrary.org/obo/BFO_0000040> .
+_:a21d7cb7ddce4687296139d1e503435b53404810ecba690267188a7a6082659b0_target_list_0 rdf:rest _:a21d7cb7ddce4687296139d1e503435b53404810ecba690267188a7a6082659b0_target_list_1 .
+_:a21d7cb7ddce4687296139d1e503435b53404810ecba690267188a7a6082659b0_target_list_1 rdf:first _:a21d7cb7ddce4687296139d1e503435b53404810ecba690267188a7a6082659b0_target_child_1 .
+_:a21d7cb7ddce4687296139d1e503435b53404810ecba690267188a7a6082659b0_target_list_1 rdf:rest _:a21d7cb7ddce4687296139d1e503435b53404810ecba690267188a7a6082659b0_target_list_2 .
+_:a21d7cb7ddce4687296139d1e503435b53404810ecba690267188a7a6082659b0_target_list_2 rdf:first _:a21d7cb7ddce4687296139d1e503435b53404810ecba690267188a7a6082659b0_target_child_2 .
+_:a21d7cb7ddce4687296139d1e503435b53404810ecba690267188a7a6082659b0_target_list_2 rdf:rest rdf:nil .
+_:a21d7cb7ddce4687296139d1e503435b53404810ecba690267188a7a6082659b0_target_child_1 rdf:type owl:Restriction .
+_:a21d7cb7ddce4687296139d1e503435b53404810ecba690267188a7a6082659b0_target_child_1 owl:onProperty <http://purl.obolibrary.org/obo/BFO_0000196> .
+_:a21d7cb7ddce4687296139d1e503435b53404810ecba690267188a7a6082659b0_target_child_1 owl:someValuesFrom _:a21d7cb7ddce4687296139d1e503435b53404810ecba690267188a7a6082659b0_target_child_1_filler .
+_:a21d7cb7ddce4687296139d1e503435b53404810ecba690267188a7a6082659b0_target_child_1_filler rdf:type owl:Class .
+_:a21d7cb7ddce4687296139d1e503435b53404810ecba690267188a7a6082659b0_target_child_1_filler owl:intersectionOf _:a21d7cb7ddce4687296139d1e503435b53404810ecba690267188a7a6082659b0_target_child_1_filler_list_0 .
+_:a21d7cb7ddce4687296139d1e503435b53404810ecba690267188a7a6082659b0_target_child_1_filler_list_0 rdf:first <http://purl.obolibrary.org/obo/BFO_0000017> .
+_:a21d7cb7ddce4687296139d1e503435b53404810ecba690267188a7a6082659b0_target_child_1_filler_list_0 rdf:rest _:a21d7cb7ddce4687296139d1e503435b53404810ecba690267188a7a6082659b0_target_child_1_filler_list_1 .
+_:a21d7cb7ddce4687296139d1e503435b53404810ecba690267188a7a6082659b0_target_child_1_filler_list_1 rdf:first _:a21d7cb7ddce4687296139d1e503435b53404810ecba690267188a7a6082659b0_target_child_1_filler_child_1 .
+_:a21d7cb7ddce4687296139d1e503435b53404810ecba690267188a7a6082659b0_target_child_1_filler_list_1 rdf:rest rdf:nil .
+_:a21d7cb7ddce4687296139d1e503435b53404810ecba690267188a7a6082659b0_target_child_1_filler_child_1 rdf:type owl:Restriction .
+_:a21d7cb7ddce4687296139d1e503435b53404810ecba690267188a7a6082659b0_target_child_1_filler_child_1 owl:onProperty <http://purl.obolibrary.org/obo/BFO_0000054> .
+_:a21d7cb7ddce4687296139d1e503435b53404810ecba690267188a7a6082659b0_target_child_1_filler_child_1 owl:someValuesFrom <http://www.w3.org/ns/sosa/Actuation> .
+_:a21d7cb7ddce4687296139d1e503435b53404810ecba690267188a7a6082659b0_target_child_2 rdf:type owl:Restriction .
+_:a21d7cb7ddce4687296139d1e503435b53404810ecba690267188a7a6082659b0_target_child_2 owl:onProperty <https://www.commoncoreontologies.org/ont00001787> .
+_:a21d7cb7ddce4687296139d1e503435b53404810ecba690267188a7a6082659b0_target_child_2 owl:someValuesFrom <http://www.w3.org/ns/sosa/Actuation> .
+
+<http://www.w3.org/ns/sosa/FeatureOfInterest> rdfs:subClassOf _:aebc5a554a5a02d96a177a4905b1f58369c2a1b3cb0c5e952b40208fd3d70f720_target .
+_:aebc5a554a5a02d96a177a4905b1f58369c2a1b3cb0c5e952b40208fd3d70f720_target rdf:type owl:Class .
+_:aebc5a554a5a02d96a177a4905b1f58369c2a1b3cb0c5e952b40208fd3d70f720_target owl:unionOf _:aebc5a554a5a02d96a177a4905b1f58369c2a1b3cb0c5e952b40208fd3d70f720_target_list_0 .
+_:aebc5a554a5a02d96a177a4905b1f58369c2a1b3cb0c5e952b40208fd3d70f720_target_list_0 rdf:first <http://purl.obolibrary.org/obo/BFO_0000020> .
+_:aebc5a554a5a02d96a177a4905b1f58369c2a1b3cb0c5e952b40208fd3d70f720_target_list_0 rdf:rest _:aebc5a554a5a02d96a177a4905b1f58369c2a1b3cb0c5e952b40208fd3d70f720_target_list_1 .
+_:aebc5a554a5a02d96a177a4905b1f58369c2a1b3cb0c5e952b40208fd3d70f720_target_list_1 rdf:first <http://purl.obolibrary.org/obo/BFO_0000144> .
+_:aebc5a554a5a02d96a177a4905b1f58369c2a1b3cb0c5e952b40208fd3d70f720_target_list_1 rdf:rest _:aebc5a554a5a02d96a177a4905b1f58369c2a1b3cb0c5e952b40208fd3d70f720_target_list_2 .
+_:aebc5a554a5a02d96a177a4905b1f58369c2a1b3cb0c5e952b40208fd3d70f720_target_list_2 rdf:first <http://purl.obolibrary.org/obo/BFO_0000040> .
+_:aebc5a554a5a02d96a177a4905b1f58369c2a1b3cb0c5e952b40208fd3d70f720_target_list_2 rdf:rest _:aebc5a554a5a02d96a177a4905b1f58369c2a1b3cb0c5e952b40208fd3d70f720_target_list_3 .
+_:aebc5a554a5a02d96a177a4905b1f58369c2a1b3cb0c5e952b40208fd3d70f720_target_list_3 rdf:first <http://purl.obolibrary.org/obo/BFO_0000015> .
+_:aebc5a554a5a02d96a177a4905b1f58369c2a1b3cb0c5e952b40208fd3d70f720_target_list_3 rdf:rest rdf:nil .
+
+<http://www.w3.org/ns/sosa/ObservableProperty> rdfs:subClassOf _:a5606980322dc337a4e5d0eb2daef2e5acbba7ee42a782247375fcf3f39d12e00_target .
+_:a5606980322dc337a4e5d0eb2daef2e5acbba7ee42a782247375fcf3f39d12e00_target rdf:type owl:Class .
+_:a5606980322dc337a4e5d0eb2daef2e5acbba7ee42a782247375fcf3f39d12e00_target owl:unionOf _:a5606980322dc337a4e5d0eb2daef2e5acbba7ee42a782247375fcf3f39d12e00_target_list_0 .
+_:a5606980322dc337a4e5d0eb2daef2e5acbba7ee42a782247375fcf3f39d12e00_target_list_0 rdf:first _:a5606980322dc337a4e5d0eb2daef2e5acbba7ee42a782247375fcf3f39d12e00_target_child_0 .
+_:a5606980322dc337a4e5d0eb2daef2e5acbba7ee42a782247375fcf3f39d12e00_target_list_0 rdf:rest _:a5606980322dc337a4e5d0eb2daef2e5acbba7ee42a782247375fcf3f39d12e00_target_list_1 .
+_:a5606980322dc337a4e5d0eb2daef2e5acbba7ee42a782247375fcf3f39d12e00_target_list_1 rdf:first _:a5606980322dc337a4e5d0eb2daef2e5acbba7ee42a782247375fcf3f39d12e00_target_child_1 .
+_:a5606980322dc337a4e5d0eb2daef2e5acbba7ee42a782247375fcf3f39d12e00_target_list_1 rdf:rest rdf:nil .
+_:a5606980322dc337a4e5d0eb2daef2e5acbba7ee42a782247375fcf3f39d12e00_target_child_0 rdf:type owl:Class .
+_:a5606980322dc337a4e5d0eb2daef2e5acbba7ee42a782247375fcf3f39d12e00_target_child_0 owl:intersectionOf _:a5606980322dc337a4e5d0eb2daef2e5acbba7ee42a782247375fcf3f39d12e00_target_child_0_list_0 .
+_:a5606980322dc337a4e5d0eb2daef2e5acbba7ee42a782247375fcf3f39d12e00_target_child_0_list_0 rdf:first <http://purl.obolibrary.org/obo/BFO_0000020> .
+_:a5606980322dc337a4e5d0eb2daef2e5acbba7ee42a782247375fcf3f39d12e00_target_child_0_list_0 rdf:rest _:a5606980322dc337a4e5d0eb2daef2e5acbba7ee42a782247375fcf3f39d12e00_target_child_0_list_1 .
+_:a5606980322dc337a4e5d0eb2daef2e5acbba7ee42a782247375fcf3f39d12e00_target_child_0_list_1 rdf:first _:a5606980322dc337a4e5d0eb2daef2e5acbba7ee42a782247375fcf3f39d12e00_target_child_0_child_1 .
+_:a5606980322dc337a4e5d0eb2daef2e5acbba7ee42a782247375fcf3f39d12e00_target_child_0_list_1 rdf:rest rdf:nil .
+_:a5606980322dc337a4e5d0eb2daef2e5acbba7ee42a782247375fcf3f39d12e00_target_child_0_child_1 rdf:type owl:Restriction .
+_:a5606980322dc337a4e5d0eb2daef2e5acbba7ee42a782247375fcf3f39d12e00_target_child_0_child_1 owl:onProperty <http://purl.obolibrary.org/obo/BFO_0000197> .
+_:a5606980322dc337a4e5d0eb2daef2e5acbba7ee42a782247375fcf3f39d12e00_target_child_0_child_1 owl:someValuesFrom <http://www.w3.org/ns/sosa/FeatureOfInterest> .
+_:a5606980322dc337a4e5d0eb2daef2e5acbba7ee42a782247375fcf3f39d12e00_target_child_1 rdf:type owl:Class .
+_:a5606980322dc337a4e5d0eb2daef2e5acbba7ee42a782247375fcf3f39d12e00_target_child_1 owl:intersectionOf _:a5606980322dc337a4e5d0eb2daef2e5acbba7ee42a782247375fcf3f39d12e00_target_child_1_list_0 .
+_:a5606980322dc337a4e5d0eb2daef2e5acbba7ee42a782247375fcf3f39d12e00_target_child_1_list_0 rdf:first <http://purl.obolibrary.org/obo/BFO_0000144> .
+_:a5606980322dc337a4e5d0eb2daef2e5acbba7ee42a782247375fcf3f39d12e00_target_child_1_list_0 rdf:rest _:a5606980322dc337a4e5d0eb2daef2e5acbba7ee42a782247375fcf3f39d12e00_target_child_1_list_1 .
+_:a5606980322dc337a4e5d0eb2daef2e5acbba7ee42a782247375fcf3f39d12e00_target_child_1_list_1 rdf:first _:a5606980322dc337a4e5d0eb2daef2e5acbba7ee42a782247375fcf3f39d12e00_target_child_1_child_1 .
+_:a5606980322dc337a4e5d0eb2daef2e5acbba7ee42a782247375fcf3f39d12e00_target_child_1_list_1 rdf:rest rdf:nil .
+_:a5606980322dc337a4e5d0eb2daef2e5acbba7ee42a782247375fcf3f39d12e00_target_child_1_child_1 rdf:type owl:Restriction .
+_:a5606980322dc337a4e5d0eb2daef2e5acbba7ee42a782247375fcf3f39d12e00_target_child_1_child_1 owl:onProperty <http://purl.obolibrary.org/obo/BFO_0000132> .
+_:a5606980322dc337a4e5d0eb2daef2e5acbba7ee42a782247375fcf3f39d12e00_target_child_1_child_1 owl:someValuesFrom <http://www.w3.org/ns/sosa/FeatureOfInterest> .
+
+<http://www.w3.org/ns/sosa/Observation> rdfs:subClassOf _:a6f6ff88affdc1afbc57c833c7eae38117a3ec8d54b7ac28931e83474e938c6c5_target .
+_:a6f6ff88affdc1afbc57c833c7eae38117a3ec8d54b7ac28931e83474e938c6c5_target rdf:type owl:Class .
+_:a6f6ff88affdc1afbc57c833c7eae38117a3ec8d54b7ac28931e83474e938c6c5_target owl:intersectionOf _:a6f6ff88affdc1afbc57c833c7eae38117a3ec8d54b7ac28931e83474e938c6c5_target_list_0 .
+_:a6f6ff88affdc1afbc57c833c7eae38117a3ec8d54b7ac28931e83474e938c6c5_target_list_0 rdf:first <https://www.commoncoreontologies.org/ont00000228> .
+_:a6f6ff88affdc1afbc57c833c7eae38117a3ec8d54b7ac28931e83474e938c6c5_target_list_0 rdf:rest _:a6f6ff88affdc1afbc57c833c7eae38117a3ec8d54b7ac28931e83474e938c6c5_target_list_1 .
+_:a6f6ff88affdc1afbc57c833c7eae38117a3ec8d54b7ac28931e83474e938c6c5_target_list_1 rdf:first _:a6f6ff88affdc1afbc57c833c7eae38117a3ec8d54b7ac28931e83474e938c6c5_target_child_1 .
+_:a6f6ff88affdc1afbc57c833c7eae38117a3ec8d54b7ac28931e83474e938c6c5_target_list_1 rdf:rest rdf:nil .
+_:a6f6ff88affdc1afbc57c833c7eae38117a3ec8d54b7ac28931e83474e938c6c5_target_child_1 rdf:type owl:Restriction .
+_:a6f6ff88affdc1afbc57c833c7eae38117a3ec8d54b7ac28931e83474e938c6c5_target_child_1 owl:onProperty <https://www.commoncoreontologies.org/ont00001777> .
+_:a6f6ff88affdc1afbc57c833c7eae38117a3ec8d54b7ac28931e83474e938c6c5_target_child_1 owl:someValuesFrom _:a6f6ff88affdc1afbc57c833c7eae38117a3ec8d54b7ac28931e83474e938c6c5_target_child_1_filler .
+_:a6f6ff88affdc1afbc57c833c7eae38117a3ec8d54b7ac28931e83474e938c6c5_target_child_1_filler rdf:type owl:Class .
+_:a6f6ff88affdc1afbc57c833c7eae38117a3ec8d54b7ac28931e83474e938c6c5_target_child_1_filler owl:intersectionOf _:a6f6ff88affdc1afbc57c833c7eae38117a3ec8d54b7ac28931e83474e938c6c5_target_child_1_filler_list_0 .
+_:a6f6ff88affdc1afbc57c833c7eae38117a3ec8d54b7ac28931e83474e938c6c5_target_child_1_filler_list_0 rdf:first <https://www.commoncoreontologies.org/ont00000345> .
+_:a6f6ff88affdc1afbc57c833c7eae38117a3ec8d54b7ac28931e83474e938c6c5_target_child_1_filler_list_0 rdf:rest _:a6f6ff88affdc1afbc57c833c7eae38117a3ec8d54b7ac28931e83474e938c6c5_target_child_1_filler_list_1 .
+_:a6f6ff88affdc1afbc57c833c7eae38117a3ec8d54b7ac28931e83474e938c6c5_target_child_1_filler_list_1 rdf:first <https://www.commoncoreontologies.org/ont00000037> .
+_:a6f6ff88affdc1afbc57c833c7eae38117a3ec8d54b7ac28931e83474e938c6c5_target_child_1_filler_list_1 rdf:rest rdf:nil .
+
+<http://www.w3.org/ns/sosa/Platform> owl:equivalentClass _:a480ce3257f6b1baaaacee7b06ce730cdf63a7dd14c16b4a1bedc09597a5d96ef_target .
+_:a480ce3257f6b1baaaacee7b06ce730cdf63a7dd14c16b4a1bedc09597a5d96ef_target rdf:type owl:Class .
+_:a480ce3257f6b1baaaacee7b06ce730cdf63a7dd14c16b4a1bedc09597a5d96ef_target owl:intersectionOf _:a480ce3257f6b1baaaacee7b06ce730cdf63a7dd14c16b4a1bedc09597a5d96ef_target_list_0 .
+_:a480ce3257f6b1baaaacee7b06ce730cdf63a7dd14c16b4a1bedc09597a5d96ef_target_list_0 rdf:first <http://purl.obolibrary.org/obo/BFO_0000040> .
+_:a480ce3257f6b1baaaacee7b06ce730cdf63a7dd14c16b4a1bedc09597a5d96ef_target_list_0 rdf:rest _:a480ce3257f6b1baaaacee7b06ce730cdf63a7dd14c16b4a1bedc09597a5d96ef_target_list_1 .
+_:a480ce3257f6b1baaaacee7b06ce730cdf63a7dd14c16b4a1bedc09597a5d96ef_target_list_1 rdf:first _:a480ce3257f6b1baaaacee7b06ce730cdf63a7dd14c16b4a1bedc09597a5d96ef_target_child_1 .
+_:a480ce3257f6b1baaaacee7b06ce730cdf63a7dd14c16b4a1bedc09597a5d96ef_target_list_1 rdf:rest rdf:nil .
+_:a480ce3257f6b1baaaacee7b06ce730cdf63a7dd14c16b4a1bedc09597a5d96ef_target_child_1 rdf:type owl:Restriction .
+_:a480ce3257f6b1baaaacee7b06ce730cdf63a7dd14c16b4a1bedc09597a5d96ef_target_child_1 owl:onProperty <http://www.w3.org/ns/sosa/hosts> .
+_:a480ce3257f6b1baaaacee7b06ce730cdf63a7dd14c16b4a1bedc09597a5d96ef_target_child_1 owl:someValuesFrom <http://www.w3.org/ns/ssn/System> .
+
+<http://www.w3.org/ns/sosa/Procedure> rdfs:subClassOf _:ad0db111747f3564ec1005c04b04a804ebaf5476f273ae2675826b889dfeda719_target .
+_:ad0db111747f3564ec1005c04b04a804ebaf5476f273ae2675826b889dfeda719_target rdf:type owl:Class .
+_:ad0db111747f3564ec1005c04b04a804ebaf5476f273ae2675826b889dfeda719_target owl:intersectionOf _:ad0db111747f3564ec1005c04b04a804ebaf5476f273ae2675826b889dfeda719_target_list_0 .
+_:ad0db111747f3564ec1005c04b04a804ebaf5476f273ae2675826b889dfeda719_target_list_0 rdf:first <https://www.commoncoreontologies.org/ont00000965> .
+_:ad0db111747f3564ec1005c04b04a804ebaf5476f273ae2675826b889dfeda719_target_list_0 rdf:rest _:ad0db111747f3564ec1005c04b04a804ebaf5476f273ae2675826b889dfeda719_target_list_1 .
+_:ad0db111747f3564ec1005c04b04a804ebaf5476f273ae2675826b889dfeda719_target_list_1 rdf:first _:ad0db111747f3564ec1005c04b04a804ebaf5476f273ae2675826b889dfeda719_target_child_1 .
+_:ad0db111747f3564ec1005c04b04a804ebaf5476f273ae2675826b889dfeda719_target_list_1 rdf:rest rdf:nil .
+_:ad0db111747f3564ec1005c04b04a804ebaf5476f273ae2675826b889dfeda719_target_child_1 rdf:type owl:Restriction .
+_:ad0db111747f3564ec1005c04b04a804ebaf5476f273ae2675826b889dfeda719_target_child_1 owl:onProperty <https://www.commoncoreontologies.org/ont00001942> .
+_:ad0db111747f3564ec1005c04b04a804ebaf5476f273ae2675826b889dfeda719_target_child_1 owl:someValuesFrom <http://purl.obolibrary.org/obo/BFO_0000015> .
+
+<http://www.w3.org/ns/sosa/Result> owl:equivalentClass _:a4de8c53cc012a2f7e0322696f11d796ad9db81474e35fcb142b297bb3b714bde_target .
+_:a4de8c53cc012a2f7e0322696f11d796ad9db81474e35fcb142b297bb3b714bde_target rdf:type owl:Class .
+_:a4de8c53cc012a2f7e0322696f11d796ad9db81474e35fcb142b297bb3b714bde_target owl:intersectionOf _:a4de8c53cc012a2f7e0322696f11d796ad9db81474e35fcb142b297bb3b714bde_target_list_0 .
+_:a4de8c53cc012a2f7e0322696f11d796ad9db81474e35fcb142b297bb3b714bde_target_list_0 rdf:first _:a4de8c53cc012a2f7e0322696f11d796ad9db81474e35fcb142b297bb3b714bde_target_child_0 .
+_:a4de8c53cc012a2f7e0322696f11d796ad9db81474e35fcb142b297bb3b714bde_target_list_0 rdf:rest _:a4de8c53cc012a2f7e0322696f11d796ad9db81474e35fcb142b297bb3b714bde_target_list_1 .
+_:a4de8c53cc012a2f7e0322696f11d796ad9db81474e35fcb142b297bb3b714bde_target_list_1 rdf:first _:a4de8c53cc012a2f7e0322696f11d796ad9db81474e35fcb142b297bb3b714bde_target_child_1 .
+_:a4de8c53cc012a2f7e0322696f11d796ad9db81474e35fcb142b297bb3b714bde_target_list_1 rdf:rest rdf:nil .
+_:a4de8c53cc012a2f7e0322696f11d796ad9db81474e35fcb142b297bb3b714bde_target_child_0 rdf:type owl:Class .
+_:a4de8c53cc012a2f7e0322696f11d796ad9db81474e35fcb142b297bb3b714bde_target_child_0 owl:unionOf _:a4de8c53cc012a2f7e0322696f11d796ad9db81474e35fcb142b297bb3b714bde_target_child_0_list_0 .
+_:a4de8c53cc012a2f7e0322696f11d796ad9db81474e35fcb142b297bb3b714bde_target_child_0_list_0 rdf:first <https://www.commoncoreontologies.org/ont00000958> .
+_:a4de8c53cc012a2f7e0322696f11d796ad9db81474e35fcb142b297bb3b714bde_target_child_0_list_0 rdf:rest _:a4de8c53cc012a2f7e0322696f11d796ad9db81474e35fcb142b297bb3b714bde_target_child_0_list_1 .
+_:a4de8c53cc012a2f7e0322696f11d796ad9db81474e35fcb142b297bb3b714bde_target_child_0_list_1 rdf:first <http://purl.obolibrary.org/obo/BFO_0000040> .
+_:a4de8c53cc012a2f7e0322696f11d796ad9db81474e35fcb142b297bb3b714bde_target_child_0_list_1 rdf:rest rdf:nil .
+_:a4de8c53cc012a2f7e0322696f11d796ad9db81474e35fcb142b297bb3b714bde_target_child_1 rdf:type owl:Restriction .
+_:a4de8c53cc012a2f7e0322696f11d796ad9db81474e35fcb142b297bb3b714bde_target_child_1 owl:onProperty <https://www.commoncoreontologies.org/ont00001816> .
+_:a4de8c53cc012a2f7e0322696f11d796ad9db81474e35fcb142b297bb3b714bde_target_child_1 owl:someValuesFrom _:a4de8c53cc012a2f7e0322696f11d796ad9db81474e35fcb142b297bb3b714bde_target_child_1_filler .
+_:a4de8c53cc012a2f7e0322696f11d796ad9db81474e35fcb142b297bb3b714bde_target_child_1_filler rdf:type owl:Class .
+_:a4de8c53cc012a2f7e0322696f11d796ad9db81474e35fcb142b297bb3b714bde_target_child_1_filler owl:unionOf _:a4de8c53cc012a2f7e0322696f11d796ad9db81474e35fcb142b297bb3b714bde_target_child_1_filler_list_0 .
+_:a4de8c53cc012a2f7e0322696f11d796ad9db81474e35fcb142b297bb3b714bde_target_child_1_filler_list_0 rdf:first <http://www.w3.org/ns/sosa/Observation> .
+_:a4de8c53cc012a2f7e0322696f11d796ad9db81474e35fcb142b297bb3b714bde_target_child_1_filler_list_0 rdf:rest _:a4de8c53cc012a2f7e0322696f11d796ad9db81474e35fcb142b297bb3b714bde_target_child_1_filler_list_1 .
+_:a4de8c53cc012a2f7e0322696f11d796ad9db81474e35fcb142b297bb3b714bde_target_child_1_filler_list_1 rdf:first <http://www.w3.org/ns/sosa/Actuation> .
+_:a4de8c53cc012a2f7e0322696f11d796ad9db81474e35fcb142b297bb3b714bde_target_child_1_filler_list_1 rdf:rest _:a4de8c53cc012a2f7e0322696f11d796ad9db81474e35fcb142b297bb3b714bde_target_child_1_filler_list_2 .
+_:a4de8c53cc012a2f7e0322696f11d796ad9db81474e35fcb142b297bb3b714bde_target_child_1_filler_list_2 rdf:first <http://www.w3.org/ns/sosa/Sampling> .
+_:a4de8c53cc012a2f7e0322696f11d796ad9db81474e35fcb142b297bb3b714bde_target_child_1_filler_list_2 rdf:rest rdf:nil .
+
+<http://www.w3.org/ns/sosa/Sample> owl:equivalentClass _:a787e892cd89062b21176fd6a4732cccaba3bd65cddaae2d9c8580e3072b140b9_target .
+_:a787e892cd89062b21176fd6a4732cccaba3bd65cddaae2d9c8580e3072b140b9_target rdf:type owl:Class .
+_:a787e892cd89062b21176fd6a4732cccaba3bd65cddaae2d9c8580e3072b140b9_target owl:intersectionOf _:a787e892cd89062b21176fd6a4732cccaba3bd65cddaae2d9c8580e3072b140b9_target_list_0 .
+_:a787e892cd89062b21176fd6a4732cccaba3bd65cddaae2d9c8580e3072b140b9_target_list_0 rdf:first <http://purl.obolibrary.org/obo/BFO_0000040> .
+_:a787e892cd89062b21176fd6a4732cccaba3bd65cddaae2d9c8580e3072b140b9_target_list_0 rdf:rest _:a787e892cd89062b21176fd6a4732cccaba3bd65cddaae2d9c8580e3072b140b9_target_list_1 .
+_:a787e892cd89062b21176fd6a4732cccaba3bd65cddaae2d9c8580e3072b140b9_target_list_1 rdf:first _:a787e892cd89062b21176fd6a4732cccaba3bd65cddaae2d9c8580e3072b140b9_target_child_1 .
+_:a787e892cd89062b21176fd6a4732cccaba3bd65cddaae2d9c8580e3072b140b9_target_list_1 rdf:rest rdf:nil .
+_:a787e892cd89062b21176fd6a4732cccaba3bd65cddaae2d9c8580e3072b140b9_target_child_1 rdf:type owl:Restriction .
+_:a787e892cd89062b21176fd6a4732cccaba3bd65cddaae2d9c8580e3072b140b9_target_child_1 owl:onProperty <https://www.commoncoreontologies.org/ont00001936> .
+_:a787e892cd89062b21176fd6a4732cccaba3bd65cddaae2d9c8580e3072b140b9_target_child_1 owl:someValuesFrom <http://www.w3.org/ns/sosa/Sampling> .
+
+<http://www.w3.org/ns/sosa/Sampler> owl:equivalentClass _:aa80712efe3f50de428bfde449a3ebdf23c87750872d13a182cf065db7d0b9ae8_target .
+_:aa80712efe3f50de428bfde449a3ebdf23c87750872d13a182cf065db7d0b9ae8_target rdf:type owl:Class .
+_:aa80712efe3f50de428bfde449a3ebdf23c87750872d13a182cf065db7d0b9ae8_target owl:intersectionOf _:aa80712efe3f50de428bfde449a3ebdf23c87750872d13a182cf065db7d0b9ae8_target_list_0 .
+_:aa80712efe3f50de428bfde449a3ebdf23c87750872d13a182cf065db7d0b9ae8_target_list_0 rdf:first <http://purl.obolibrary.org/obo/BFO_0000040> .
+_:aa80712efe3f50de428bfde449a3ebdf23c87750872d13a182cf065db7d0b9ae8_target_list_0 rdf:rest _:aa80712efe3f50de428bfde449a3ebdf23c87750872d13a182cf065db7d0b9ae8_target_list_1 .
+_:aa80712efe3f50de428bfde449a3ebdf23c87750872d13a182cf065db7d0b9ae8_target_list_1 rdf:first _:aa80712efe3f50de428bfde449a3ebdf23c87750872d13a182cf065db7d0b9ae8_target_child_1 .
+_:aa80712efe3f50de428bfde449a3ebdf23c87750872d13a182cf065db7d0b9ae8_target_list_1 rdf:rest _:aa80712efe3f50de428bfde449a3ebdf23c87750872d13a182cf065db7d0b9ae8_target_list_2 .
+_:aa80712efe3f50de428bfde449a3ebdf23c87750872d13a182cf065db7d0b9ae8_target_list_2 rdf:first _:aa80712efe3f50de428bfde449a3ebdf23c87750872d13a182cf065db7d0b9ae8_target_child_2 .
+_:aa80712efe3f50de428bfde449a3ebdf23c87750872d13a182cf065db7d0b9ae8_target_list_2 rdf:rest rdf:nil .
+_:aa80712efe3f50de428bfde449a3ebdf23c87750872d13a182cf065db7d0b9ae8_target_child_1 rdf:type owl:Restriction .
+_:aa80712efe3f50de428bfde449a3ebdf23c87750872d13a182cf065db7d0b9ae8_target_child_1 owl:onProperty <http://purl.obolibrary.org/obo/BFO_0000196> .
+_:aa80712efe3f50de428bfde449a3ebdf23c87750872d13a182cf065db7d0b9ae8_target_child_1 owl:someValuesFrom _:aa80712efe3f50de428bfde449a3ebdf23c87750872d13a182cf065db7d0b9ae8_target_child_1_filler .
+_:aa80712efe3f50de428bfde449a3ebdf23c87750872d13a182cf065db7d0b9ae8_target_child_1_filler rdf:type owl:Class .
+_:aa80712efe3f50de428bfde449a3ebdf23c87750872d13a182cf065db7d0b9ae8_target_child_1_filler owl:intersectionOf _:aa80712efe3f50de428bfde449a3ebdf23c87750872d13a182cf065db7d0b9ae8_target_child_1_filler_list_0 .
+_:aa80712efe3f50de428bfde449a3ebdf23c87750872d13a182cf065db7d0b9ae8_target_child_1_filler_list_0 rdf:first <http://purl.obolibrary.org/obo/BFO_0000017> .
+_:aa80712efe3f50de428bfde449a3ebdf23c87750872d13a182cf065db7d0b9ae8_target_child_1_filler_list_0 rdf:rest _:aa80712efe3f50de428bfde449a3ebdf23c87750872d13a182cf065db7d0b9ae8_target_child_1_filler_list_1 .
+_:aa80712efe3f50de428bfde449a3ebdf23c87750872d13a182cf065db7d0b9ae8_target_child_1_filler_list_1 rdf:first _:aa80712efe3f50de428bfde449a3ebdf23c87750872d13a182cf065db7d0b9ae8_target_child_1_filler_child_1 .
+_:aa80712efe3f50de428bfde449a3ebdf23c87750872d13a182cf065db7d0b9ae8_target_child_1_filler_list_1 rdf:rest rdf:nil .
+_:aa80712efe3f50de428bfde449a3ebdf23c87750872d13a182cf065db7d0b9ae8_target_child_1_filler_child_1 rdf:type owl:Restriction .
+_:aa80712efe3f50de428bfde449a3ebdf23c87750872d13a182cf065db7d0b9ae8_target_child_1_filler_child_1 owl:onProperty <http://purl.obolibrary.org/obo/BFO_0000054> .
+_:aa80712efe3f50de428bfde449a3ebdf23c87750872d13a182cf065db7d0b9ae8_target_child_1_filler_child_1 owl:someValuesFrom <http://www.w3.org/ns/sosa/Sampling> .
+_:aa80712efe3f50de428bfde449a3ebdf23c87750872d13a182cf065db7d0b9ae8_target_child_2 rdf:type owl:Restriction .
+_:aa80712efe3f50de428bfde449a3ebdf23c87750872d13a182cf065db7d0b9ae8_target_child_2 owl:onProperty <https://www.commoncoreontologies.org/ont00001787> .
+_:aa80712efe3f50de428bfde449a3ebdf23c87750872d13a182cf065db7d0b9ae8_target_child_2 owl:someValuesFrom <http://www.w3.org/ns/sosa/Sampling> .
+
+<http://www.w3.org/ns/sosa/Sampling> owl:equivalentClass _:ae69a0d20905384f1a3b3e5f9df6b82987f1a1da4e90db05becbc99d980b39168_target .
+_:ae69a0d20905384f1a3b3e5f9df6b82987f1a1da4e90db05becbc99d980b39168_target rdf:type owl:Class .
+_:ae69a0d20905384f1a3b3e5f9df6b82987f1a1da4e90db05becbc99d980b39168_target owl:intersectionOf _:ae69a0d20905384f1a3b3e5f9df6b82987f1a1da4e90db05becbc99d980b39168_target_list_0 .
+_:ae69a0d20905384f1a3b3e5f9df6b82987f1a1da4e90db05becbc99d980b39168_target_list_0 rdf:first <https://www.commoncoreontologies.org/ont00000228> .
+_:ae69a0d20905384f1a3b3e5f9df6b82987f1a1da4e90db05becbc99d980b39168_target_list_0 rdf:rest _:ae69a0d20905384f1a3b3e5f9df6b82987f1a1da4e90db05becbc99d980b39168_target_list_1 .
+_:ae69a0d20905384f1a3b3e5f9df6b82987f1a1da4e90db05becbc99d980b39168_target_list_1 rdf:first _:ae69a0d20905384f1a3b3e5f9df6b82987f1a1da4e90db05becbc99d980b39168_target_child_1 .
+_:ae69a0d20905384f1a3b3e5f9df6b82987f1a1da4e90db05becbc99d980b39168_target_list_1 rdf:rest _:ae69a0d20905384f1a3b3e5f9df6b82987f1a1da4e90db05becbc99d980b39168_target_list_2 .
+_:ae69a0d20905384f1a3b3e5f9df6b82987f1a1da4e90db05becbc99d980b39168_target_list_2 rdf:first _:ae69a0d20905384f1a3b3e5f9df6b82987f1a1da4e90db05becbc99d980b39168_target_child_2 .
+_:ae69a0d20905384f1a3b3e5f9df6b82987f1a1da4e90db05becbc99d980b39168_target_list_2 rdf:rest rdf:nil .
+_:ae69a0d20905384f1a3b3e5f9df6b82987f1a1da4e90db05becbc99d980b39168_target_child_1 rdf:type owl:Restriction .
+_:ae69a0d20905384f1a3b3e5f9df6b82987f1a1da4e90db05becbc99d980b39168_target_child_1 owl:onProperty <https://www.commoncoreontologies.org/ont00001920> .
+_:ae69a0d20905384f1a3b3e5f9df6b82987f1a1da4e90db05becbc99d980b39168_target_child_1 owl:someValuesFrom <http://www.w3.org/ns/sosa/Procedure> .
+_:ae69a0d20905384f1a3b3e5f9df6b82987f1a1da4e90db05becbc99d980b39168_target_child_2 rdf:type owl:Restriction .
+_:ae69a0d20905384f1a3b3e5f9df6b82987f1a1da4e90db05becbc99d980b39168_target_child_2 owl:onProperty <https://www.commoncoreontologies.org/ont00001986> .
+_:ae69a0d20905384f1a3b3e5f9df6b82987f1a1da4e90db05becbc99d980b39168_target_child_2 owl:someValuesFrom <http://www.w3.org/ns/sosa/Sample> .
+
+<http://www.w3.org/ns/sosa/Sensor> rdfs:subClassOf _:af1380a66f7734f9b3e29c3e53388eabffa1e5fb296f1e0a192ada48d796a6c2b_target .
+_:af1380a66f7734f9b3e29c3e53388eabffa1e5fb296f1e0a192ada48d796a6c2b_target rdf:type owl:Class .
+_:af1380a66f7734f9b3e29c3e53388eabffa1e5fb296f1e0a192ada48d796a6c2b_target owl:intersectionOf _:af1380a66f7734f9b3e29c3e53388eabffa1e5fb296f1e0a192ada48d796a6c2b_target_list_0 .
+_:af1380a66f7734f9b3e29c3e53388eabffa1e5fb296f1e0a192ada48d796a6c2b_target_list_0 rdf:first <http://purl.obolibrary.org/obo/BFO_0000040> .
+_:af1380a66f7734f9b3e29c3e53388eabffa1e5fb296f1e0a192ada48d796a6c2b_target_list_0 rdf:rest _:af1380a66f7734f9b3e29c3e53388eabffa1e5fb296f1e0a192ada48d796a6c2b_target_list_1 .
+_:af1380a66f7734f9b3e29c3e53388eabffa1e5fb296f1e0a192ada48d796a6c2b_target_list_1 rdf:first _:af1380a66f7734f9b3e29c3e53388eabffa1e5fb296f1e0a192ada48d796a6c2b_target_child_1 .
+_:af1380a66f7734f9b3e29c3e53388eabffa1e5fb296f1e0a192ada48d796a6c2b_target_list_1 rdf:rest _:af1380a66f7734f9b3e29c3e53388eabffa1e5fb296f1e0a192ada48d796a6c2b_target_list_2 .
+_:af1380a66f7734f9b3e29c3e53388eabffa1e5fb296f1e0a192ada48d796a6c2b_target_list_2 rdf:first _:af1380a66f7734f9b3e29c3e53388eabffa1e5fb296f1e0a192ada48d796a6c2b_target_child_2 .
+_:af1380a66f7734f9b3e29c3e53388eabffa1e5fb296f1e0a192ada48d796a6c2b_target_list_2 rdf:rest rdf:nil .
+_:af1380a66f7734f9b3e29c3e53388eabffa1e5fb296f1e0a192ada48d796a6c2b_target_child_1 rdf:type owl:Restriction .
+_:af1380a66f7734f9b3e29c3e53388eabffa1e5fb296f1e0a192ada48d796a6c2b_target_child_1 owl:onProperty <http://purl.obolibrary.org/obo/BFO_0000196> .
+_:af1380a66f7734f9b3e29c3e53388eabffa1e5fb296f1e0a192ada48d796a6c2b_target_child_1 owl:someValuesFrom _:af1380a66f7734f9b3e29c3e53388eabffa1e5fb296f1e0a192ada48d796a6c2b_target_child_1_filler .
+_:af1380a66f7734f9b3e29c3e53388eabffa1e5fb296f1e0a192ada48d796a6c2b_target_child_1_filler rdf:type owl:Class .
+_:af1380a66f7734f9b3e29c3e53388eabffa1e5fb296f1e0a192ada48d796a6c2b_target_child_1_filler owl:intersectionOf _:af1380a66f7734f9b3e29c3e53388eabffa1e5fb296f1e0a192ada48d796a6c2b_target_child_1_filler_list_0 .
+_:af1380a66f7734f9b3e29c3e53388eabffa1e5fb296f1e0a192ada48d796a6c2b_target_child_1_filler_list_0 rdf:first <http://purl.obolibrary.org/obo/BFO_0000017> .
+_:af1380a66f7734f9b3e29c3e53388eabffa1e5fb296f1e0a192ada48d796a6c2b_target_child_1_filler_list_0 rdf:rest _:af1380a66f7734f9b3e29c3e53388eabffa1e5fb296f1e0a192ada48d796a6c2b_target_child_1_filler_list_1 .
+_:af1380a66f7734f9b3e29c3e53388eabffa1e5fb296f1e0a192ada48d796a6c2b_target_child_1_filler_list_1 rdf:first _:af1380a66f7734f9b3e29c3e53388eabffa1e5fb296f1e0a192ada48d796a6c2b_target_child_1_filler_child_1 .
+_:af1380a66f7734f9b3e29c3e53388eabffa1e5fb296f1e0a192ada48d796a6c2b_target_child_1_filler_list_1 rdf:rest rdf:nil .
+_:af1380a66f7734f9b3e29c3e53388eabffa1e5fb296f1e0a192ada48d796a6c2b_target_child_1_filler_child_1 rdf:type owl:Restriction .
+_:af1380a66f7734f9b3e29c3e53388eabffa1e5fb296f1e0a192ada48d796a6c2b_target_child_1_filler_child_1 owl:onProperty <http://purl.obolibrary.org/obo/BFO_0000054> .
+_:af1380a66f7734f9b3e29c3e53388eabffa1e5fb296f1e0a192ada48d796a6c2b_target_child_1_filler_child_1 owl:someValuesFrom <http://www.w3.org/ns/sosa/Observation> .
+_:af1380a66f7734f9b3e29c3e53388eabffa1e5fb296f1e0a192ada48d796a6c2b_target_child_2 rdf:type owl:Restriction .
+_:af1380a66f7734f9b3e29c3e53388eabffa1e5fb296f1e0a192ada48d796a6c2b_target_child_2 owl:onProperty <https://www.commoncoreontologies.org/ont00001787> .
+_:af1380a66f7734f9b3e29c3e53388eabffa1e5fb296f1e0a192ada48d796a6c2b_target_child_2 owl:someValuesFrom <http://www.w3.org/ns/sosa/Observation> .
+
+<http://www.w3.org/ns/sosa/actsOnProperty> rdfs:subPropertyOf <https://www.commoncoreontologies.org/ont00001834> .
+
+<http://www.w3.org/ns/sosa/hasFeatureOfInterest> rdfs:domain _:a2d8f0bb889aed23463bdc12f71eb087cf980f269d7283687d266c012c25c4f52_target .
+_:a2d8f0bb889aed23463bdc12f71eb087cf980f269d7283687d266c012c25c4f52_target rdf:type owl:Class .
+_:a2d8f0bb889aed23463bdc12f71eb087cf980f269d7283687d266c012c25c4f52_target owl:unionOf _:a2d8f0bb889aed23463bdc12f71eb087cf980f269d7283687d266c012c25c4f52_target_list_0 .
+_:a2d8f0bb889aed23463bdc12f71eb087cf980f269d7283687d266c012c25c4f52_target_list_0 rdf:first <http://www.w3.org/ns/sosa/Observation> .
+_:a2d8f0bb889aed23463bdc12f71eb087cf980f269d7283687d266c012c25c4f52_target_list_0 rdf:rest _:a2d8f0bb889aed23463bdc12f71eb087cf980f269d7283687d266c012c25c4f52_target_list_1 .
+_:a2d8f0bb889aed23463bdc12f71eb087cf980f269d7283687d266c012c25c4f52_target_list_1 rdf:first <http://www.w3.org/ns/sosa/Actuation> .
+_:a2d8f0bb889aed23463bdc12f71eb087cf980f269d7283687d266c012c25c4f52_target_list_1 rdf:rest _:a2d8f0bb889aed23463bdc12f71eb087cf980f269d7283687d266c012c25c4f52_target_list_2 .
+_:a2d8f0bb889aed23463bdc12f71eb087cf980f269d7283687d266c012c25c4f52_target_list_2 rdf:first <http://www.w3.org/ns/sosa/Sampling> .
+_:a2d8f0bb889aed23463bdc12f71eb087cf980f269d7283687d266c012c25c4f52_target_list_2 rdf:rest rdf:nil .
+
+<http://www.w3.org/ns/sosa/hasFeatureOfInterest> rdfs:range <http://www.w3.org/ns/sosa/FeatureOfInterest> .
+
+<http://www.w3.org/ns/sosa/hasResult> rdfs:subPropertyOf <https://www.commoncoreontologies.org/ont00001986> .
+
+<http://www.w3.org/ns/sosa/hasSample> owl:propertyChainAxiom _:ac0432102a5bd62d16ad94c26ec3e08d19540ba218dfb1a28a6bd87cd1e4be9ac_chain_list_0 .
+_:ac0432102a5bd62d16ad94c26ec3e08d19540ba218dfb1a28a6bd87cd1e4be9ac_chain_list_0 rdf:first <https://www.commoncoreontologies.org/ont00001873> .
+_:ac0432102a5bd62d16ad94c26ec3e08d19540ba218dfb1a28a6bd87cd1e4be9ac_chain_list_0 rdf:rest _:ac0432102a5bd62d16ad94c26ec3e08d19540ba218dfb1a28a6bd87cd1e4be9ac_chain_list_1 .
+_:ac0432102a5bd62d16ad94c26ec3e08d19540ba218dfb1a28a6bd87cd1e4be9ac_chain_list_1 rdf:first <http://purl.obolibrary.org/obo/BFO_0000084> .
+_:ac0432102a5bd62d16ad94c26ec3e08d19540ba218dfb1a28a6bd87cd1e4be9ac_chain_list_1 rdf:rest rdf:nil .
+
+<http://www.w3.org/ns/sosa/hosts> owl:propertyChainAxiom _:a90d2b3a965084a150dcd254003bbdd2e5d706d8dd1b7a941c44e44ee2ea1737e_chain_list_0 .
+_:a90d2b3a965084a150dcd254003bbdd2e5d706d8dd1b7a941c44e44ee2ea1737e_chain_list_0 rdf:first <http://purl.obolibrary.org/obo/BFO_0000196> .
+_:a90d2b3a965084a150dcd254003bbdd2e5d706d8dd1b7a941c44e44ee2ea1737e_chain_list_0 rdf:rest _:a90d2b3a965084a150dcd254003bbdd2e5d706d8dd1b7a941c44e44ee2ea1737e_chain_list_1 .
+_:a90d2b3a965084a150dcd254003bbdd2e5d706d8dd1b7a941c44e44ee2ea1737e_chain_list_1 rdf:first <http://purl.obolibrary.org/obo/BFO_0000054> .
+_:a90d2b3a965084a150dcd254003bbdd2e5d706d8dd1b7a941c44e44ee2ea1737e_chain_list_1 rdf:rest _:a90d2b3a965084a150dcd254003bbdd2e5d706d8dd1b7a941c44e44ee2ea1737e_chain_list_2 .
+_:a90d2b3a965084a150dcd254003bbdd2e5d706d8dd1b7a941c44e44ee2ea1737e_chain_list_2 rdf:first <http://purl.obolibrary.org/obo/BFO_0000057> .
+_:a90d2b3a965084a150dcd254003bbdd2e5d706d8dd1b7a941c44e44ee2ea1737e_chain_list_2 rdf:rest rdf:nil .
+
+<http://www.w3.org/ns/sosa/isActedOnBy> rdfs:subPropertyOf <https://www.commoncoreontologies.org/ont00001886> .
+
+<http://www.w3.org/ns/sosa/isFeatureOfInterestOf> rdfs:domain <http://www.w3.org/ns/sosa/FeatureOfInterest> .
+
+<http://www.w3.org/ns/sosa/isFeatureOfInterestOf> rdfs:range _:a046c9120e36b99488082b91da7f607659195e4d0af549e456e88766fe7643f9a_target .
+_:a046c9120e36b99488082b91da7f607659195e4d0af549e456e88766fe7643f9a_target rdf:type owl:Class .
+_:a046c9120e36b99488082b91da7f607659195e4d0af549e456e88766fe7643f9a_target owl:unionOf _:a046c9120e36b99488082b91da7f607659195e4d0af549e456e88766fe7643f9a_target_list_0 .
+_:a046c9120e36b99488082b91da7f607659195e4d0af549e456e88766fe7643f9a_target_list_0 rdf:first <http://www.w3.org/ns/sosa/Observation> .
+_:a046c9120e36b99488082b91da7f607659195e4d0af549e456e88766fe7643f9a_target_list_0 rdf:rest _:a046c9120e36b99488082b91da7f607659195e4d0af549e456e88766fe7643f9a_target_list_1 .
+_:a046c9120e36b99488082b91da7f607659195e4d0af549e456e88766fe7643f9a_target_list_1 rdf:first <http://www.w3.org/ns/sosa/Actuation> .
+_:a046c9120e36b99488082b91da7f607659195e4d0af549e456e88766fe7643f9a_target_list_1 rdf:rest _:a046c9120e36b99488082b91da7f607659195e4d0af549e456e88766fe7643f9a_target_list_2 .
+_:a046c9120e36b99488082b91da7f607659195e4d0af549e456e88766fe7643f9a_target_list_2 rdf:first <http://www.w3.org/ns/sosa/Sampling> .
+_:a046c9120e36b99488082b91da7f607659195e4d0af549e456e88766fe7643f9a_target_list_2 rdf:rest rdf:nil .
+
+<http://www.w3.org/ns/sosa/isHostedBy> owl:propertyChainAxiom _:a47859e2cfd5df437d1f55c83560793ab22f035de9b829ccdedcc4d3118cc4f3e_chain_list_0 .
+_:a47859e2cfd5df437d1f55c83560793ab22f035de9b829ccdedcc4d3118cc4f3e_chain_list_0 rdf:first <http://purl.obolibrary.org/obo/BFO_0000056> .
+_:a47859e2cfd5df437d1f55c83560793ab22f035de9b829ccdedcc4d3118cc4f3e_chain_list_0 rdf:rest _:a47859e2cfd5df437d1f55c83560793ab22f035de9b829ccdedcc4d3118cc4f3e_chain_list_1 .
+_:a47859e2cfd5df437d1f55c83560793ab22f035de9b829ccdedcc4d3118cc4f3e_chain_list_1 rdf:first <http://purl.obolibrary.org/obo/BFO_0000055> .
+_:a47859e2cfd5df437d1f55c83560793ab22f035de9b829ccdedcc4d3118cc4f3e_chain_list_1 rdf:rest _:a47859e2cfd5df437d1f55c83560793ab22f035de9b829ccdedcc4d3118cc4f3e_chain_list_2 .
+_:a47859e2cfd5df437d1f55c83560793ab22f035de9b829ccdedcc4d3118cc4f3e_chain_list_2 rdf:first <http://purl.obolibrary.org/obo/BFO_0000197> .
+_:a47859e2cfd5df437d1f55c83560793ab22f035de9b829ccdedcc4d3118cc4f3e_chain_list_2 rdf:rest rdf:nil .
+
+<http://www.w3.org/ns/sosa/isObservedBy> rdfs:domain <http://www.w3.org/ns/sosa/ObservableProperty> .
+
+<http://www.w3.org/ns/sosa/isObservedBy> rdfs:range <http://www.w3.org/ns/sosa/Sensor> .
+
+<http://www.w3.org/ns/sosa/isResultOf> rdfs:subPropertyOf <https://www.commoncoreontologies.org/ont00001816> .
+
+<http://www.w3.org/ns/sosa/isSampleOf> owl:propertyChainAxiom _:a84f1b6aa230d7c28f6304184fc7fac90089a78438b92a07b92a9e45763c9b951_chain_list_0 .
+_:a84f1b6aa230d7c28f6304184fc7fac90089a78438b92a07b92a9e45763c9b951_chain_list_0 rdf:first <http://purl.obolibrary.org/obo/BFO_0000101> .
+_:a84f1b6aa230d7c28f6304184fc7fac90089a78438b92a07b92a9e45763c9b951_chain_list_0 rdf:rest _:a84f1b6aa230d7c28f6304184fc7fac90089a78438b92a07b92a9e45763c9b951_chain_list_1 .
+_:a84f1b6aa230d7c28f6304184fc7fac90089a78438b92a07b92a9e45763c9b951_chain_list_1 rdf:first <https://www.commoncoreontologies.org/ont00001938> .
+_:a84f1b6aa230d7c28f6304184fc7fac90089a78438b92a07b92a9e45763c9b951_chain_list_1 rdf:rest rdf:nil .
+
+<http://www.w3.org/ns/sosa/madeActuation> rdfs:domain <http://www.w3.org/ns/sosa/Actuator> .
+
+<http://www.w3.org/ns/sosa/madeActuation> rdfs:range <http://www.w3.org/ns/sosa/Actuation> .
+
+<http://www.w3.org/ns/sosa/madeByActuator> rdfs:domain <http://www.w3.org/ns/sosa/Actuation> .
+
+<http://www.w3.org/ns/sosa/madeByActuator> rdfs:range <http://www.w3.org/ns/sosa/Actuator> .
+
+<http://www.w3.org/ns/sosa/madeBySampler> rdfs:subPropertyOf <https://www.commoncoreontologies.org/ont00001833> .
+
+<http://www.w3.org/ns/sosa/madeBySensor> rdfs:domain <http://www.w3.org/ns/sosa/Observation> .
+
+<http://www.w3.org/ns/sosa/madeBySensor> rdfs:range <http://www.w3.org/ns/sosa/Sensor> .
+
+<http://www.w3.org/ns/sosa/madeObservation> rdfs:domain <http://www.w3.org/ns/sosa/Sensor> .
+
+<http://www.w3.org/ns/sosa/madeObservation> rdfs:range <http://www.w3.org/ns/sosa/Observation> .
+
+<http://www.w3.org/ns/sosa/madeSampling> rdfs:subPropertyOf <https://www.commoncoreontologies.org/ont00001787> .
+
+<http://www.w3.org/ns/sosa/observedProperty> rdfs:subPropertyOf <https://www.commoncoreontologies.org/ont00001921> .
+
+<http://www.w3.org/ns/sosa/observes> rdfs:domain <http://www.w3.org/ns/sosa/Sensor> .
+
+<http://www.w3.org/ns/sosa/observes> rdfs:range <http://www.w3.org/ns/sosa/ObservableProperty> .
+
+<http://www.w3.org/ns/sosa/phenomenonTime> rdfs:subPropertyOf <http://purl.obolibrary.org/obo/BFO_0000199> .
+
+<http://www.w3.org/ns/sosa/sampling/RelationshipNature> rdfs:subClassOf <https://www.commoncoreontologies.org/ont00000958> .
+
+<http://www.w3.org/ns/sosa/sampling/SampleRelationship> rdfs:subClassOf <https://www.commoncoreontologies.org/ont00000958> .
+
+<http://www.w3.org/ns/sosa/sampling/hasSampleRelationship> rdfs:subPropertyOf <https://www.commoncoreontologies.org/ont00001801> .
+
+<http://www.w3.org/ns/sosa/sampling/natureOfRelationship> rdfs:subPropertyOf <https://www.commoncoreontologies.org/ont00001808> .
+
+<http://www.w3.org/ns/sosa/sampling/relatedSample> rdfs:subPropertyOf <https://www.commoncoreontologies.org/ont00001808> .
+
+<http://www.w3.org/ns/sosa/usedProcedure> rdfs:subPropertyOf <https://www.commoncoreontologies.org/ont00001920> .
+
+<http://www.w3.org/ns/ssn/Deployment> owl:equivalentClass _:a7b6dc290ded8df4f46f20ce28efdc86479348dd0c0746fd31c883e97724b0361_target .
+_:a7b6dc290ded8df4f46f20ce28efdc86479348dd0c0746fd31c883e97724b0361_target rdf:type owl:Class .
+_:a7b6dc290ded8df4f46f20ce28efdc86479348dd0c0746fd31c883e97724b0361_target owl:intersectionOf _:a7b6dc290ded8df4f46f20ce28efdc86479348dd0c0746fd31c883e97724b0361_target_list_0 .
+_:a7b6dc290ded8df4f46f20ce28efdc86479348dd0c0746fd31c883e97724b0361_target_list_0 rdf:first <https://www.commoncoreontologies.org/ont00000228> .
+_:a7b6dc290ded8df4f46f20ce28efdc86479348dd0c0746fd31c883e97724b0361_target_list_0 rdf:rest _:a7b6dc290ded8df4f46f20ce28efdc86479348dd0c0746fd31c883e97724b0361_target_list_1 .
+_:a7b6dc290ded8df4f46f20ce28efdc86479348dd0c0746fd31c883e97724b0361_target_list_1 rdf:first _:a7b6dc290ded8df4f46f20ce28efdc86479348dd0c0746fd31c883e97724b0361_target_child_1 .
+_:a7b6dc290ded8df4f46f20ce28efdc86479348dd0c0746fd31c883e97724b0361_target_list_1 rdf:rest _:a7b6dc290ded8df4f46f20ce28efdc86479348dd0c0746fd31c883e97724b0361_target_list_2 .
+_:a7b6dc290ded8df4f46f20ce28efdc86479348dd0c0746fd31c883e97724b0361_target_list_2 rdf:first _:a7b6dc290ded8df4f46f20ce28efdc86479348dd0c0746fd31c883e97724b0361_target_child_2 .
+_:a7b6dc290ded8df4f46f20ce28efdc86479348dd0c0746fd31c883e97724b0361_target_list_2 rdf:rest rdf:nil .
+_:a7b6dc290ded8df4f46f20ce28efdc86479348dd0c0746fd31c883e97724b0361_target_child_1 rdf:type owl:Restriction .
+_:a7b6dc290ded8df4f46f20ce28efdc86479348dd0c0746fd31c883e97724b0361_target_child_1 owl:onProperty <http://www.w3.org/ns/ssn/deployedSystem> .
+_:a7b6dc290ded8df4f46f20ce28efdc86479348dd0c0746fd31c883e97724b0361_target_child_1 owl:someValuesFrom <http://www.w3.org/ns/ssn/System> .
+_:a7b6dc290ded8df4f46f20ce28efdc86479348dd0c0746fd31c883e97724b0361_target_child_2 rdf:type owl:Restriction .
+_:a7b6dc290ded8df4f46f20ce28efdc86479348dd0c0746fd31c883e97724b0361_target_child_2 owl:onProperty <http://www.w3.org/ns/ssn/deployedOnPlatform> .
+_:a7b6dc290ded8df4f46f20ce28efdc86479348dd0c0746fd31c883e97724b0361_target_child_2 owl:someValuesFrom <http://purl.obolibrary.org/obo/BFO_0000040> .
+
+<http://www.w3.org/ns/ssn/Input> rdfs:subClassOf <https://www.commoncoreontologies.org/ont00000958> .
+
+<http://www.w3.org/ns/ssn/Output> rdfs:subClassOf <https://www.commoncoreontologies.org/ont00000958> .
+
+<http://www.w3.org/ns/ssn/Property> owl:equivalentClass _:ae97401fddd65d2c240938d965cb3ecb82f52b396f7fbdc7ccee0de7edf3ff74b_target .
+_:ae97401fddd65d2c240938d965cb3ecb82f52b396f7fbdc7ccee0de7edf3ff74b_target rdf:type owl:Class .
+_:ae97401fddd65d2c240938d965cb3ecb82f52b396f7fbdc7ccee0de7edf3ff74b_target owl:unionOf _:ae97401fddd65d2c240938d965cb3ecb82f52b396f7fbdc7ccee0de7edf3ff74b_target_list_0 .
+_:ae97401fddd65d2c240938d965cb3ecb82f52b396f7fbdc7ccee0de7edf3ff74b_target_list_0 rdf:first <http://purl.obolibrary.org/obo/BFO_0000020> .
+_:ae97401fddd65d2c240938d965cb3ecb82f52b396f7fbdc7ccee0de7edf3ff74b_target_list_0 rdf:rest _:ae97401fddd65d2c240938d965cb3ecb82f52b396f7fbdc7ccee0de7edf3ff74b_target_list_1 .
+_:ae97401fddd65d2c240938d965cb3ecb82f52b396f7fbdc7ccee0de7edf3ff74b_target_list_1 rdf:first <http://purl.obolibrary.org/obo/BFO_0000144> .
+_:ae97401fddd65d2c240938d965cb3ecb82f52b396f7fbdc7ccee0de7edf3ff74b_target_list_1 rdf:rest rdf:nil .
+
+<http://www.w3.org/ns/ssn/Stimulus> owl:equivalentClass _:a3c8142551309a66a37dc13ff25eb6fd6b31e7089a776f7391316bacb3705cf1e_target .
+_:a3c8142551309a66a37dc13ff25eb6fd6b31e7089a776f7391316bacb3705cf1e_target rdf:type owl:Class .
+_:a3c8142551309a66a37dc13ff25eb6fd6b31e7089a776f7391316bacb3705cf1e_target owl:intersectionOf _:a3c8142551309a66a37dc13ff25eb6fd6b31e7089a776f7391316bacb3705cf1e_target_list_0 .
+_:a3c8142551309a66a37dc13ff25eb6fd6b31e7089a776f7391316bacb3705cf1e_target_list_0 rdf:first <https://www.commoncoreontologies.org/ont00000978> .
+_:a3c8142551309a66a37dc13ff25eb6fd6b31e7089a776f7391316bacb3705cf1e_target_list_0 rdf:rest _:a3c8142551309a66a37dc13ff25eb6fd6b31e7089a776f7391316bacb3705cf1e_target_list_1 .
+_:a3c8142551309a66a37dc13ff25eb6fd6b31e7089a776f7391316bacb3705cf1e_target_list_1 rdf:first _:a3c8142551309a66a37dc13ff25eb6fd6b31e7089a776f7391316bacb3705cf1e_target_child_1 .
+_:a3c8142551309a66a37dc13ff25eb6fd6b31e7089a776f7391316bacb3705cf1e_target_list_1 rdf:rest rdf:nil .
+_:a3c8142551309a66a37dc13ff25eb6fd6b31e7089a776f7391316bacb3705cf1e_target_child_1 rdf:type owl:Restriction .
+_:a3c8142551309a66a37dc13ff25eb6fd6b31e7089a776f7391316bacb3705cf1e_target_child_1 owl:onProperty <https://www.commoncoreontologies.org/ont00001803> .
+_:a3c8142551309a66a37dc13ff25eb6fd6b31e7089a776f7391316bacb3705cf1e_target_child_1 owl:someValuesFrom <http://www.w3.org/ns/sosa/Observation> .
+
+<http://www.w3.org/ns/ssn/System> owl:equivalentClass _:a0db60d0e9764151246aa7f88574dbc9fb112eecb2191d00822192f51ec298678_target .
+_:a0db60d0e9764151246aa7f88574dbc9fb112eecb2191d00822192f51ec298678_target rdf:type owl:Class .
+_:a0db60d0e9764151246aa7f88574dbc9fb112eecb2191d00822192f51ec298678_target owl:intersectionOf _:a0db60d0e9764151246aa7f88574dbc9fb112eecb2191d00822192f51ec298678_target_list_0 .
+_:a0db60d0e9764151246aa7f88574dbc9fb112eecb2191d00822192f51ec298678_target_list_0 rdf:first <http://purl.obolibrary.org/obo/BFO_0000040> .
+_:a0db60d0e9764151246aa7f88574dbc9fb112eecb2191d00822192f51ec298678_target_list_0 rdf:rest _:a0db60d0e9764151246aa7f88574dbc9fb112eecb2191d00822192f51ec298678_target_list_1 .
+_:a0db60d0e9764151246aa7f88574dbc9fb112eecb2191d00822192f51ec298678_target_list_1 rdf:first _:a0db60d0e9764151246aa7f88574dbc9fb112eecb2191d00822192f51ec298678_target_child_1 .
+_:a0db60d0e9764151246aa7f88574dbc9fb112eecb2191d00822192f51ec298678_target_list_1 rdf:rest rdf:nil .
+_:a0db60d0e9764151246aa7f88574dbc9fb112eecb2191d00822192f51ec298678_target_child_1 rdf:type owl:Restriction .
+_:a0db60d0e9764151246aa7f88574dbc9fb112eecb2191d00822192f51ec298678_target_child_1 owl:onProperty <http://www.w3.org/ns/ssn/implements> .
+_:a0db60d0e9764151246aa7f88574dbc9fb112eecb2191d00822192f51ec298678_target_child_1 owl:someValuesFrom <http://www.w3.org/ns/sosa/Procedure> .
+
+<http://www.w3.org/ns/ssn/deployedOnPlatform> rdfs:subPropertyOf <http://purl.obolibrary.org/obo/BFO_0000057> .
+
+<http://www.w3.org/ns/ssn/deployedSystem> rdfs:subPropertyOf <http://purl.obolibrary.org/obo/BFO_0000057> .
+
+<http://www.w3.org/ns/ssn/detects> rdfs:subPropertyOf <https://www.commoncoreontologies.org/ont00001886> .
+
+<http://www.w3.org/ns/ssn/forProperty> owl:propertyChainAxiom _:aac90bbff84f27289fdc5c5fb492323384ea75b344016bb5eb7a4d34a540a8f91_chain_list_0 .
+_:aac90bbff84f27289fdc5c5fb492323384ea75b344016bb5eb7a4d34a540a8f91_chain_list_0 rdf:first <https://www.commoncoreontologies.org/ont00001917> .
+_:aac90bbff84f27289fdc5c5fb492323384ea75b344016bb5eb7a4d34a540a8f91_chain_list_0 rdf:rest _:aac90bbff84f27289fdc5c5fb492323384ea75b344016bb5eb7a4d34a540a8f91_chain_list_1 .
+_:aac90bbff84f27289fdc5c5fb492323384ea75b344016bb5eb7a4d34a540a8f91_chain_list_1 rdf:first <https://www.commoncoreontologies.org/ont00001808> .
+_:aac90bbff84f27289fdc5c5fb492323384ea75b344016bb5eb7a4d34a540a8f91_chain_list_1 rdf:rest rdf:nil .
+
+<http://www.w3.org/ns/ssn/hasDeployment> rdfs:subPropertyOf <http://purl.obolibrary.org/obo/BFO_0000056> .
+
+<http://www.w3.org/ns/ssn/hasInput> rdfs:domain <http://www.w3.org/ns/sosa/Procedure> .
+
+<http://www.w3.org/ns/ssn/hasInput> rdfs:range <http://www.w3.org/ns/ssn/Input> .
+
+<http://www.w3.org/ns/ssn/hasOutput> rdfs:domain <http://www.w3.org/ns/sosa/Procedure> .
+
+<http://www.w3.org/ns/ssn/hasOutput> rdfs:range <http://www.w3.org/ns/ssn/Output> .
+
+<http://www.w3.org/ns/ssn/hasProperty> rdfs:range _:a6dfa77b04dfaea343d0a8767e6467c603eafddf10395ff40ac7416f52c7fd4d4_target .
+_:a6dfa77b04dfaea343d0a8767e6467c603eafddf10395ff40ac7416f52c7fd4d4_target rdf:type owl:Class .
+_:a6dfa77b04dfaea343d0a8767e6467c603eafddf10395ff40ac7416f52c7fd4d4_target owl:unionOf _:a6dfa77b04dfaea343d0a8767e6467c603eafddf10395ff40ac7416f52c7fd4d4_target_list_0 .
+_:a6dfa77b04dfaea343d0a8767e6467c603eafddf10395ff40ac7416f52c7fd4d4_target_list_0 rdf:first <http://purl.obolibrary.org/obo/BFO_0000020> .
+_:a6dfa77b04dfaea343d0a8767e6467c603eafddf10395ff40ac7416f52c7fd4d4_target_list_0 rdf:rest _:a6dfa77b04dfaea343d0a8767e6467c603eafddf10395ff40ac7416f52c7fd4d4_target_list_1 .
+_:a6dfa77b04dfaea343d0a8767e6467c603eafddf10395ff40ac7416f52c7fd4d4_target_list_1 rdf:first <http://purl.obolibrary.org/obo/BFO_0000144> .
+_:a6dfa77b04dfaea343d0a8767e6467c603eafddf10395ff40ac7416f52c7fd4d4_target_list_1 rdf:rest rdf:nil .
+
+<http://www.w3.org/ns/ssn/hasSubSystem> rdfs:subPropertyOf <http://purl.obolibrary.org/obo/BFO_0000178> .
+
+<http://www.w3.org/ns/ssn/implementedBy> rdfs:subPropertyOf <https://www.commoncoreontologies.org/ont00001942> .
+
+<http://www.w3.org/ns/ssn/implements> rdfs:subPropertyOf <https://www.commoncoreontologies.org/ont00001920> .
+
+<http://www.w3.org/ns/ssn/inDeployment> rdfs:subPropertyOf <http://purl.obolibrary.org/obo/BFO_0000056> .
+
+<http://www.w3.org/ns/ssn/isPropertyOf> rdfs:domain _:a0caeec31770247fe2efeb443e85fefe9b4e1648a7d9569adc35d2972b77682b1_target .
+_:a0caeec31770247fe2efeb443e85fefe9b4e1648a7d9569adc35d2972b77682b1_target rdf:type owl:Class .
+_:a0caeec31770247fe2efeb443e85fefe9b4e1648a7d9569adc35d2972b77682b1_target owl:unionOf _:a0caeec31770247fe2efeb443e85fefe9b4e1648a7d9569adc35d2972b77682b1_target_list_0 .
+_:a0caeec31770247fe2efeb443e85fefe9b4e1648a7d9569adc35d2972b77682b1_target_list_0 rdf:first <http://purl.obolibrary.org/obo/BFO_0000020> .
+_:a0caeec31770247fe2efeb443e85fefe9b4e1648a7d9569adc35d2972b77682b1_target_list_0 rdf:rest _:a0caeec31770247fe2efeb443e85fefe9b4e1648a7d9569adc35d2972b77682b1_target_list_1 .
+_:a0caeec31770247fe2efeb443e85fefe9b4e1648a7d9569adc35d2972b77682b1_target_list_1 rdf:first <http://purl.obolibrary.org/obo/BFO_0000144> .
+_:a0caeec31770247fe2efeb443e85fefe9b4e1648a7d9569adc35d2972b77682b1_target_list_1 rdf:rest rdf:nil .
+
+<http://www.w3.org/ns/ssn/isProxyFor> rdfs:domain <http://www.w3.org/ns/ssn/Stimulus> .
+
+<http://www.w3.org/ns/ssn/isProxyFor> rdfs:range <http://www.w3.org/ns/ssn/Property> .
+
+<http://www.w3.org/ns/ssn/systems/Accuracy> rdfs:subClassOf _:a0aae335885ecdd46575658fe71c7cf073d4dcdda299250671a41f4ab3447536c_target .
+_:a0aae335885ecdd46575658fe71c7cf073d4dcdda299250671a41f4ab3447536c_target rdf:type owl:Class .
+_:a0aae335885ecdd46575658fe71c7cf073d4dcdda299250671a41f4ab3447536c_target owl:intersectionOf _:a0aae335885ecdd46575658fe71c7cf073d4dcdda299250671a41f4ab3447536c_target_list_0 .
+_:a0aae335885ecdd46575658fe71c7cf073d4dcdda299250671a41f4ab3447536c_target_list_0 rdf:first <http://purl.obolibrary.org/obo/BFO_0000034> .
+_:a0aae335885ecdd46575658fe71c7cf073d4dcdda299250671a41f4ab3447536c_target_list_0 rdf:rest _:a0aae335885ecdd46575658fe71c7cf073d4dcdda299250671a41f4ab3447536c_target_list_1 .
+_:a0aae335885ecdd46575658fe71c7cf073d4dcdda299250671a41f4ab3447536c_target_list_1 rdf:first _:a0aae335885ecdd46575658fe71c7cf073d4dcdda299250671a41f4ab3447536c_target_child_1 .
+_:a0aae335885ecdd46575658fe71c7cf073d4dcdda299250671a41f4ab3447536c_target_list_1 rdf:rest rdf:nil .
+_:a0aae335885ecdd46575658fe71c7cf073d4dcdda299250671a41f4ab3447536c_target_child_1 rdf:type owl:Restriction .
+_:a0aae335885ecdd46575658fe71c7cf073d4dcdda299250671a41f4ab3447536c_target_child_1 owl:onProperty <http://purl.obolibrary.org/obo/BFO_0000054> .
+_:a0aae335885ecdd46575658fe71c7cf073d4dcdda299250671a41f4ab3447536c_target_child_1 owl:someValuesFrom _:a0aae335885ecdd46575658fe71c7cf073d4dcdda299250671a41f4ab3447536c_target_child_1_filler .
+_:a0aae335885ecdd46575658fe71c7cf073d4dcdda299250671a41f4ab3447536c_target_child_1_filler rdf:type owl:Class .
+_:a0aae335885ecdd46575658fe71c7cf073d4dcdda299250671a41f4ab3447536c_target_child_1_filler owl:intersectionOf _:a0aae335885ecdd46575658fe71c7cf073d4dcdda299250671a41f4ab3447536c_target_child_1_filler_list_0 .
+_:a0aae335885ecdd46575658fe71c7cf073d4dcdda299250671a41f4ab3447536c_target_child_1_filler_list_0 rdf:first <http://purl.obolibrary.org/obo/BFO_0000015> .
+_:a0aae335885ecdd46575658fe71c7cf073d4dcdda299250671a41f4ab3447536c_target_child_1_filler_list_0 rdf:rest _:a0aae335885ecdd46575658fe71c7cf073d4dcdda299250671a41f4ab3447536c_target_child_1_filler_list_1 .
+_:a0aae335885ecdd46575658fe71c7cf073d4dcdda299250671a41f4ab3447536c_target_child_1_filler_list_1 rdf:first _:a0aae335885ecdd46575658fe71c7cf073d4dcdda299250671a41f4ab3447536c_target_child_1_filler_child_1 .
+_:a0aae335885ecdd46575658fe71c7cf073d4dcdda299250671a41f4ab3447536c_target_child_1_filler_list_1 rdf:rest rdf:nil .
+_:a0aae335885ecdd46575658fe71c7cf073d4dcdda299250671a41f4ab3447536c_target_child_1_filler_child_1 rdf:type owl:Restriction .
+_:a0aae335885ecdd46575658fe71c7cf073d4dcdda299250671a41f4ab3447536c_target_child_1_filler_child_1 owl:onProperty <https://www.commoncoreontologies.org/ont00001801> .
+_:a0aae335885ecdd46575658fe71c7cf073d4dcdda299250671a41f4ab3447536c_target_child_1_filler_child_1 owl:someValuesFrom _:a0aae335885ecdd46575658fe71c7cf073d4dcdda299250671a41f4ab3447536c_target_child_1_filler_child_1_filler .
+_:a0aae335885ecdd46575658fe71c7cf073d4dcdda299250671a41f4ab3447536c_target_child_1_filler_child_1_filler rdf:type owl:Class .
+_:a0aae335885ecdd46575658fe71c7cf073d4dcdda299250671a41f4ab3447536c_target_child_1_filler_child_1_filler owl:intersectionOf _:a0aae335885ecdd46575658fe71c7cf073d4dcdda299250671a41f4ab3447536c_target_child_1_filler_child_1_filler_list_0 .
+_:a0aae335885ecdd46575658fe71c7cf073d4dcdda299250671a41f4ab3447536c_target_child_1_filler_child_1_filler_list_0 rdf:first <https://www.commoncoreontologies.org/ont00000853> .
+_:a0aae335885ecdd46575658fe71c7cf073d4dcdda299250671a41f4ab3447536c_target_child_1_filler_child_1_filler_list_0 rdf:rest _:a0aae335885ecdd46575658fe71c7cf073d4dcdda299250671a41f4ab3447536c_target_child_1_filler_child_1_filler_list_1 .
+_:a0aae335885ecdd46575658fe71c7cf073d4dcdda299250671a41f4ab3447536c_target_child_1_filler_child_1_filler_list_1 rdf:first _:a0aae335885ecdd46575658fe71c7cf073d4dcdda299250671a41f4ab3447536c_target_child_1_filler_child_1_filler_child_1 .
+_:a0aae335885ecdd46575658fe71c7cf073d4dcdda299250671a41f4ab3447536c_target_child_1_filler_child_1_filler_list_1 rdf:rest rdf:nil .
+_:a0aae335885ecdd46575658fe71c7cf073d4dcdda299250671a41f4ab3447536c_target_child_1_filler_child_1_filler_child_1 rdf:type owl:Restriction .
+_:a0aae335885ecdd46575658fe71c7cf073d4dcdda299250671a41f4ab3447536c_target_child_1_filler_child_1_filler_child_1 owl:onProperty <https://www.commoncoreontologies.org/ont00001904> .
+_:a0aae335885ecdd46575658fe71c7cf073d4dcdda299250671a41f4ab3447536c_target_child_1_filler_child_1_filler_child_1 owl:someValuesFrom _:a0aae335885ecdd46575658fe71c7cf073d4dcdda299250671a41f4ab3447536c_target_child_1_filler_child_1_filler_child_1_filler .
+_:a0aae335885ecdd46575658fe71c7cf073d4dcdda299250671a41f4ab3447536c_target_child_1_filler_child_1_filler_child_1_filler rdf:type owl:Class .
+_:a0aae335885ecdd46575658fe71c7cf073d4dcdda299250671a41f4ab3447536c_target_child_1_filler_child_1_filler_child_1_filler owl:intersectionOf _:a0aae335885ecdd46575658fe71c7cf073d4dcdda299250671a41f4ab3447536c_target_child_1_filler_child_1_filler_child_1_filler_list_0 .
+_:a0aae335885ecdd46575658fe71c7cf073d4dcdda299250671a41f4ab3447536c_target_child_1_filler_child_1_filler_child_1_filler_list_0 rdf:first <https://www.commoncoreontologies.org/ont00000592> .
+_:a0aae335885ecdd46575658fe71c7cf073d4dcdda299250671a41f4ab3447536c_target_child_1_filler_child_1_filler_child_1_filler_list_0 rdf:rest _:a0aae335885ecdd46575658fe71c7cf073d4dcdda299250671a41f4ab3447536c_target_child_1_filler_child_1_filler_child_1_filler_list_1 .
+_:a0aae335885ecdd46575658fe71c7cf073d4dcdda299250671a41f4ab3447536c_target_child_1_filler_child_1_filler_child_1_filler_list_1 rdf:first _:a0aae335885ecdd46575658fe71c7cf073d4dcdda299250671a41f4ab3447536c_target_child_1_filler_child_1_filler_child_1_filler_child_1 .
+_:a0aae335885ecdd46575658fe71c7cf073d4dcdda299250671a41f4ab3447536c_target_child_1_filler_child_1_filler_child_1_filler_list_1 rdf:rest rdf:nil .
+_:a0aae335885ecdd46575658fe71c7cf073d4dcdda299250671a41f4ab3447536c_target_child_1_filler_child_1_filler_child_1_filler_child_1 rdf:type owl:Restriction .
+_:a0aae335885ecdd46575658fe71c7cf073d4dcdda299250671a41f4ab3447536c_target_child_1_filler_child_1_filler_child_1_filler_child_1 owl:onProperty <https://www.commoncoreontologies.org/ont00001920> .
+_:a0aae335885ecdd46575658fe71c7cf073d4dcdda299250671a41f4ab3447536c_target_child_1_filler_child_1_filler_child_1_filler_child_1 owl:someValuesFrom <https://www.commoncoreontologies.org/ont00000118> .
+
+<http://www.w3.org/ns/ssn/systems/ActuationRange> rdfs:subClassOf _:a04f2e1c545b6c6f252d9cf377e1e1f325bafa846d37c6b75a975a692ea059963_target .
+_:a04f2e1c545b6c6f252d9cf377e1e1f325bafa846d37c6b75a975a692ea059963_target rdf:type owl:Class .
+_:a04f2e1c545b6c6f252d9cf377e1e1f325bafa846d37c6b75a975a692ea059963_target owl:intersectionOf _:a04f2e1c545b6c6f252d9cf377e1e1f325bafa846d37c6b75a975a692ea059963_target_list_0 .
+_:a04f2e1c545b6c6f252d9cf377e1e1f325bafa846d37c6b75a975a692ea059963_target_list_0 rdf:first <http://purl.obolibrary.org/obo/BFO_0000034> .
+_:a04f2e1c545b6c6f252d9cf377e1e1f325bafa846d37c6b75a975a692ea059963_target_list_0 rdf:rest _:a04f2e1c545b6c6f252d9cf377e1e1f325bafa846d37c6b75a975a692ea059963_target_list_1 .
+_:a04f2e1c545b6c6f252d9cf377e1e1f325bafa846d37c6b75a975a692ea059963_target_list_1 rdf:first _:a04f2e1c545b6c6f252d9cf377e1e1f325bafa846d37c6b75a975a692ea059963_target_child_1 .
+_:a04f2e1c545b6c6f252d9cf377e1e1f325bafa846d37c6b75a975a692ea059963_target_list_1 rdf:rest rdf:nil .
+_:a04f2e1c545b6c6f252d9cf377e1e1f325bafa846d37c6b75a975a692ea059963_target_child_1 rdf:type owl:Restriction .
+_:a04f2e1c545b6c6f252d9cf377e1e1f325bafa846d37c6b75a975a692ea059963_target_child_1 owl:onProperty <http://purl.obolibrary.org/obo/BFO_0000054> .
+_:a04f2e1c545b6c6f252d9cf377e1e1f325bafa846d37c6b75a975a692ea059963_target_child_1 owl:someValuesFrom _:a04f2e1c545b6c6f252d9cf377e1e1f325bafa846d37c6b75a975a692ea059963_target_child_1_filler .
+_:a04f2e1c545b6c6f252d9cf377e1e1f325bafa846d37c6b75a975a692ea059963_target_child_1_filler rdf:type owl:Class .
+_:a04f2e1c545b6c6f252d9cf377e1e1f325bafa846d37c6b75a975a692ea059963_target_child_1_filler owl:intersectionOf _:a04f2e1c545b6c6f252d9cf377e1e1f325bafa846d37c6b75a975a692ea059963_target_child_1_filler_list_0 .
+_:a04f2e1c545b6c6f252d9cf377e1e1f325bafa846d37c6b75a975a692ea059963_target_child_1_filler_list_0 rdf:first <http://www.w3.org/ns/sosa/Actuation> .
+_:a04f2e1c545b6c6f252d9cf377e1e1f325bafa846d37c6b75a975a692ea059963_target_child_1_filler_list_0 rdf:rest _:a04f2e1c545b6c6f252d9cf377e1e1f325bafa846d37c6b75a975a692ea059963_target_child_1_filler_list_1 .
+_:a04f2e1c545b6c6f252d9cf377e1e1f325bafa846d37c6b75a975a692ea059963_target_child_1_filler_list_1 rdf:first _:a04f2e1c545b6c6f252d9cf377e1e1f325bafa846d37c6b75a975a692ea059963_target_child_1_filler_child_1 .
+_:a04f2e1c545b6c6f252d9cf377e1e1f325bafa846d37c6b75a975a692ea059963_target_child_1_filler_list_1 rdf:rest rdf:nil .
+_:a04f2e1c545b6c6f252d9cf377e1e1f325bafa846d37c6b75a975a692ea059963_target_child_1_filler_child_1 rdf:type owl:Class .
+_:a04f2e1c545b6c6f252d9cf377e1e1f325bafa846d37c6b75a975a692ea059963_target_child_1_filler_child_1 owl:intersectionOf _:a04f2e1c545b6c6f252d9cf377e1e1f325bafa846d37c6b75a975a692ea059963_target_child_1_filler_child_1_list_0 .
+_:a04f2e1c545b6c6f252d9cf377e1e1f325bafa846d37c6b75a975a692ea059963_target_child_1_filler_child_1_list_0 rdf:first _:a04f2e1c545b6c6f252d9cf377e1e1f325bafa846d37c6b75a975a692ea059963_target_child_1_filler_child_1_child_0 .
+_:a04f2e1c545b6c6f252d9cf377e1e1f325bafa846d37c6b75a975a692ea059963_target_child_1_filler_child_1_list_0 rdf:rest _:a04f2e1c545b6c6f252d9cf377e1e1f325bafa846d37c6b75a975a692ea059963_target_child_1_filler_child_1_list_1 .
+_:a04f2e1c545b6c6f252d9cf377e1e1f325bafa846d37c6b75a975a692ea059963_target_child_1_filler_child_1_list_1 rdf:first _:a04f2e1c545b6c6f252d9cf377e1e1f325bafa846d37c6b75a975a692ea059963_target_child_1_filler_child_1_child_1 .
+_:a04f2e1c545b6c6f252d9cf377e1e1f325bafa846d37c6b75a975a692ea059963_target_child_1_filler_child_1_list_1 rdf:rest rdf:nil .
+_:a04f2e1c545b6c6f252d9cf377e1e1f325bafa846d37c6b75a975a692ea059963_target_child_1_filler_child_1_child_0 rdf:type owl:Restriction .
+_:a04f2e1c545b6c6f252d9cf377e1e1f325bafa846d37c6b75a975a692ea059963_target_child_1_filler_child_1_child_0 owl:onProperty <https://www.commoncoreontologies.org/ont00001986> .
+_:a04f2e1c545b6c6f252d9cf377e1e1f325bafa846d37c6b75a975a692ea059963_target_child_1_filler_child_1_child_0 owl:someValuesFrom <http://purl.obolibrary.org/obo/BFO_0000020> .
+_:a04f2e1c545b6c6f252d9cf377e1e1f325bafa846d37c6b75a975a692ea059963_target_child_1_filler_child_1_child_1 rdf:type owl:Restriction .
+_:a04f2e1c545b6c6f252d9cf377e1e1f325bafa846d37c6b75a975a692ea059963_target_child_1_filler_child_1_child_1 owl:onProperty <https://www.commoncoreontologies.org/ont00001920> .
+_:a04f2e1c545b6c6f252d9cf377e1e1f325bafa846d37c6b75a975a692ea059963_target_child_1_filler_child_1_child_1 owl:someValuesFrom <https://www.commoncoreontologies.org/ont00000118> .
+
+<http://www.w3.org/ns/ssn/systems/BatteryLifetime> rdfs:subClassOf _:adcf3f04234e744a132f942e4d0ce6fe2bb71420cf0c3de60b8163d8b6d9ffe4a_target .
+_:adcf3f04234e744a132f942e4d0ce6fe2bb71420cf0c3de60b8163d8b6d9ffe4a_target rdf:type owl:Class .
+_:adcf3f04234e744a132f942e4d0ce6fe2bb71420cf0c3de60b8163d8b6d9ffe4a_target owl:intersectionOf _:adcf3f04234e744a132f942e4d0ce6fe2bb71420cf0c3de60b8163d8b6d9ffe4a_target_list_0 .
+_:adcf3f04234e744a132f942e4d0ce6fe2bb71420cf0c3de60b8163d8b6d9ffe4a_target_list_0 rdf:first <http://purl.obolibrary.org/obo/BFO_0000034> .
+_:adcf3f04234e744a132f942e4d0ce6fe2bb71420cf0c3de60b8163d8b6d9ffe4a_target_list_0 rdf:rest _:adcf3f04234e744a132f942e4d0ce6fe2bb71420cf0c3de60b8163d8b6d9ffe4a_target_list_1 .
+_:adcf3f04234e744a132f942e4d0ce6fe2bb71420cf0c3de60b8163d8b6d9ffe4a_target_list_1 rdf:first _:adcf3f04234e744a132f942e4d0ce6fe2bb71420cf0c3de60b8163d8b6d9ffe4a_target_child_1 .
+_:adcf3f04234e744a132f942e4d0ce6fe2bb71420cf0c3de60b8163d8b6d9ffe4a_target_list_1 rdf:rest rdf:nil .
+_:adcf3f04234e744a132f942e4d0ce6fe2bb71420cf0c3de60b8163d8b6d9ffe4a_target_child_1 rdf:type owl:Restriction .
+_:adcf3f04234e744a132f942e4d0ce6fe2bb71420cf0c3de60b8163d8b6d9ffe4a_target_child_1 owl:onProperty <http://purl.obolibrary.org/obo/BFO_0000054> .
+_:adcf3f04234e744a132f942e4d0ce6fe2bb71420cf0c3de60b8163d8b6d9ffe4a_target_child_1 owl:someValuesFrom _:adcf3f04234e744a132f942e4d0ce6fe2bb71420cf0c3de60b8163d8b6d9ffe4a_target_child_1_filler .
+_:adcf3f04234e744a132f942e4d0ce6fe2bb71420cf0c3de60b8163d8b6d9ffe4a_target_child_1_filler rdf:type owl:Class .
+_:adcf3f04234e744a132f942e4d0ce6fe2bb71420cf0c3de60b8163d8b6d9ffe4a_target_child_1_filler owl:intersectionOf _:adcf3f04234e744a132f942e4d0ce6fe2bb71420cf0c3de60b8163d8b6d9ffe4a_target_child_1_filler_list_0 .
+_:adcf3f04234e744a132f942e4d0ce6fe2bb71420cf0c3de60b8163d8b6d9ffe4a_target_child_1_filler_list_0 rdf:first <https://www.commoncoreontologies.org/ont00001213> .
+_:adcf3f04234e744a132f942e4d0ce6fe2bb71420cf0c3de60b8163d8b6d9ffe4a_target_child_1_filler_list_0 rdf:rest _:adcf3f04234e744a132f942e4d0ce6fe2bb71420cf0c3de60b8163d8b6d9ffe4a_target_child_1_filler_list_1 .
+_:adcf3f04234e744a132f942e4d0ce6fe2bb71420cf0c3de60b8163d8b6d9ffe4a_target_child_1_filler_list_1 rdf:first _:adcf3f04234e744a132f942e4d0ce6fe2bb71420cf0c3de60b8163d8b6d9ffe4a_target_child_1_filler_child_1 .
+_:adcf3f04234e744a132f942e4d0ce6fe2bb71420cf0c3de60b8163d8b6d9ffe4a_target_child_1_filler_list_1 rdf:rest _:adcf3f04234e744a132f942e4d0ce6fe2bb71420cf0c3de60b8163d8b6d9ffe4a_target_child_1_filler_list_2 .
+_:adcf3f04234e744a132f942e4d0ce6fe2bb71420cf0c3de60b8163d8b6d9ffe4a_target_child_1_filler_list_2 rdf:first _:adcf3f04234e744a132f942e4d0ce6fe2bb71420cf0c3de60b8163d8b6d9ffe4a_target_child_1_filler_child_2 .
+_:adcf3f04234e744a132f942e4d0ce6fe2bb71420cf0c3de60b8163d8b6d9ffe4a_target_child_1_filler_list_2 rdf:rest rdf:nil .
+_:adcf3f04234e744a132f942e4d0ce6fe2bb71420cf0c3de60b8163d8b6d9ffe4a_target_child_1_filler_child_1 rdf:type owl:Restriction .
+_:adcf3f04234e744a132f942e4d0ce6fe2bb71420cf0c3de60b8163d8b6d9ffe4a_target_child_1_filler_child_1 owl:onProperty <http://purl.obolibrary.org/obo/BFO_0000117> .
+_:adcf3f04234e744a132f942e4d0ce6fe2bb71420cf0c3de60b8163d8b6d9ffe4a_target_child_1_filler_child_1 owl:someValuesFrom <https://www.commoncoreontologies.org/ont00000503> .
+_:adcf3f04234e744a132f942e4d0ce6fe2bb71420cf0c3de60b8163d8b6d9ffe4a_target_child_1_filler_child_2 rdf:type owl:Restriction .
+_:adcf3f04234e744a132f942e4d0ce6fe2bb71420cf0c3de60b8163d8b6d9ffe4a_target_child_1_filler_child_2 owl:onProperty <https://www.commoncoreontologies.org/ont00001819> .
+_:adcf3f04234e744a132f942e4d0ce6fe2bb71420cf0c3de60b8163d8b6d9ffe4a_target_child_1_filler_child_2 owl:someValuesFrom _:adcf3f04234e744a132f942e4d0ce6fe2bb71420cf0c3de60b8163d8b6d9ffe4a_target_child_1_filler_child_2_filler .
+_:adcf3f04234e744a132f942e4d0ce6fe2bb71420cf0c3de60b8163d8b6d9ffe4a_target_child_1_filler_child_2_filler rdf:type owl:Class .
+_:adcf3f04234e744a132f942e4d0ce6fe2bb71420cf0c3de60b8163d8b6d9ffe4a_target_child_1_filler_child_2_filler owl:intersectionOf _:adcf3f04234e744a132f942e4d0ce6fe2bb71420cf0c3de60b8163d8b6d9ffe4a_target_child_1_filler_child_2_filler_list_0 .
+_:adcf3f04234e744a132f942e4d0ce6fe2bb71420cf0c3de60b8163d8b6d9ffe4a_target_child_1_filler_child_2_filler_list_0 rdf:first <http://purl.obolibrary.org/obo/BFO_0000015> .
+_:adcf3f04234e744a132f942e4d0ce6fe2bb71420cf0c3de60b8163d8b6d9ffe4a_target_child_1_filler_child_2_filler_list_0 rdf:rest _:adcf3f04234e744a132f942e4d0ce6fe2bb71420cf0c3de60b8163d8b6d9ffe4a_target_child_1_filler_child_2_filler_list_1 .
+_:adcf3f04234e744a132f942e4d0ce6fe2bb71420cf0c3de60b8163d8b6d9ffe4a_target_child_1_filler_child_2_filler_list_1 rdf:first _:adcf3f04234e744a132f942e4d0ce6fe2bb71420cf0c3de60b8163d8b6d9ffe4a_target_child_1_filler_child_2_filler_child_1 .
+_:adcf3f04234e744a132f942e4d0ce6fe2bb71420cf0c3de60b8163d8b6d9ffe4a_target_child_1_filler_child_2_filler_list_1 rdf:rest rdf:nil .
+_:adcf3f04234e744a132f942e4d0ce6fe2bb71420cf0c3de60b8163d8b6d9ffe4a_target_child_1_filler_child_2_filler_child_1 rdf:type owl:Restriction .
+_:adcf3f04234e744a132f942e4d0ce6fe2bb71420cf0c3de60b8163d8b6d9ffe4a_target_child_1_filler_child_2_filler_child_1 owl:onProperty <http://purl.obolibrary.org/obo/BFO_0000055> .
+_:adcf3f04234e744a132f942e4d0ce6fe2bb71420cf0c3de60b8163d8b6d9ffe4a_target_child_1_filler_child_2_filler_child_1 owl:someValuesFrom _:adcf3f04234e744a132f942e4d0ce6fe2bb71420cf0c3de60b8163d8b6d9ffe4a_target_child_1_filler_child_2_filler_child_1_filler .
+_:adcf3f04234e744a132f942e4d0ce6fe2bb71420cf0c3de60b8163d8b6d9ffe4a_target_child_1_filler_child_2_filler_child_1_filler rdf:type owl:Class .
+_:adcf3f04234e744a132f942e4d0ce6fe2bb71420cf0c3de60b8163d8b6d9ffe4a_target_child_1_filler_child_2_filler_child_1_filler owl:intersectionOf _:adcf3f04234e744a132f942e4d0ce6fe2bb71420cf0c3de60b8163d8b6d9ffe4a_target_child_1_filler_child_2_filler_child_1_filler_list_0 .
+_:adcf3f04234e744a132f942e4d0ce6fe2bb71420cf0c3de60b8163d8b6d9ffe4a_target_child_1_filler_child_2_filler_child_1_filler_list_0 rdf:first <https://www.commoncoreontologies.org/ont00000177> .
+_:adcf3f04234e744a132f942e4d0ce6fe2bb71420cf0c3de60b8163d8b6d9ffe4a_target_child_1_filler_child_2_filler_child_1_filler_list_0 rdf:rest _:adcf3f04234e744a132f942e4d0ce6fe2bb71420cf0c3de60b8163d8b6d9ffe4a_target_child_1_filler_child_2_filler_child_1_filler_list_1 .
+_:adcf3f04234e744a132f942e4d0ce6fe2bb71420cf0c3de60b8163d8b6d9ffe4a_target_child_1_filler_child_2_filler_child_1_filler_list_1 rdf:first _:adcf3f04234e744a132f942e4d0ce6fe2bb71420cf0c3de60b8163d8b6d9ffe4a_target_child_1_filler_child_2_filler_child_1_filler_child_1 .
+_:adcf3f04234e744a132f942e4d0ce6fe2bb71420cf0c3de60b8163d8b6d9ffe4a_target_child_1_filler_child_2_filler_child_1_filler_list_1 rdf:rest rdf:nil .
+_:adcf3f04234e744a132f942e4d0ce6fe2bb71420cf0c3de60b8163d8b6d9ffe4a_target_child_1_filler_child_2_filler_child_1_filler_child_1 rdf:type owl:Restriction .
+_:adcf3f04234e744a132f942e4d0ce6fe2bb71420cf0c3de60b8163d8b6d9ffe4a_target_child_1_filler_child_2_filler_child_1_filler_child_1 owl:onProperty <https://www.commoncoreontologies.org/ont00001920> .
+_:adcf3f04234e744a132f942e4d0ce6fe2bb71420cf0c3de60b8163d8b6d9ffe4a_target_child_1_filler_child_2_filler_child_1_filler_child_1 owl:someValuesFrom <https://www.commoncoreontologies.org/ont00000319> .
+
+<http://www.w3.org/ns/ssn/systems/Condition> rdfs:subClassOf _:a3555605bb2df608876e70c42ec20fa13f80abde4df1a61953beef445621384e2_target .
+_:a3555605bb2df608876e70c42ec20fa13f80abde4df1a61953beef445621384e2_target rdf:type owl:Class .
+_:a3555605bb2df608876e70c42ec20fa13f80abde4df1a61953beef445621384e2_target owl:intersectionOf _:a3555605bb2df608876e70c42ec20fa13f80abde4df1a61953beef445621384e2_target_list_0 .
+_:a3555605bb2df608876e70c42ec20fa13f80abde4df1a61953beef445621384e2_target_list_0 rdf:first _:a3555605bb2df608876e70c42ec20fa13f80abde4df1a61953beef445621384e2_target_child_0 .
+_:a3555605bb2df608876e70c42ec20fa13f80abde4df1a61953beef445621384e2_target_list_0 rdf:rest _:a3555605bb2df608876e70c42ec20fa13f80abde4df1a61953beef445621384e2_target_list_1 .
+_:a3555605bb2df608876e70c42ec20fa13f80abde4df1a61953beef445621384e2_target_list_1 rdf:first _:a3555605bb2df608876e70c42ec20fa13f80abde4df1a61953beef445621384e2_target_child_1 .
+_:a3555605bb2df608876e70c42ec20fa13f80abde4df1a61953beef445621384e2_target_list_1 rdf:rest rdf:nil .
+_:a3555605bb2df608876e70c42ec20fa13f80abde4df1a61953beef445621384e2_target_child_0 rdf:type owl:Class .
+_:a3555605bb2df608876e70c42ec20fa13f80abde4df1a61953beef445621384e2_target_child_0 owl:unionOf _:a3555605bb2df608876e70c42ec20fa13f80abde4df1a61953beef445621384e2_target_child_0_list_0 .
+_:a3555605bb2df608876e70c42ec20fa13f80abde4df1a61953beef445621384e2_target_child_0_list_0 rdf:first <http://purl.obolibrary.org/obo/BFO_0000020> .
+_:a3555605bb2df608876e70c42ec20fa13f80abde4df1a61953beef445621384e2_target_child_0_list_0 rdf:rest _:a3555605bb2df608876e70c42ec20fa13f80abde4df1a61953beef445621384e2_target_child_0_list_1 .
+_:a3555605bb2df608876e70c42ec20fa13f80abde4df1a61953beef445621384e2_target_child_0_list_1 rdf:first <http://purl.obolibrary.org/obo/BFO_0000144> .
+_:a3555605bb2df608876e70c42ec20fa13f80abde4df1a61953beef445621384e2_target_child_0_list_1 rdf:rest rdf:nil .
+_:a3555605bb2df608876e70c42ec20fa13f80abde4df1a61953beef445621384e2_target_child_1 rdf:type owl:Restriction .
+_:a3555605bb2df608876e70c42ec20fa13f80abde4df1a61953beef445621384e2_target_child_1 owl:onProperty <https://www.commoncoreontologies.org/ont00001884> .
+_:a3555605bb2df608876e70c42ec20fa13f80abde4df1a61953beef445621384e2_target_child_1 owl:someValuesFrom <https://www.commoncoreontologies.org/ont00000127> .
+
+<http://www.w3.org/ns/ssn/systems/DetectionLimit> rdfs:subClassOf _:a25eb572d7c35d5e480c606eddf558b7b5e986136f82f7da5657c857653b81705_target .
+_:a25eb572d7c35d5e480c606eddf558b7b5e986136f82f7da5657c857653b81705_target rdf:type owl:Class .
+_:a25eb572d7c35d5e480c606eddf558b7b5e986136f82f7da5657c857653b81705_target owl:intersectionOf _:a25eb572d7c35d5e480c606eddf558b7b5e986136f82f7da5657c857653b81705_target_list_0 .
+_:a25eb572d7c35d5e480c606eddf558b7b5e986136f82f7da5657c857653b81705_target_list_0 rdf:first <http://purl.obolibrary.org/obo/BFO_0000034> .
+_:a25eb572d7c35d5e480c606eddf558b7b5e986136f82f7da5657c857653b81705_target_list_0 rdf:rest _:a25eb572d7c35d5e480c606eddf558b7b5e986136f82f7da5657c857653b81705_target_list_1 .
+_:a25eb572d7c35d5e480c606eddf558b7b5e986136f82f7da5657c857653b81705_target_list_1 rdf:first _:a25eb572d7c35d5e480c606eddf558b7b5e986136f82f7da5657c857653b81705_target_child_1 .
+_:a25eb572d7c35d5e480c606eddf558b7b5e986136f82f7da5657c857653b81705_target_list_1 rdf:rest rdf:nil .
+_:a25eb572d7c35d5e480c606eddf558b7b5e986136f82f7da5657c857653b81705_target_child_1 rdf:type owl:Restriction .
+_:a25eb572d7c35d5e480c606eddf558b7b5e986136f82f7da5657c857653b81705_target_child_1 owl:onProperty <http://purl.obolibrary.org/obo/BFO_0000054> .
+_:a25eb572d7c35d5e480c606eddf558b7b5e986136f82f7da5657c857653b81705_target_child_1 owl:someValuesFrom _:a25eb572d7c35d5e480c606eddf558b7b5e986136f82f7da5657c857653b81705_target_child_1_filler .
+_:a25eb572d7c35d5e480c606eddf558b7b5e986136f82f7da5657c857653b81705_target_child_1_filler rdf:type owl:Class .
+_:a25eb572d7c35d5e480c606eddf558b7b5e986136f82f7da5657c857653b81705_target_child_1_filler owl:intersectionOf _:a25eb572d7c35d5e480c606eddf558b7b5e986136f82f7da5657c857653b81705_target_child_1_filler_list_0 .
+_:a25eb572d7c35d5e480c606eddf558b7b5e986136f82f7da5657c857653b81705_target_child_1_filler_list_0 rdf:first <http://purl.obolibrary.org/obo/BFO_0000015> .
+_:a25eb572d7c35d5e480c606eddf558b7b5e986136f82f7da5657c857653b81705_target_child_1_filler_list_0 rdf:rest _:a25eb572d7c35d5e480c606eddf558b7b5e986136f82f7da5657c857653b81705_target_child_1_filler_list_1 .
+_:a25eb572d7c35d5e480c606eddf558b7b5e986136f82f7da5657c857653b81705_target_child_1_filler_list_1 rdf:first _:a25eb572d7c35d5e480c606eddf558b7b5e986136f82f7da5657c857653b81705_target_child_1_filler_child_1 .
+_:a25eb572d7c35d5e480c606eddf558b7b5e986136f82f7da5657c857653b81705_target_child_1_filler_list_1 rdf:rest rdf:nil .
+_:a25eb572d7c35d5e480c606eddf558b7b5e986136f82f7da5657c857653b81705_target_child_1_filler_child_1 rdf:type owl:Restriction .
+_:a25eb572d7c35d5e480c606eddf558b7b5e986136f82f7da5657c857653b81705_target_child_1_filler_child_1 owl:onProperty <https://www.commoncoreontologies.org/ont00001801> .
+_:a25eb572d7c35d5e480c606eddf558b7b5e986136f82f7da5657c857653b81705_target_child_1_filler_child_1 owl:someValuesFrom _:a25eb572d7c35d5e480c606eddf558b7b5e986136f82f7da5657c857653b81705_target_child_1_filler_child_1_filler .
+_:a25eb572d7c35d5e480c606eddf558b7b5e986136f82f7da5657c857653b81705_target_child_1_filler_child_1_filler rdf:type owl:Class .
+_:a25eb572d7c35d5e480c606eddf558b7b5e986136f82f7da5657c857653b81705_target_child_1_filler_child_1_filler owl:intersectionOf _:a25eb572d7c35d5e480c606eddf558b7b5e986136f82f7da5657c857653b81705_target_child_1_filler_child_1_filler_list_0 .
+_:a25eb572d7c35d5e480c606eddf558b7b5e986136f82f7da5657c857653b81705_target_child_1_filler_child_1_filler_list_0 rdf:first <https://www.commoncoreontologies.org/ont00000853> .
+_:a25eb572d7c35d5e480c606eddf558b7b5e986136f82f7da5657c857653b81705_target_child_1_filler_child_1_filler_list_0 rdf:rest _:a25eb572d7c35d5e480c606eddf558b7b5e986136f82f7da5657c857653b81705_target_child_1_filler_child_1_filler_list_1 .
+_:a25eb572d7c35d5e480c606eddf558b7b5e986136f82f7da5657c857653b81705_target_child_1_filler_child_1_filler_list_1 rdf:first _:a25eb572d7c35d5e480c606eddf558b7b5e986136f82f7da5657c857653b81705_target_child_1_filler_child_1_filler_child_1 .
+_:a25eb572d7c35d5e480c606eddf558b7b5e986136f82f7da5657c857653b81705_target_child_1_filler_child_1_filler_list_1 rdf:rest rdf:nil .
+_:a25eb572d7c35d5e480c606eddf558b7b5e986136f82f7da5657c857653b81705_target_child_1_filler_child_1_filler_child_1 rdf:type owl:Restriction .
+_:a25eb572d7c35d5e480c606eddf558b7b5e986136f82f7da5657c857653b81705_target_child_1_filler_child_1_filler_child_1 owl:onProperty <https://www.commoncoreontologies.org/ont00001904> .
+_:a25eb572d7c35d5e480c606eddf558b7b5e986136f82f7da5657c857653b81705_target_child_1_filler_child_1_filler_child_1 owl:someValuesFrom _:a25eb572d7c35d5e480c606eddf558b7b5e986136f82f7da5657c857653b81705_target_child_1_filler_child_1_filler_child_1_filler .
+_:a25eb572d7c35d5e480c606eddf558b7b5e986136f82f7da5657c857653b81705_target_child_1_filler_child_1_filler_child_1_filler rdf:type owl:Class .
+_:a25eb572d7c35d5e480c606eddf558b7b5e986136f82f7da5657c857653b81705_target_child_1_filler_child_1_filler_child_1_filler owl:intersectionOf _:a25eb572d7c35d5e480c606eddf558b7b5e986136f82f7da5657c857653b81705_target_child_1_filler_child_1_filler_child_1_filler_list_0 .
+_:a25eb572d7c35d5e480c606eddf558b7b5e986136f82f7da5657c857653b81705_target_child_1_filler_child_1_filler_child_1_filler_list_0 rdf:first <https://www.commoncoreontologies.org/ont00000592> .
+_:a25eb572d7c35d5e480c606eddf558b7b5e986136f82f7da5657c857653b81705_target_child_1_filler_child_1_filler_child_1_filler_list_0 rdf:rest _:a25eb572d7c35d5e480c606eddf558b7b5e986136f82f7da5657c857653b81705_target_child_1_filler_child_1_filler_child_1_filler_list_1 .
+_:a25eb572d7c35d5e480c606eddf558b7b5e986136f82f7da5657c857653b81705_target_child_1_filler_child_1_filler_child_1_filler_list_1 rdf:first _:a25eb572d7c35d5e480c606eddf558b7b5e986136f82f7da5657c857653b81705_target_child_1_filler_child_1_filler_child_1_filler_child_1 .
+_:a25eb572d7c35d5e480c606eddf558b7b5e986136f82f7da5657c857653b81705_target_child_1_filler_child_1_filler_child_1_filler_list_1 rdf:rest rdf:nil .
+_:a25eb572d7c35d5e480c606eddf558b7b5e986136f82f7da5657c857653b81705_target_child_1_filler_child_1_filler_child_1_filler_child_1 rdf:type owl:Restriction .
+_:a25eb572d7c35d5e480c606eddf558b7b5e986136f82f7da5657c857653b81705_target_child_1_filler_child_1_filler_child_1_filler_child_1 owl:onProperty <https://www.commoncoreontologies.org/ont00001920> .
+_:a25eb572d7c35d5e480c606eddf558b7b5e986136f82f7da5657c857653b81705_target_child_1_filler_child_1_filler_child_1_filler_child_1 owl:someValuesFrom <https://www.commoncoreontologies.org/ont00000118> .
+
+<http://www.w3.org/ns/ssn/systems/Drift> rdfs:subClassOf _:a7bfe203db92e7e2b6f107641f3edbbcc111a4b9879471d70e1928b2817c0b853_target .
+_:a7bfe203db92e7e2b6f107641f3edbbcc111a4b9879471d70e1928b2817c0b853_target rdf:type owl:Class .
+_:a7bfe203db92e7e2b6f107641f3edbbcc111a4b9879471d70e1928b2817c0b853_target owl:intersectionOf _:a7bfe203db92e7e2b6f107641f3edbbcc111a4b9879471d70e1928b2817c0b853_target_list_0 .
+_:a7bfe203db92e7e2b6f107641f3edbbcc111a4b9879471d70e1928b2817c0b853_target_list_0 rdf:first <http://purl.obolibrary.org/obo/BFO_0000034> .
+_:a7bfe203db92e7e2b6f107641f3edbbcc111a4b9879471d70e1928b2817c0b853_target_list_0 rdf:rest _:a7bfe203db92e7e2b6f107641f3edbbcc111a4b9879471d70e1928b2817c0b853_target_list_1 .
+_:a7bfe203db92e7e2b6f107641f3edbbcc111a4b9879471d70e1928b2817c0b853_target_list_1 rdf:first _:a7bfe203db92e7e2b6f107641f3edbbcc111a4b9879471d70e1928b2817c0b853_target_child_1 .
+_:a7bfe203db92e7e2b6f107641f3edbbcc111a4b9879471d70e1928b2817c0b853_target_list_1 rdf:rest rdf:nil .
+_:a7bfe203db92e7e2b6f107641f3edbbcc111a4b9879471d70e1928b2817c0b853_target_child_1 rdf:type owl:Restriction .
+_:a7bfe203db92e7e2b6f107641f3edbbcc111a4b9879471d70e1928b2817c0b853_target_child_1 owl:onProperty <http://purl.obolibrary.org/obo/BFO_0000054> .
+_:a7bfe203db92e7e2b6f107641f3edbbcc111a4b9879471d70e1928b2817c0b853_target_child_1 owl:someValuesFrom _:a7bfe203db92e7e2b6f107641f3edbbcc111a4b9879471d70e1928b2817c0b853_target_child_1_filler .
+_:a7bfe203db92e7e2b6f107641f3edbbcc111a4b9879471d70e1928b2817c0b853_target_child_1_filler rdf:type owl:Class .
+_:a7bfe203db92e7e2b6f107641f3edbbcc111a4b9879471d70e1928b2817c0b853_target_child_1_filler owl:intersectionOf _:a7bfe203db92e7e2b6f107641f3edbbcc111a4b9879471d70e1928b2817c0b853_target_child_1_filler_list_0 .
+_:a7bfe203db92e7e2b6f107641f3edbbcc111a4b9879471d70e1928b2817c0b853_target_child_1_filler_list_0 rdf:first <http://purl.obolibrary.org/obo/BFO_0000015> .
+_:a7bfe203db92e7e2b6f107641f3edbbcc111a4b9879471d70e1928b2817c0b853_target_child_1_filler_list_0 rdf:rest _:a7bfe203db92e7e2b6f107641f3edbbcc111a4b9879471d70e1928b2817c0b853_target_child_1_filler_list_1 .
+_:a7bfe203db92e7e2b6f107641f3edbbcc111a4b9879471d70e1928b2817c0b853_target_child_1_filler_list_1 rdf:first _:a7bfe203db92e7e2b6f107641f3edbbcc111a4b9879471d70e1928b2817c0b853_target_child_1_filler_child_1 .
+_:a7bfe203db92e7e2b6f107641f3edbbcc111a4b9879471d70e1928b2817c0b853_target_child_1_filler_list_1 rdf:rest rdf:nil .
+_:a7bfe203db92e7e2b6f107641f3edbbcc111a4b9879471d70e1928b2817c0b853_target_child_1_filler_child_1 rdf:type owl:Restriction .
+_:a7bfe203db92e7e2b6f107641f3edbbcc111a4b9879471d70e1928b2817c0b853_target_child_1_filler_child_1 owl:onProperty <https://www.commoncoreontologies.org/ont00001801> .
+_:a7bfe203db92e7e2b6f107641f3edbbcc111a4b9879471d70e1928b2817c0b853_target_child_1_filler_child_1 owl:someValuesFrom _:a7bfe203db92e7e2b6f107641f3edbbcc111a4b9879471d70e1928b2817c0b853_target_child_1_filler_child_1_filler .
+_:a7bfe203db92e7e2b6f107641f3edbbcc111a4b9879471d70e1928b2817c0b853_target_child_1_filler_child_1_filler rdf:type owl:Class .
+_:a7bfe203db92e7e2b6f107641f3edbbcc111a4b9879471d70e1928b2817c0b853_target_child_1_filler_child_1_filler owl:intersectionOf _:a7bfe203db92e7e2b6f107641f3edbbcc111a4b9879471d70e1928b2817c0b853_target_child_1_filler_child_1_filler_list_0 .
+_:a7bfe203db92e7e2b6f107641f3edbbcc111a4b9879471d70e1928b2817c0b853_target_child_1_filler_child_1_filler_list_0 rdf:first <https://www.commoncoreontologies.org/ont00000853> .
+_:a7bfe203db92e7e2b6f107641f3edbbcc111a4b9879471d70e1928b2817c0b853_target_child_1_filler_child_1_filler_list_0 rdf:rest _:a7bfe203db92e7e2b6f107641f3edbbcc111a4b9879471d70e1928b2817c0b853_target_child_1_filler_child_1_filler_list_1 .
+_:a7bfe203db92e7e2b6f107641f3edbbcc111a4b9879471d70e1928b2817c0b853_target_child_1_filler_child_1_filler_list_1 rdf:first _:a7bfe203db92e7e2b6f107641f3edbbcc111a4b9879471d70e1928b2817c0b853_target_child_1_filler_child_1_filler_child_1 .
+_:a7bfe203db92e7e2b6f107641f3edbbcc111a4b9879471d70e1928b2817c0b853_target_child_1_filler_child_1_filler_list_1 rdf:rest rdf:nil .
+_:a7bfe203db92e7e2b6f107641f3edbbcc111a4b9879471d70e1928b2817c0b853_target_child_1_filler_child_1_filler_child_1 rdf:type owl:Restriction .
+_:a7bfe203db92e7e2b6f107641f3edbbcc111a4b9879471d70e1928b2817c0b853_target_child_1_filler_child_1_filler_child_1 owl:onProperty <https://www.commoncoreontologies.org/ont00001904> .
+_:a7bfe203db92e7e2b6f107641f3edbbcc111a4b9879471d70e1928b2817c0b853_target_child_1_filler_child_1_filler_child_1 owl:someValuesFrom _:a7bfe203db92e7e2b6f107641f3edbbcc111a4b9879471d70e1928b2817c0b853_target_child_1_filler_child_1_filler_child_1_filler .
+_:a7bfe203db92e7e2b6f107641f3edbbcc111a4b9879471d70e1928b2817c0b853_target_child_1_filler_child_1_filler_child_1_filler rdf:type owl:Class .
+_:a7bfe203db92e7e2b6f107641f3edbbcc111a4b9879471d70e1928b2817c0b853_target_child_1_filler_child_1_filler_child_1_filler owl:intersectionOf _:a7bfe203db92e7e2b6f107641f3edbbcc111a4b9879471d70e1928b2817c0b853_target_child_1_filler_child_1_filler_child_1_filler_list_0 .
+_:a7bfe203db92e7e2b6f107641f3edbbcc111a4b9879471d70e1928b2817c0b853_target_child_1_filler_child_1_filler_child_1_filler_list_0 rdf:first <https://www.commoncoreontologies.org/ont00000731> .
+_:a7bfe203db92e7e2b6f107641f3edbbcc111a4b9879471d70e1928b2817c0b853_target_child_1_filler_child_1_filler_child_1_filler_list_0 rdf:rest _:a7bfe203db92e7e2b6f107641f3edbbcc111a4b9879471d70e1928b2817c0b853_target_child_1_filler_child_1_filler_child_1_filler_list_1 .
+_:a7bfe203db92e7e2b6f107641f3edbbcc111a4b9879471d70e1928b2817c0b853_target_child_1_filler_child_1_filler_child_1_filler_list_1 rdf:first _:a7bfe203db92e7e2b6f107641f3edbbcc111a4b9879471d70e1928b2817c0b853_target_child_1_filler_child_1_filler_child_1_filler_child_1 .
+_:a7bfe203db92e7e2b6f107641f3edbbcc111a4b9879471d70e1928b2817c0b853_target_child_1_filler_child_1_filler_child_1_filler_list_1 rdf:rest rdf:nil .
+_:a7bfe203db92e7e2b6f107641f3edbbcc111a4b9879471d70e1928b2817c0b853_target_child_1_filler_child_1_filler_child_1_filler_child_1 rdf:type owl:Restriction .
+_:a7bfe203db92e7e2b6f107641f3edbbcc111a4b9879471d70e1928b2817c0b853_target_child_1_filler_child_1_filler_child_1_filler_child_1 owl:onProperty <https://www.commoncoreontologies.org/ont00001920> .
+_:a7bfe203db92e7e2b6f107641f3edbbcc111a4b9879471d70e1928b2817c0b853_target_child_1_filler_child_1_filler_child_1_filler_child_1 owl:someValuesFrom <https://www.commoncoreontologies.org/ont00000118> .
+
+<http://www.w3.org/ns/ssn/systems/Frequency> rdfs:subClassOf _:ad0be6196d522ed9650cdfebad33b965d523868a68682405423324b28c54f1e82_target .
+_:ad0be6196d522ed9650cdfebad33b965d523868a68682405423324b28c54f1e82_target rdf:type owl:Class .
+_:ad0be6196d522ed9650cdfebad33b965d523868a68682405423324b28c54f1e82_target owl:intersectionOf _:ad0be6196d522ed9650cdfebad33b965d523868a68682405423324b28c54f1e82_target_list_0 .
+_:ad0be6196d522ed9650cdfebad33b965d523868a68682405423324b28c54f1e82_target_list_0 rdf:first <http://purl.obolibrary.org/obo/BFO_0000034> .
+_:ad0be6196d522ed9650cdfebad33b965d523868a68682405423324b28c54f1e82_target_list_0 rdf:rest _:ad0be6196d522ed9650cdfebad33b965d523868a68682405423324b28c54f1e82_target_list_1 .
+_:ad0be6196d522ed9650cdfebad33b965d523868a68682405423324b28c54f1e82_target_list_1 rdf:first _:ad0be6196d522ed9650cdfebad33b965d523868a68682405423324b28c54f1e82_target_child_1 .
+_:ad0be6196d522ed9650cdfebad33b965d523868a68682405423324b28c54f1e82_target_list_1 rdf:rest rdf:nil .
+_:ad0be6196d522ed9650cdfebad33b965d523868a68682405423324b28c54f1e82_target_child_1 rdf:type owl:Restriction .
+_:ad0be6196d522ed9650cdfebad33b965d523868a68682405423324b28c54f1e82_target_child_1 owl:onProperty <http://purl.obolibrary.org/obo/BFO_0000054> .
+_:ad0be6196d522ed9650cdfebad33b965d523868a68682405423324b28c54f1e82_target_child_1 owl:someValuesFrom _:ad0be6196d522ed9650cdfebad33b965d523868a68682405423324b28c54f1e82_target_child_1_filler .
+_:ad0be6196d522ed9650cdfebad33b965d523868a68682405423324b28c54f1e82_target_child_1_filler rdf:type owl:Class .
+_:ad0be6196d522ed9650cdfebad33b965d523868a68682405423324b28c54f1e82_target_child_1_filler owl:intersectionOf _:ad0be6196d522ed9650cdfebad33b965d523868a68682405423324b28c54f1e82_target_child_1_filler_list_0 .
+_:ad0be6196d522ed9650cdfebad33b965d523868a68682405423324b28c54f1e82_target_child_1_filler_list_0 rdf:first <https://www.commoncoreontologies.org/ont00000228> .
+_:ad0be6196d522ed9650cdfebad33b965d523868a68682405423324b28c54f1e82_target_child_1_filler_list_0 rdf:rest _:ad0be6196d522ed9650cdfebad33b965d523868a68682405423324b28c54f1e82_target_child_1_filler_list_1 .
+_:ad0be6196d522ed9650cdfebad33b965d523868a68682405423324b28c54f1e82_target_child_1_filler_list_1 rdf:first _:ad0be6196d522ed9650cdfebad33b965d523868a68682405423324b28c54f1e82_target_child_1_filler_child_1 .
+_:ad0be6196d522ed9650cdfebad33b965d523868a68682405423324b28c54f1e82_target_child_1_filler_list_1 rdf:rest rdf:nil .
+_:ad0be6196d522ed9650cdfebad33b965d523868a68682405423324b28c54f1e82_target_child_1_filler_child_1 rdf:type owl:Restriction .
+_:ad0be6196d522ed9650cdfebad33b965d523868a68682405423324b28c54f1e82_target_child_1_filler_child_1 owl:onProperty <http://purl.obolibrary.org/obo/BFO_0000117> .
+_:ad0be6196d522ed9650cdfebad33b965d523868a68682405423324b28c54f1e82_target_child_1_filler_child_1 owl:someValuesFrom _:ad0be6196d522ed9650cdfebad33b965d523868a68682405423324b28c54f1e82_target_child_1_filler_child_1_filler .
+_:ad0be6196d522ed9650cdfebad33b965d523868a68682405423324b28c54f1e82_target_child_1_filler_child_1_filler rdf:type owl:Class .
+_:ad0be6196d522ed9650cdfebad33b965d523868a68682405423324b28c54f1e82_target_child_1_filler_child_1_filler owl:intersectionOf _:ad0be6196d522ed9650cdfebad33b965d523868a68682405423324b28c54f1e82_target_child_1_filler_child_1_filler_list_0 .
+_:ad0be6196d522ed9650cdfebad33b965d523868a68682405423324b28c54f1e82_target_child_1_filler_child_1_filler_list_0 rdf:first <https://www.commoncoreontologies.org/ont00001047> .
+_:ad0be6196d522ed9650cdfebad33b965d523868a68682405423324b28c54f1e82_target_child_1_filler_child_1_filler_list_0 rdf:rest _:ad0be6196d522ed9650cdfebad33b965d523868a68682405423324b28c54f1e82_target_child_1_filler_child_1_filler_list_1 .
+_:ad0be6196d522ed9650cdfebad33b965d523868a68682405423324b28c54f1e82_target_child_1_filler_child_1_filler_list_1 rdf:first _:ad0be6196d522ed9650cdfebad33b965d523868a68682405423324b28c54f1e82_target_child_1_filler_child_1_filler_child_1 .
+_:ad0be6196d522ed9650cdfebad33b965d523868a68682405423324b28c54f1e82_target_child_1_filler_child_1_filler_list_1 rdf:rest rdf:nil .
+_:ad0be6196d522ed9650cdfebad33b965d523868a68682405423324b28c54f1e82_target_child_1_filler_child_1_filler_child_1 rdf:type owl:Restriction .
+_:ad0be6196d522ed9650cdfebad33b965d523868a68682405423324b28c54f1e82_target_child_1_filler_child_1_filler_child_1 owl:onProperty <https://www.commoncoreontologies.org/ont00001920> .
+_:ad0be6196d522ed9650cdfebad33b965d523868a68682405423324b28c54f1e82_target_child_1_filler_child_1_filler_child_1 owl:someValuesFrom <https://www.commoncoreontologies.org/ont00000118> .
+
+<http://www.w3.org/ns/ssn/systems/Latency> rdfs:subClassOf _:a3457b3a3df2aa6fa0356c77e1cfd6ff95dbb450c7e9965c5bf1beb987488a3a1_target .
+_:a3457b3a3df2aa6fa0356c77e1cfd6ff95dbb450c7e9965c5bf1beb987488a3a1_target rdf:type owl:Class .
+_:a3457b3a3df2aa6fa0356c77e1cfd6ff95dbb450c7e9965c5bf1beb987488a3a1_target owl:intersectionOf _:a3457b3a3df2aa6fa0356c77e1cfd6ff95dbb450c7e9965c5bf1beb987488a3a1_target_list_0 .
+_:a3457b3a3df2aa6fa0356c77e1cfd6ff95dbb450c7e9965c5bf1beb987488a3a1_target_list_0 rdf:first <http://purl.obolibrary.org/obo/BFO_0000034> .
+_:a3457b3a3df2aa6fa0356c77e1cfd6ff95dbb450c7e9965c5bf1beb987488a3a1_target_list_0 rdf:rest _:a3457b3a3df2aa6fa0356c77e1cfd6ff95dbb450c7e9965c5bf1beb987488a3a1_target_list_1 .
+_:a3457b3a3df2aa6fa0356c77e1cfd6ff95dbb450c7e9965c5bf1beb987488a3a1_target_list_1 rdf:first _:a3457b3a3df2aa6fa0356c77e1cfd6ff95dbb450c7e9965c5bf1beb987488a3a1_target_child_1 .
+_:a3457b3a3df2aa6fa0356c77e1cfd6ff95dbb450c7e9965c5bf1beb987488a3a1_target_list_1 rdf:rest rdf:nil .
+_:a3457b3a3df2aa6fa0356c77e1cfd6ff95dbb450c7e9965c5bf1beb987488a3a1_target_child_1 rdf:type owl:Restriction .
+_:a3457b3a3df2aa6fa0356c77e1cfd6ff95dbb450c7e9965c5bf1beb987488a3a1_target_child_1 owl:onProperty <http://purl.obolibrary.org/obo/BFO_0000054> .
+_:a3457b3a3df2aa6fa0356c77e1cfd6ff95dbb450c7e9965c5bf1beb987488a3a1_target_child_1 owl:someValuesFrom _:a3457b3a3df2aa6fa0356c77e1cfd6ff95dbb450c7e9965c5bf1beb987488a3a1_target_child_1_filler .
+_:a3457b3a3df2aa6fa0356c77e1cfd6ff95dbb450c7e9965c5bf1beb987488a3a1_target_child_1_filler rdf:type owl:Class .
+_:a3457b3a3df2aa6fa0356c77e1cfd6ff95dbb450c7e9965c5bf1beb987488a3a1_target_child_1_filler owl:intersectionOf _:a3457b3a3df2aa6fa0356c77e1cfd6ff95dbb450c7e9965c5bf1beb987488a3a1_target_child_1_filler_list_0 .
+_:a3457b3a3df2aa6fa0356c77e1cfd6ff95dbb450c7e9965c5bf1beb987488a3a1_target_child_1_filler_list_0 rdf:first <https://www.commoncoreontologies.org/ont00000228> .
+_:a3457b3a3df2aa6fa0356c77e1cfd6ff95dbb450c7e9965c5bf1beb987488a3a1_target_child_1_filler_list_0 rdf:rest _:a3457b3a3df2aa6fa0356c77e1cfd6ff95dbb450c7e9965c5bf1beb987488a3a1_target_child_1_filler_list_1 .
+_:a3457b3a3df2aa6fa0356c77e1cfd6ff95dbb450c7e9965c5bf1beb987488a3a1_target_child_1_filler_list_1 rdf:first _:a3457b3a3df2aa6fa0356c77e1cfd6ff95dbb450c7e9965c5bf1beb987488a3a1_target_child_1_filler_child_1 .
+_:a3457b3a3df2aa6fa0356c77e1cfd6ff95dbb450c7e9965c5bf1beb987488a3a1_target_child_1_filler_list_1 rdf:rest _:a3457b3a3df2aa6fa0356c77e1cfd6ff95dbb450c7e9965c5bf1beb987488a3a1_target_child_1_filler_list_2 .
+_:a3457b3a3df2aa6fa0356c77e1cfd6ff95dbb450c7e9965c5bf1beb987488a3a1_target_child_1_filler_list_2 rdf:first _:a3457b3a3df2aa6fa0356c77e1cfd6ff95dbb450c7e9965c5bf1beb987488a3a1_target_child_1_filler_child_2 .
+_:a3457b3a3df2aa6fa0356c77e1cfd6ff95dbb450c7e9965c5bf1beb987488a3a1_target_child_1_filler_list_2 rdf:rest _:a3457b3a3df2aa6fa0356c77e1cfd6ff95dbb450c7e9965c5bf1beb987488a3a1_target_child_1_filler_list_3 .
+_:a3457b3a3df2aa6fa0356c77e1cfd6ff95dbb450c7e9965c5bf1beb987488a3a1_target_child_1_filler_list_3 rdf:first _:a3457b3a3df2aa6fa0356c77e1cfd6ff95dbb450c7e9965c5bf1beb987488a3a1_target_child_1_filler_child_3 .
+_:a3457b3a3df2aa6fa0356c77e1cfd6ff95dbb450c7e9965c5bf1beb987488a3a1_target_child_1_filler_list_3 rdf:rest rdf:nil .
+_:a3457b3a3df2aa6fa0356c77e1cfd6ff95dbb450c7e9965c5bf1beb987488a3a1_target_child_1_filler_child_1 rdf:type owl:Restriction .
+_:a3457b3a3df2aa6fa0356c77e1cfd6ff95dbb450c7e9965c5bf1beb987488a3a1_target_child_1_filler_child_1 owl:onProperty <https://www.commoncoreontologies.org/ont00001777> .
+_:a3457b3a3df2aa6fa0356c77e1cfd6ff95dbb450c7e9965c5bf1beb987488a3a1_target_child_1_filler_child_1 owl:someValuesFrom <https://www.commoncoreontologies.org/ont00000978> .
+_:a3457b3a3df2aa6fa0356c77e1cfd6ff95dbb450c7e9965c5bf1beb987488a3a1_target_child_1_filler_child_2 rdf:type owl:Restriction .
+_:a3457b3a3df2aa6fa0356c77e1cfd6ff95dbb450c7e9965c5bf1beb987488a3a1_target_child_1_filler_child_2 owl:onProperty <https://www.commoncoreontologies.org/ont00001777> .
+_:a3457b3a3df2aa6fa0356c77e1cfd6ff95dbb450c7e9965c5bf1beb987488a3a1_target_child_1_filler_child_2 owl:someValuesFrom <https://www.commoncoreontologies.org/ont00000660> .
+_:a3457b3a3df2aa6fa0356c77e1cfd6ff95dbb450c7e9965c5bf1beb987488a3a1_target_child_1_filler_child_3 rdf:type owl:Restriction .
+_:a3457b3a3df2aa6fa0356c77e1cfd6ff95dbb450c7e9965c5bf1beb987488a3a1_target_child_1_filler_child_3 owl:onProperty <http://purl.obolibrary.org/obo/BFO_0000199> .
+_:a3457b3a3df2aa6fa0356c77e1cfd6ff95dbb450c7e9965c5bf1beb987488a3a1_target_child_1_filler_child_3 owl:someValuesFrom _:a3457b3a3df2aa6fa0356c77e1cfd6ff95dbb450c7e9965c5bf1beb987488a3a1_target_child_1_filler_child_3_filler .
+_:a3457b3a3df2aa6fa0356c77e1cfd6ff95dbb450c7e9965c5bf1beb987488a3a1_target_child_1_filler_child_3_filler rdf:type owl:Class .
+_:a3457b3a3df2aa6fa0356c77e1cfd6ff95dbb450c7e9965c5bf1beb987488a3a1_target_child_1_filler_child_3_filler owl:intersectionOf _:a3457b3a3df2aa6fa0356c77e1cfd6ff95dbb450c7e9965c5bf1beb987488a3a1_target_child_1_filler_child_3_filler_list_0 .
+_:a3457b3a3df2aa6fa0356c77e1cfd6ff95dbb450c7e9965c5bf1beb987488a3a1_target_child_1_filler_child_3_filler_list_0 rdf:first <http://purl.obolibrary.org/obo/BFO_0000008> .
+_:a3457b3a3df2aa6fa0356c77e1cfd6ff95dbb450c7e9965c5bf1beb987488a3a1_target_child_1_filler_child_3_filler_list_0 rdf:rest _:a3457b3a3df2aa6fa0356c77e1cfd6ff95dbb450c7e9965c5bf1beb987488a3a1_target_child_1_filler_child_3_filler_list_1 .
+_:a3457b3a3df2aa6fa0356c77e1cfd6ff95dbb450c7e9965c5bf1beb987488a3a1_target_child_1_filler_child_3_filler_list_1 rdf:first _:a3457b3a3df2aa6fa0356c77e1cfd6ff95dbb450c7e9965c5bf1beb987488a3a1_target_child_1_filler_child_3_filler_child_1 .
+_:a3457b3a3df2aa6fa0356c77e1cfd6ff95dbb450c7e9965c5bf1beb987488a3a1_target_child_1_filler_child_3_filler_list_1 rdf:rest rdf:nil .
+_:a3457b3a3df2aa6fa0356c77e1cfd6ff95dbb450c7e9965c5bf1beb987488a3a1_target_child_1_filler_child_3_filler_child_1 rdf:type owl:Restriction .
+_:a3457b3a3df2aa6fa0356c77e1cfd6ff95dbb450c7e9965c5bf1beb987488a3a1_target_child_1_filler_child_3_filler_child_1 owl:onProperty <https://www.commoncoreontologies.org/ont00001920> .
+_:a3457b3a3df2aa6fa0356c77e1cfd6ff95dbb450c7e9965c5bf1beb987488a3a1_target_child_1_filler_child_3_filler_child_1 owl:someValuesFrom <https://www.commoncoreontologies.org/ont00000118> .
+
+<http://www.w3.org/ns/ssn/systems/MaintenanceSchedule> rdfs:subClassOf _:ac8c01d3cea6d9185b6c07763b28bec3b25a8e467d2abeeba7dda4edadb99ad61_target .
+_:ac8c01d3cea6d9185b6c07763b28bec3b25a8e467d2abeeba7dda4edadb99ad61_target rdf:type owl:Class .
+_:ac8c01d3cea6d9185b6c07763b28bec3b25a8e467d2abeeba7dda4edadb99ad61_target owl:intersectionOf _:ac8c01d3cea6d9185b6c07763b28bec3b25a8e467d2abeeba7dda4edadb99ad61_target_list_0 .
+_:ac8c01d3cea6d9185b6c07763b28bec3b25a8e467d2abeeba7dda4edadb99ad61_target_list_0 rdf:first <http://purl.obolibrary.org/obo/BFO_0000016> .
+_:ac8c01d3cea6d9185b6c07763b28bec3b25a8e467d2abeeba7dda4edadb99ad61_target_list_0 rdf:rest _:ac8c01d3cea6d9185b6c07763b28bec3b25a8e467d2abeeba7dda4edadb99ad61_target_list_1 .
+_:ac8c01d3cea6d9185b6c07763b28bec3b25a8e467d2abeeba7dda4edadb99ad61_target_list_1 rdf:first _:ac8c01d3cea6d9185b6c07763b28bec3b25a8e467d2abeeba7dda4edadb99ad61_target_child_1 .
+_:ac8c01d3cea6d9185b6c07763b28bec3b25a8e467d2abeeba7dda4edadb99ad61_target_list_1 rdf:rest rdf:nil .
+_:ac8c01d3cea6d9185b6c07763b28bec3b25a8e467d2abeeba7dda4edadb99ad61_target_child_1 rdf:type owl:Restriction .
+_:ac8c01d3cea6d9185b6c07763b28bec3b25a8e467d2abeeba7dda4edadb99ad61_target_child_1 owl:onProperty <http://purl.obolibrary.org/obo/BFO_0000054> .
+_:ac8c01d3cea6d9185b6c07763b28bec3b25a8e467d2abeeba7dda4edadb99ad61_target_child_1 owl:someValuesFrom _:ac8c01d3cea6d9185b6c07763b28bec3b25a8e467d2abeeba7dda4edadb99ad61_target_child_1_filler .
+_:ac8c01d3cea6d9185b6c07763b28bec3b25a8e467d2abeeba7dda4edadb99ad61_target_child_1_filler rdf:type owl:Class .
+_:ac8c01d3cea6d9185b6c07763b28bec3b25a8e467d2abeeba7dda4edadb99ad61_target_child_1_filler owl:intersectionOf _:ac8c01d3cea6d9185b6c07763b28bec3b25a8e467d2abeeba7dda4edadb99ad61_target_child_1_filler_list_0 .
+_:ac8c01d3cea6d9185b6c07763b28bec3b25a8e467d2abeeba7dda4edadb99ad61_target_child_1_filler_list_0 rdf:first <https://www.commoncoreontologies.org/ont00000004> .
+_:ac8c01d3cea6d9185b6c07763b28bec3b25a8e467d2abeeba7dda4edadb99ad61_target_child_1_filler_list_0 rdf:rest _:ac8c01d3cea6d9185b6c07763b28bec3b25a8e467d2abeeba7dda4edadb99ad61_target_child_1_filler_list_1 .
+_:ac8c01d3cea6d9185b6c07763b28bec3b25a8e467d2abeeba7dda4edadb99ad61_target_child_1_filler_list_1 rdf:first _:ac8c01d3cea6d9185b6c07763b28bec3b25a8e467d2abeeba7dda4edadb99ad61_target_child_1_filler_child_1 .
+_:ac8c01d3cea6d9185b6c07763b28bec3b25a8e467d2abeeba7dda4edadb99ad61_target_child_1_filler_list_1 rdf:rest rdf:nil .
+_:ac8c01d3cea6d9185b6c07763b28bec3b25a8e467d2abeeba7dda4edadb99ad61_target_child_1_filler_child_1 rdf:type owl:Restriction .
+_:ac8c01d3cea6d9185b6c07763b28bec3b25a8e467d2abeeba7dda4edadb99ad61_target_child_1_filler_child_1 owl:onProperty <https://www.commoncoreontologies.org/ont00001834> .
+_:ac8c01d3cea6d9185b6c07763b28bec3b25a8e467d2abeeba7dda4edadb99ad61_target_child_1_filler_child_1 owl:someValuesFrom _:ac8c01d3cea6d9185b6c07763b28bec3b25a8e467d2abeeba7dda4edadb99ad61_target_child_1_filler_child_1_filler .
+_:ac8c01d3cea6d9185b6c07763b28bec3b25a8e467d2abeeba7dda4edadb99ad61_target_child_1_filler_child_1_filler rdf:type owl:Class .
+_:ac8c01d3cea6d9185b6c07763b28bec3b25a8e467d2abeeba7dda4edadb99ad61_target_child_1_filler_child_1_filler owl:intersectionOf _:ac8c01d3cea6d9185b6c07763b28bec3b25a8e467d2abeeba7dda4edadb99ad61_target_child_1_filler_child_1_filler_list_0 .
+_:ac8c01d3cea6d9185b6c07763b28bec3b25a8e467d2abeeba7dda4edadb99ad61_target_child_1_filler_child_1_filler_list_0 rdf:first <http://purl.obolibrary.org/obo/BFO_0000020> .
+_:ac8c01d3cea6d9185b6c07763b28bec3b25a8e467d2abeeba7dda4edadb99ad61_target_child_1_filler_child_1_filler_list_0 rdf:rest _:ac8c01d3cea6d9185b6c07763b28bec3b25a8e467d2abeeba7dda4edadb99ad61_target_child_1_filler_child_1_filler_list_1 .
+_:ac8c01d3cea6d9185b6c07763b28bec3b25a8e467d2abeeba7dda4edadb99ad61_target_child_1_filler_child_1_filler_list_1 rdf:first _:ac8c01d3cea6d9185b6c07763b28bec3b25a8e467d2abeeba7dda4edadb99ad61_target_child_1_filler_child_1_filler_child_1 .
+_:ac8c01d3cea6d9185b6c07763b28bec3b25a8e467d2abeeba7dda4edadb99ad61_target_child_1_filler_child_1_filler_list_1 rdf:rest rdf:nil .
+_:ac8c01d3cea6d9185b6c07763b28bec3b25a8e467d2abeeba7dda4edadb99ad61_target_child_1_filler_child_1_filler_child_1 rdf:type owl:Restriction .
+_:ac8c01d3cea6d9185b6c07763b28bec3b25a8e467d2abeeba7dda4edadb99ad61_target_child_1_filler_child_1_filler_child_1 owl:onProperty <http://purl.obolibrary.org/obo/BFO_0000056> .
+_:ac8c01d3cea6d9185b6c07763b28bec3b25a8e467d2abeeba7dda4edadb99ad61_target_child_1_filler_child_1_filler_child_1 owl:someValuesFrom _:ac8c01d3cea6d9185b6c07763b28bec3b25a8e467d2abeeba7dda4edadb99ad61_target_child_1_filler_child_1_filler_child_1_filler .
+_:ac8c01d3cea6d9185b6c07763b28bec3b25a8e467d2abeeba7dda4edadb99ad61_target_child_1_filler_child_1_filler_child_1_filler rdf:type owl:Class .
+_:ac8c01d3cea6d9185b6c07763b28bec3b25a8e467d2abeeba7dda4edadb99ad61_target_child_1_filler_child_1_filler_child_1_filler owl:intersectionOf _:ac8c01d3cea6d9185b6c07763b28bec3b25a8e467d2abeeba7dda4edadb99ad61_target_child_1_filler_child_1_filler_child_1_filler_list_0 .
+_:ac8c01d3cea6d9185b6c07763b28bec3b25a8e467d2abeeba7dda4edadb99ad61_target_child_1_filler_child_1_filler_child_1_filler_list_0 rdf:first <https://www.commoncoreontologies.org/ont00000950> .
+_:ac8c01d3cea6d9185b6c07763b28bec3b25a8e467d2abeeba7dda4edadb99ad61_target_child_1_filler_child_1_filler_child_1_filler_list_0 rdf:rest _:ac8c01d3cea6d9185b6c07763b28bec3b25a8e467d2abeeba7dda4edadb99ad61_target_child_1_filler_child_1_filler_child_1_filler_list_1 .
+_:ac8c01d3cea6d9185b6c07763b28bec3b25a8e467d2abeeba7dda4edadb99ad61_target_child_1_filler_child_1_filler_child_1_filler_list_1 rdf:first _:ac8c01d3cea6d9185b6c07763b28bec3b25a8e467d2abeeba7dda4edadb99ad61_target_child_1_filler_child_1_filler_child_1_filler_child_1 .
+_:ac8c01d3cea6d9185b6c07763b28bec3b25a8e467d2abeeba7dda4edadb99ad61_target_child_1_filler_child_1_filler_child_1_filler_list_1 rdf:rest rdf:nil .
+_:ac8c01d3cea6d9185b6c07763b28bec3b25a8e467d2abeeba7dda4edadb99ad61_target_child_1_filler_child_1_filler_child_1_filler_child_1 rdf:type owl:Restriction .
+_:ac8c01d3cea6d9185b6c07763b28bec3b25a8e467d2abeeba7dda4edadb99ad61_target_child_1_filler_child_1_filler_child_1_filler_child_1 owl:onProperty <http://purl.obolibrary.org/obo/BFO_0000117> .
+_:ac8c01d3cea6d9185b6c07763b28bec3b25a8e467d2abeeba7dda4edadb99ad61_target_child_1_filler_child_1_filler_child_1_filler_child_1 owl:someValuesFrom _:ac8c01d3cea6d9185b6c07763b28bec3b25a8e467d2abeeba7dda4edadb99ad61_target_child_1_filler_child_1_filler_child_1_filler_child_1_filler .
+_:ac8c01d3cea6d9185b6c07763b28bec3b25a8e467d2abeeba7dda4edadb99ad61_target_child_1_filler_child_1_filler_child_1_filler_child_1_filler rdf:type owl:Class .
+_:ac8c01d3cea6d9185b6c07763b28bec3b25a8e467d2abeeba7dda4edadb99ad61_target_child_1_filler_child_1_filler_child_1_filler_child_1_filler owl:intersectionOf _:ac8c01d3cea6d9185b6c07763b28bec3b25a8e467d2abeeba7dda4edadb99ad61_target_child_1_filler_child_1_filler_child_1_filler_child_1_filler_list_0 .
+_:ac8c01d3cea6d9185b6c07763b28bec3b25a8e467d2abeeba7dda4edadb99ad61_target_child_1_filler_child_1_filler_child_1_filler_child_1_filler_list_0 rdf:first <https://www.commoncoreontologies.org/ont00001047> .
+_:ac8c01d3cea6d9185b6c07763b28bec3b25a8e467d2abeeba7dda4edadb99ad61_target_child_1_filler_child_1_filler_child_1_filler_child_1_filler_list_0 rdf:rest _:ac8c01d3cea6d9185b6c07763b28bec3b25a8e467d2abeeba7dda4edadb99ad61_target_child_1_filler_child_1_filler_child_1_filler_child_1_filler_list_1 .
+_:ac8c01d3cea6d9185b6c07763b28bec3b25a8e467d2abeeba7dda4edadb99ad61_target_child_1_filler_child_1_filler_child_1_filler_child_1_filler_list_1 rdf:first _:ac8c01d3cea6d9185b6c07763b28bec3b25a8e467d2abeeba7dda4edadb99ad61_target_child_1_filler_child_1_filler_child_1_filler_child_1_filler_child_1 .
+_:ac8c01d3cea6d9185b6c07763b28bec3b25a8e467d2abeeba7dda4edadb99ad61_target_child_1_filler_child_1_filler_child_1_filler_child_1_filler_list_1 rdf:rest rdf:nil .
+_:ac8c01d3cea6d9185b6c07763b28bec3b25a8e467d2abeeba7dda4edadb99ad61_target_child_1_filler_child_1_filler_child_1_filler_child_1_filler_child_1 rdf:type owl:Restriction .
+_:ac8c01d3cea6d9185b6c07763b28bec3b25a8e467d2abeeba7dda4edadb99ad61_target_child_1_filler_child_1_filler_child_1_filler_child_1_filler_child_1 owl:onProperty <https://www.commoncoreontologies.org/ont00001920> .
+_:ac8c01d3cea6d9185b6c07763b28bec3b25a8e467d2abeeba7dda4edadb99ad61_target_child_1_filler_child_1_filler_child_1_filler_child_1_filler_child_1 owl:someValuesFrom <https://www.commoncoreontologies.org/ont00000319> .
+
+<http://www.w3.org/ns/ssn/systems/MeasurementRange> rdfs:subClassOf _:a89dc07e0f0e0a2117964d686c2a88b7da77cb761bba5c3cb74b6b6521502cf11_target .
+_:a89dc07e0f0e0a2117964d686c2a88b7da77cb761bba5c3cb74b6b6521502cf11_target rdf:type owl:Class .
+_:a89dc07e0f0e0a2117964d686c2a88b7da77cb761bba5c3cb74b6b6521502cf11_target owl:intersectionOf _:a89dc07e0f0e0a2117964d686c2a88b7da77cb761bba5c3cb74b6b6521502cf11_target_list_0 .
+_:a89dc07e0f0e0a2117964d686c2a88b7da77cb761bba5c3cb74b6b6521502cf11_target_list_0 rdf:first <http://purl.obolibrary.org/obo/BFO_0000034> .
+_:a89dc07e0f0e0a2117964d686c2a88b7da77cb761bba5c3cb74b6b6521502cf11_target_list_0 rdf:rest _:a89dc07e0f0e0a2117964d686c2a88b7da77cb761bba5c3cb74b6b6521502cf11_target_list_1 .
+_:a89dc07e0f0e0a2117964d686c2a88b7da77cb761bba5c3cb74b6b6521502cf11_target_list_1 rdf:first _:a89dc07e0f0e0a2117964d686c2a88b7da77cb761bba5c3cb74b6b6521502cf11_target_child_1 .
+_:a89dc07e0f0e0a2117964d686c2a88b7da77cb761bba5c3cb74b6b6521502cf11_target_list_1 rdf:rest rdf:nil .
+_:a89dc07e0f0e0a2117964d686c2a88b7da77cb761bba5c3cb74b6b6521502cf11_target_child_1 rdf:type owl:Restriction .
+_:a89dc07e0f0e0a2117964d686c2a88b7da77cb761bba5c3cb74b6b6521502cf11_target_child_1 owl:onProperty <http://purl.obolibrary.org/obo/BFO_0000054> .
+_:a89dc07e0f0e0a2117964d686c2a88b7da77cb761bba5c3cb74b6b6521502cf11_target_child_1 owl:someValuesFrom _:a89dc07e0f0e0a2117964d686c2a88b7da77cb761bba5c3cb74b6b6521502cf11_target_child_1_filler .
+_:a89dc07e0f0e0a2117964d686c2a88b7da77cb761bba5c3cb74b6b6521502cf11_target_child_1_filler rdf:type owl:Class .
+_:a89dc07e0f0e0a2117964d686c2a88b7da77cb761bba5c3cb74b6b6521502cf11_target_child_1_filler owl:intersectionOf _:a89dc07e0f0e0a2117964d686c2a88b7da77cb761bba5c3cb74b6b6521502cf11_target_child_1_filler_list_0 .
+_:a89dc07e0f0e0a2117964d686c2a88b7da77cb761bba5c3cb74b6b6521502cf11_target_child_1_filler_list_0 rdf:first <http://www.w3.org/ns/sosa/Observation> .
+_:a89dc07e0f0e0a2117964d686c2a88b7da77cb761bba5c3cb74b6b6521502cf11_target_child_1_filler_list_0 rdf:rest _:a89dc07e0f0e0a2117964d686c2a88b7da77cb761bba5c3cb74b6b6521502cf11_target_child_1_filler_list_1 .
+_:a89dc07e0f0e0a2117964d686c2a88b7da77cb761bba5c3cb74b6b6521502cf11_target_child_1_filler_list_1 rdf:first _:a89dc07e0f0e0a2117964d686c2a88b7da77cb761bba5c3cb74b6b6521502cf11_target_child_1_filler_child_1 .
+_:a89dc07e0f0e0a2117964d686c2a88b7da77cb761bba5c3cb74b6b6521502cf11_target_child_1_filler_list_1 rdf:rest rdf:nil .
+_:a89dc07e0f0e0a2117964d686c2a88b7da77cb761bba5c3cb74b6b6521502cf11_target_child_1_filler_child_1 rdf:type owl:Restriction .
+_:a89dc07e0f0e0a2117964d686c2a88b7da77cb761bba5c3cb74b6b6521502cf11_target_child_1_filler_child_1 owl:onProperty <https://www.commoncoreontologies.org/ont00001819> .
+_:a89dc07e0f0e0a2117964d686c2a88b7da77cb761bba5c3cb74b6b6521502cf11_target_child_1_filler_child_1 owl:someValuesFrom _:a89dc07e0f0e0a2117964d686c2a88b7da77cb761bba5c3cb74b6b6521502cf11_target_child_1_filler_child_1_filler .
+_:a89dc07e0f0e0a2117964d686c2a88b7da77cb761bba5c3cb74b6b6521502cf11_target_child_1_filler_child_1_filler rdf:type owl:Class .
+_:a89dc07e0f0e0a2117964d686c2a88b7da77cb761bba5c3cb74b6b6521502cf11_target_child_1_filler_child_1_filler owl:intersectionOf _:a89dc07e0f0e0a2117964d686c2a88b7da77cb761bba5c3cb74b6b6521502cf11_target_child_1_filler_child_1_filler_list_0 .
+_:a89dc07e0f0e0a2117964d686c2a88b7da77cb761bba5c3cb74b6b6521502cf11_target_child_1_filler_child_1_filler_list_0 rdf:first <http://www.w3.org/ns/ssn/Stimulus> .
+_:a89dc07e0f0e0a2117964d686c2a88b7da77cb761bba5c3cb74b6b6521502cf11_target_child_1_filler_child_1_filler_list_0 rdf:rest _:a89dc07e0f0e0a2117964d686c2a88b7da77cb761bba5c3cb74b6b6521502cf11_target_child_1_filler_child_1_filler_list_1 .
+_:a89dc07e0f0e0a2117964d686c2a88b7da77cb761bba5c3cb74b6b6521502cf11_target_child_1_filler_child_1_filler_list_1 rdf:first _:a89dc07e0f0e0a2117964d686c2a88b7da77cb761bba5c3cb74b6b6521502cf11_target_child_1_filler_child_1_filler_child_1 .
+_:a89dc07e0f0e0a2117964d686c2a88b7da77cb761bba5c3cb74b6b6521502cf11_target_child_1_filler_child_1_filler_list_1 rdf:rest rdf:nil .
+_:a89dc07e0f0e0a2117964d686c2a88b7da77cb761bba5c3cb74b6b6521502cf11_target_child_1_filler_child_1_filler_child_1 rdf:type owl:Restriction .
+_:a89dc07e0f0e0a2117964d686c2a88b7da77cb761bba5c3cb74b6b6521502cf11_target_child_1_filler_child_1_filler_child_1 owl:onProperty <https://www.commoncoreontologies.org/ont00001920> .
+_:a89dc07e0f0e0a2117964d686c2a88b7da77cb761bba5c3cb74b6b6521502cf11_target_child_1_filler_child_1_filler_child_1 owl:someValuesFrom <https://www.commoncoreontologies.org/ont00000118> .
+
+<http://www.w3.org/ns/ssn/systems/OperatingPowerRange> rdfs:subClassOf _:a2d3f18260f6d804a9e949bda85aca7dcfe2d170b01199991ee8797423dd99a61_target .
+_:a2d3f18260f6d804a9e949bda85aca7dcfe2d170b01199991ee8797423dd99a61_target rdf:type owl:Class .
+_:a2d3f18260f6d804a9e949bda85aca7dcfe2d170b01199991ee8797423dd99a61_target owl:intersectionOf _:a2d3f18260f6d804a9e949bda85aca7dcfe2d170b01199991ee8797423dd99a61_target_list_0 .
+_:a2d3f18260f6d804a9e949bda85aca7dcfe2d170b01199991ee8797423dd99a61_target_list_0 rdf:first <http://purl.obolibrary.org/obo/BFO_0000034> .
+_:a2d3f18260f6d804a9e949bda85aca7dcfe2d170b01199991ee8797423dd99a61_target_list_0 rdf:rest _:a2d3f18260f6d804a9e949bda85aca7dcfe2d170b01199991ee8797423dd99a61_target_list_1 .
+_:a2d3f18260f6d804a9e949bda85aca7dcfe2d170b01199991ee8797423dd99a61_target_list_1 rdf:first _:a2d3f18260f6d804a9e949bda85aca7dcfe2d170b01199991ee8797423dd99a61_target_child_1 .
+_:a2d3f18260f6d804a9e949bda85aca7dcfe2d170b01199991ee8797423dd99a61_target_list_1 rdf:rest rdf:nil .
+_:a2d3f18260f6d804a9e949bda85aca7dcfe2d170b01199991ee8797423dd99a61_target_child_1 rdf:type owl:Restriction .
+_:a2d3f18260f6d804a9e949bda85aca7dcfe2d170b01199991ee8797423dd99a61_target_child_1 owl:onProperty <http://purl.obolibrary.org/obo/BFO_0000054> .
+_:a2d3f18260f6d804a9e949bda85aca7dcfe2d170b01199991ee8797423dd99a61_target_child_1 owl:someValuesFrom _:a2d3f18260f6d804a9e949bda85aca7dcfe2d170b01199991ee8797423dd99a61_target_child_1_filler .
+_:a2d3f18260f6d804a9e949bda85aca7dcfe2d170b01199991ee8797423dd99a61_target_child_1_filler rdf:type owl:Class .
+_:a2d3f18260f6d804a9e949bda85aca7dcfe2d170b01199991ee8797423dd99a61_target_child_1_filler owl:intersectionOf _:a2d3f18260f6d804a9e949bda85aca7dcfe2d170b01199991ee8797423dd99a61_target_child_1_filler_list_0 .
+_:a2d3f18260f6d804a9e949bda85aca7dcfe2d170b01199991ee8797423dd99a61_target_child_1_filler_list_0 rdf:first <http://purl.obolibrary.org/obo/BFO_0000015> .
+_:a2d3f18260f6d804a9e949bda85aca7dcfe2d170b01199991ee8797423dd99a61_target_child_1_filler_list_0 rdf:rest _:a2d3f18260f6d804a9e949bda85aca7dcfe2d170b01199991ee8797423dd99a61_target_child_1_filler_list_1 .
+_:a2d3f18260f6d804a9e949bda85aca7dcfe2d170b01199991ee8797423dd99a61_target_child_1_filler_list_1 rdf:first _:a2d3f18260f6d804a9e949bda85aca7dcfe2d170b01199991ee8797423dd99a61_target_child_1_filler_child_1 .
+_:a2d3f18260f6d804a9e949bda85aca7dcfe2d170b01199991ee8797423dd99a61_target_child_1_filler_list_1 rdf:rest rdf:nil .
+_:a2d3f18260f6d804a9e949bda85aca7dcfe2d170b01199991ee8797423dd99a61_target_child_1_filler_child_1 rdf:type owl:Restriction .
+_:a2d3f18260f6d804a9e949bda85aca7dcfe2d170b01199991ee8797423dd99a61_target_child_1_filler_child_1 owl:onProperty <http://purl.obolibrary.org/obo/BFO_0000117> .
+_:a2d3f18260f6d804a9e949bda85aca7dcfe2d170b01199991ee8797423dd99a61_target_child_1_filler_child_1 owl:someValuesFrom _:a2d3f18260f6d804a9e949bda85aca7dcfe2d170b01199991ee8797423dd99a61_target_child_1_filler_child_1_filler .
+_:a2d3f18260f6d804a9e949bda85aca7dcfe2d170b01199991ee8797423dd99a61_target_child_1_filler_child_1_filler rdf:type owl:Class .
+_:a2d3f18260f6d804a9e949bda85aca7dcfe2d170b01199991ee8797423dd99a61_target_child_1_filler_child_1_filler owl:intersectionOf _:a2d3f18260f6d804a9e949bda85aca7dcfe2d170b01199991ee8797423dd99a61_target_child_1_filler_child_1_filler_list_0 .
+_:a2d3f18260f6d804a9e949bda85aca7dcfe2d170b01199991ee8797423dd99a61_target_child_1_filler_child_1_filler_list_0 rdf:first <https://www.commoncoreontologies.org/ont00000503> .
+_:a2d3f18260f6d804a9e949bda85aca7dcfe2d170b01199991ee8797423dd99a61_target_child_1_filler_child_1_filler_list_0 rdf:rest _:a2d3f18260f6d804a9e949bda85aca7dcfe2d170b01199991ee8797423dd99a61_target_child_1_filler_child_1_filler_list_1 .
+_:a2d3f18260f6d804a9e949bda85aca7dcfe2d170b01199991ee8797423dd99a61_target_child_1_filler_child_1_filler_list_1 rdf:first _:a2d3f18260f6d804a9e949bda85aca7dcfe2d170b01199991ee8797423dd99a61_target_child_1_filler_child_1_filler_child_1 .
+_:a2d3f18260f6d804a9e949bda85aca7dcfe2d170b01199991ee8797423dd99a61_target_child_1_filler_child_1_filler_list_1 rdf:rest rdf:nil .
+_:a2d3f18260f6d804a9e949bda85aca7dcfe2d170b01199991ee8797423dd99a61_target_child_1_filler_child_1_filler_child_1 rdf:type owl:Restriction .
+_:a2d3f18260f6d804a9e949bda85aca7dcfe2d170b01199991ee8797423dd99a61_target_child_1_filler_child_1_filler_child_1 owl:onProperty <https://www.commoncoreontologies.org/ont00001920> .
+_:a2d3f18260f6d804a9e949bda85aca7dcfe2d170b01199991ee8797423dd99a61_target_child_1_filler_child_1_filler_child_1 owl:someValuesFrom <https://www.commoncoreontologies.org/ont00000319> .
+
+<http://www.w3.org/ns/ssn/systems/OperatingProperty> rdfs:subClassOf _:a3f12e123ab52f767626a55a1d07c7d5d85a955e538890927ea02090db15411ab_target .
+_:a3f12e123ab52f767626a55a1d07c7d5d85a955e538890927ea02090db15411ab_target rdf:type owl:Class .
+_:a3f12e123ab52f767626a55a1d07c7d5d85a955e538890927ea02090db15411ab_target owl:intersectionOf _:a3f12e123ab52f767626a55a1d07c7d5d85a955e538890927ea02090db15411ab_target_list_0 .
+_:a3f12e123ab52f767626a55a1d07c7d5d85a955e538890927ea02090db15411ab_target_list_0 rdf:first _:a3f12e123ab52f767626a55a1d07c7d5d85a955e538890927ea02090db15411ab_target_child_0 .
+_:a3f12e123ab52f767626a55a1d07c7d5d85a955e538890927ea02090db15411ab_target_list_0 rdf:rest _:a3f12e123ab52f767626a55a1d07c7d5d85a955e538890927ea02090db15411ab_target_list_1 .
+_:a3f12e123ab52f767626a55a1d07c7d5d85a955e538890927ea02090db15411ab_target_list_1 rdf:first _:a3f12e123ab52f767626a55a1d07c7d5d85a955e538890927ea02090db15411ab_target_child_1 .
+_:a3f12e123ab52f767626a55a1d07c7d5d85a955e538890927ea02090db15411ab_target_list_1 rdf:rest rdf:nil .
+_:a3f12e123ab52f767626a55a1d07c7d5d85a955e538890927ea02090db15411ab_target_child_0 rdf:type owl:Class .
+_:a3f12e123ab52f767626a55a1d07c7d5d85a955e538890927ea02090db15411ab_target_child_0 owl:unionOf _:a3f12e123ab52f767626a55a1d07c7d5d85a955e538890927ea02090db15411ab_target_child_0_list_0 .
+_:a3f12e123ab52f767626a55a1d07c7d5d85a955e538890927ea02090db15411ab_target_child_0_list_0 rdf:first <http://purl.obolibrary.org/obo/BFO_0000020> .
+_:a3f12e123ab52f767626a55a1d07c7d5d85a955e538890927ea02090db15411ab_target_child_0_list_0 rdf:rest _:a3f12e123ab52f767626a55a1d07c7d5d85a955e538890927ea02090db15411ab_target_child_0_list_1 .
+_:a3f12e123ab52f767626a55a1d07c7d5d85a955e538890927ea02090db15411ab_target_child_0_list_1 rdf:first <http://purl.obolibrary.org/obo/BFO_0000144> .
+_:a3f12e123ab52f767626a55a1d07c7d5d85a955e538890927ea02090db15411ab_target_child_0_list_1 rdf:rest rdf:nil .
+_:a3f12e123ab52f767626a55a1d07c7d5d85a955e538890927ea02090db15411ab_target_child_1 rdf:type owl:Restriction .
+_:a3f12e123ab52f767626a55a1d07c7d5d85a955e538890927ea02090db15411ab_target_child_1 owl:onProperty <https://www.commoncoreontologies.org/ont00001920> .
+_:a3f12e123ab52f767626a55a1d07c7d5d85a955e538890927ea02090db15411ab_target_child_1 owl:someValuesFrom <https://www.commoncoreontologies.org/ont00000319> .
+
+<http://www.w3.org/ns/ssn/systems/OperatingRange> rdfs:subClassOf _:aa7156d6ebbd83de2547dbd7e11a2c103e9fd8cc8be71a59c57656e86df5a715f_target .
+_:aa7156d6ebbd83de2547dbd7e11a2c103e9fd8cc8be71a59c57656e86df5a715f_target rdf:type owl:Class .
+_:aa7156d6ebbd83de2547dbd7e11a2c103e9fd8cc8be71a59c57656e86df5a715f_target owl:intersectionOf _:aa7156d6ebbd83de2547dbd7e11a2c103e9fd8cc8be71a59c57656e86df5a715f_target_list_0 .
+_:aa7156d6ebbd83de2547dbd7e11a2c103e9fd8cc8be71a59c57656e86df5a715f_target_list_0 rdf:first _:aa7156d6ebbd83de2547dbd7e11a2c103e9fd8cc8be71a59c57656e86df5a715f_target_child_0 .
+_:aa7156d6ebbd83de2547dbd7e11a2c103e9fd8cc8be71a59c57656e86df5a715f_target_list_0 rdf:rest _:aa7156d6ebbd83de2547dbd7e11a2c103e9fd8cc8be71a59c57656e86df5a715f_target_list_1 .
+_:aa7156d6ebbd83de2547dbd7e11a2c103e9fd8cc8be71a59c57656e86df5a715f_target_list_1 rdf:first _:aa7156d6ebbd83de2547dbd7e11a2c103e9fd8cc8be71a59c57656e86df5a715f_target_child_1 .
+_:aa7156d6ebbd83de2547dbd7e11a2c103e9fd8cc8be71a59c57656e86df5a715f_target_list_1 rdf:rest rdf:nil .
+_:aa7156d6ebbd83de2547dbd7e11a2c103e9fd8cc8be71a59c57656e86df5a715f_target_child_0 rdf:type owl:Class .
+_:aa7156d6ebbd83de2547dbd7e11a2c103e9fd8cc8be71a59c57656e86df5a715f_target_child_0 owl:unionOf _:aa7156d6ebbd83de2547dbd7e11a2c103e9fd8cc8be71a59c57656e86df5a715f_target_child_0_list_0 .
+_:aa7156d6ebbd83de2547dbd7e11a2c103e9fd8cc8be71a59c57656e86df5a715f_target_child_0_list_0 rdf:first <http://purl.obolibrary.org/obo/BFO_0000020> .
+_:aa7156d6ebbd83de2547dbd7e11a2c103e9fd8cc8be71a59c57656e86df5a715f_target_child_0_list_0 rdf:rest _:aa7156d6ebbd83de2547dbd7e11a2c103e9fd8cc8be71a59c57656e86df5a715f_target_child_0_list_1 .
+_:aa7156d6ebbd83de2547dbd7e11a2c103e9fd8cc8be71a59c57656e86df5a715f_target_child_0_list_1 rdf:first <http://purl.obolibrary.org/obo/BFO_0000144> .
+_:aa7156d6ebbd83de2547dbd7e11a2c103e9fd8cc8be71a59c57656e86df5a715f_target_child_0_list_1 rdf:rest rdf:nil .
+_:aa7156d6ebbd83de2547dbd7e11a2c103e9fd8cc8be71a59c57656e86df5a715f_target_child_1 rdf:type owl:Restriction .
+_:aa7156d6ebbd83de2547dbd7e11a2c103e9fd8cc8be71a59c57656e86df5a715f_target_child_1 owl:onProperty <https://www.commoncoreontologies.org/ont00001920> .
+_:aa7156d6ebbd83de2547dbd7e11a2c103e9fd8cc8be71a59c57656e86df5a715f_target_child_1 owl:someValuesFrom <https://www.commoncoreontologies.org/ont00000319> .
+
+<http://www.w3.org/ns/ssn/systems/Precision> rdfs:subClassOf _:a7bcd034eadbf0577e59b123707dd31bbd105681183ea0b8e5cf98914676d3a59_target .
+_:a7bcd034eadbf0577e59b123707dd31bbd105681183ea0b8e5cf98914676d3a59_target rdf:type owl:Class .
+_:a7bcd034eadbf0577e59b123707dd31bbd105681183ea0b8e5cf98914676d3a59_target owl:intersectionOf _:a7bcd034eadbf0577e59b123707dd31bbd105681183ea0b8e5cf98914676d3a59_target_list_0 .
+_:a7bcd034eadbf0577e59b123707dd31bbd105681183ea0b8e5cf98914676d3a59_target_list_0 rdf:first <http://purl.obolibrary.org/obo/BFO_0000034> .
+_:a7bcd034eadbf0577e59b123707dd31bbd105681183ea0b8e5cf98914676d3a59_target_list_0 rdf:rest _:a7bcd034eadbf0577e59b123707dd31bbd105681183ea0b8e5cf98914676d3a59_target_list_1 .
+_:a7bcd034eadbf0577e59b123707dd31bbd105681183ea0b8e5cf98914676d3a59_target_list_1 rdf:first _:a7bcd034eadbf0577e59b123707dd31bbd105681183ea0b8e5cf98914676d3a59_target_child_1 .
+_:a7bcd034eadbf0577e59b123707dd31bbd105681183ea0b8e5cf98914676d3a59_target_list_1 rdf:rest rdf:nil .
+_:a7bcd034eadbf0577e59b123707dd31bbd105681183ea0b8e5cf98914676d3a59_target_child_1 rdf:type owl:Restriction .
+_:a7bcd034eadbf0577e59b123707dd31bbd105681183ea0b8e5cf98914676d3a59_target_child_1 owl:onProperty <http://purl.obolibrary.org/obo/BFO_0000054> .
+_:a7bcd034eadbf0577e59b123707dd31bbd105681183ea0b8e5cf98914676d3a59_target_child_1 owl:someValuesFrom _:a7bcd034eadbf0577e59b123707dd31bbd105681183ea0b8e5cf98914676d3a59_target_child_1_filler .
+_:a7bcd034eadbf0577e59b123707dd31bbd105681183ea0b8e5cf98914676d3a59_target_child_1_filler rdf:type owl:Class .
+_:a7bcd034eadbf0577e59b123707dd31bbd105681183ea0b8e5cf98914676d3a59_target_child_1_filler owl:intersectionOf _:a7bcd034eadbf0577e59b123707dd31bbd105681183ea0b8e5cf98914676d3a59_target_child_1_filler_list_0 .
+_:a7bcd034eadbf0577e59b123707dd31bbd105681183ea0b8e5cf98914676d3a59_target_child_1_filler_list_0 rdf:first <http://purl.obolibrary.org/obo/BFO_0000015> .
+_:a7bcd034eadbf0577e59b123707dd31bbd105681183ea0b8e5cf98914676d3a59_target_child_1_filler_list_0 rdf:rest _:a7bcd034eadbf0577e59b123707dd31bbd105681183ea0b8e5cf98914676d3a59_target_child_1_filler_list_1 .
+_:a7bcd034eadbf0577e59b123707dd31bbd105681183ea0b8e5cf98914676d3a59_target_child_1_filler_list_1 rdf:first _:a7bcd034eadbf0577e59b123707dd31bbd105681183ea0b8e5cf98914676d3a59_target_child_1_filler_child_1 .
+_:a7bcd034eadbf0577e59b123707dd31bbd105681183ea0b8e5cf98914676d3a59_target_child_1_filler_list_1 rdf:rest rdf:nil .
+_:a7bcd034eadbf0577e59b123707dd31bbd105681183ea0b8e5cf98914676d3a59_target_child_1_filler_child_1 rdf:type owl:Restriction .
+_:a7bcd034eadbf0577e59b123707dd31bbd105681183ea0b8e5cf98914676d3a59_target_child_1_filler_child_1 owl:onProperty <https://www.commoncoreontologies.org/ont00001801> .
+_:a7bcd034eadbf0577e59b123707dd31bbd105681183ea0b8e5cf98914676d3a59_target_child_1_filler_child_1 owl:someValuesFrom _:a7bcd034eadbf0577e59b123707dd31bbd105681183ea0b8e5cf98914676d3a59_target_child_1_filler_child_1_filler .
+_:a7bcd034eadbf0577e59b123707dd31bbd105681183ea0b8e5cf98914676d3a59_target_child_1_filler_child_1_filler rdf:type owl:Class .
+_:a7bcd034eadbf0577e59b123707dd31bbd105681183ea0b8e5cf98914676d3a59_target_child_1_filler_child_1_filler owl:intersectionOf _:a7bcd034eadbf0577e59b123707dd31bbd105681183ea0b8e5cf98914676d3a59_target_child_1_filler_child_1_filler_list_0 .
+_:a7bcd034eadbf0577e59b123707dd31bbd105681183ea0b8e5cf98914676d3a59_target_child_1_filler_child_1_filler_list_0 rdf:first <https://www.commoncoreontologies.org/ont00000853> .
+_:a7bcd034eadbf0577e59b123707dd31bbd105681183ea0b8e5cf98914676d3a59_target_child_1_filler_child_1_filler_list_0 rdf:rest _:a7bcd034eadbf0577e59b123707dd31bbd105681183ea0b8e5cf98914676d3a59_target_child_1_filler_child_1_filler_list_1 .
+_:a7bcd034eadbf0577e59b123707dd31bbd105681183ea0b8e5cf98914676d3a59_target_child_1_filler_child_1_filler_list_1 rdf:first _:a7bcd034eadbf0577e59b123707dd31bbd105681183ea0b8e5cf98914676d3a59_target_child_1_filler_child_1_filler_child_1 .
+_:a7bcd034eadbf0577e59b123707dd31bbd105681183ea0b8e5cf98914676d3a59_target_child_1_filler_child_1_filler_list_1 rdf:rest rdf:nil .
+_:a7bcd034eadbf0577e59b123707dd31bbd105681183ea0b8e5cf98914676d3a59_target_child_1_filler_child_1_filler_child_1 rdf:type owl:Restriction .
+_:a7bcd034eadbf0577e59b123707dd31bbd105681183ea0b8e5cf98914676d3a59_target_child_1_filler_child_1_filler_child_1 owl:onProperty <https://www.commoncoreontologies.org/ont00001904> .
+_:a7bcd034eadbf0577e59b123707dd31bbd105681183ea0b8e5cf98914676d3a59_target_child_1_filler_child_1_filler_child_1 owl:someValuesFrom _:a7bcd034eadbf0577e59b123707dd31bbd105681183ea0b8e5cf98914676d3a59_target_child_1_filler_child_1_filler_child_1_filler .
+_:a7bcd034eadbf0577e59b123707dd31bbd105681183ea0b8e5cf98914676d3a59_target_child_1_filler_child_1_filler_child_1_filler rdf:type owl:Class .
+_:a7bcd034eadbf0577e59b123707dd31bbd105681183ea0b8e5cf98914676d3a59_target_child_1_filler_child_1_filler_child_1_filler owl:intersectionOf _:a7bcd034eadbf0577e59b123707dd31bbd105681183ea0b8e5cf98914676d3a59_target_child_1_filler_child_1_filler_child_1_filler_list_0 .
+_:a7bcd034eadbf0577e59b123707dd31bbd105681183ea0b8e5cf98914676d3a59_target_child_1_filler_child_1_filler_child_1_filler_list_0 rdf:first <https://www.commoncoreontologies.org/ont00001256> .
+_:a7bcd034eadbf0577e59b123707dd31bbd105681183ea0b8e5cf98914676d3a59_target_child_1_filler_child_1_filler_child_1_filler_list_0 rdf:rest _:a7bcd034eadbf0577e59b123707dd31bbd105681183ea0b8e5cf98914676d3a59_target_child_1_filler_child_1_filler_child_1_filler_list_1 .
+_:a7bcd034eadbf0577e59b123707dd31bbd105681183ea0b8e5cf98914676d3a59_target_child_1_filler_child_1_filler_child_1_filler_list_1 rdf:first _:a7bcd034eadbf0577e59b123707dd31bbd105681183ea0b8e5cf98914676d3a59_target_child_1_filler_child_1_filler_child_1_filler_child_1 .
+_:a7bcd034eadbf0577e59b123707dd31bbd105681183ea0b8e5cf98914676d3a59_target_child_1_filler_child_1_filler_child_1_filler_list_1 rdf:rest rdf:nil .
+_:a7bcd034eadbf0577e59b123707dd31bbd105681183ea0b8e5cf98914676d3a59_target_child_1_filler_child_1_filler_child_1_filler_child_1 rdf:type owl:Restriction .
+_:a7bcd034eadbf0577e59b123707dd31bbd105681183ea0b8e5cf98914676d3a59_target_child_1_filler_child_1_filler_child_1_filler_child_1 owl:onProperty <https://www.commoncoreontologies.org/ont00001920> .
+_:a7bcd034eadbf0577e59b123707dd31bbd105681183ea0b8e5cf98914676d3a59_target_child_1_filler_child_1_filler_child_1_filler_child_1 owl:someValuesFrom <https://www.commoncoreontologies.org/ont00000118> .
+
+<http://www.w3.org/ns/ssn/systems/Resolution> rdfs:subClassOf _:a851caee27c77385ceed70a2deb1a071a3e708361318649f6f62e6b37813791a9_target .
+_:a851caee27c77385ceed70a2deb1a071a3e708361318649f6f62e6b37813791a9_target rdf:type owl:Class .
+_:a851caee27c77385ceed70a2deb1a071a3e708361318649f6f62e6b37813791a9_target owl:intersectionOf _:a851caee27c77385ceed70a2deb1a071a3e708361318649f6f62e6b37813791a9_target_list_0 .
+_:a851caee27c77385ceed70a2deb1a071a3e708361318649f6f62e6b37813791a9_target_list_0 rdf:first <http://purl.obolibrary.org/obo/BFO_0000034> .
+_:a851caee27c77385ceed70a2deb1a071a3e708361318649f6f62e6b37813791a9_target_list_0 rdf:rest _:a851caee27c77385ceed70a2deb1a071a3e708361318649f6f62e6b37813791a9_target_list_1 .
+_:a851caee27c77385ceed70a2deb1a071a3e708361318649f6f62e6b37813791a9_target_list_1 rdf:first _:a851caee27c77385ceed70a2deb1a071a3e708361318649f6f62e6b37813791a9_target_child_1 .
+_:a851caee27c77385ceed70a2deb1a071a3e708361318649f6f62e6b37813791a9_target_list_1 rdf:rest rdf:nil .
+_:a851caee27c77385ceed70a2deb1a071a3e708361318649f6f62e6b37813791a9_target_child_1 rdf:type owl:Restriction .
+_:a851caee27c77385ceed70a2deb1a071a3e708361318649f6f62e6b37813791a9_target_child_1 owl:onProperty <http://purl.obolibrary.org/obo/BFO_0000054> .
+_:a851caee27c77385ceed70a2deb1a071a3e708361318649f6f62e6b37813791a9_target_child_1 owl:someValuesFrom _:a851caee27c77385ceed70a2deb1a071a3e708361318649f6f62e6b37813791a9_target_child_1_filler .
+_:a851caee27c77385ceed70a2deb1a071a3e708361318649f6f62e6b37813791a9_target_child_1_filler rdf:type owl:Class .
+_:a851caee27c77385ceed70a2deb1a071a3e708361318649f6f62e6b37813791a9_target_child_1_filler owl:intersectionOf _:a851caee27c77385ceed70a2deb1a071a3e708361318649f6f62e6b37813791a9_target_child_1_filler_list_0 .
+_:a851caee27c77385ceed70a2deb1a071a3e708361318649f6f62e6b37813791a9_target_child_1_filler_list_0 rdf:first <http://purl.obolibrary.org/obo/BFO_0000015> .
+_:a851caee27c77385ceed70a2deb1a071a3e708361318649f6f62e6b37813791a9_target_child_1_filler_list_0 rdf:rest _:a851caee27c77385ceed70a2deb1a071a3e708361318649f6f62e6b37813791a9_target_child_1_filler_list_1 .
+_:a851caee27c77385ceed70a2deb1a071a3e708361318649f6f62e6b37813791a9_target_child_1_filler_list_1 rdf:first _:a851caee27c77385ceed70a2deb1a071a3e708361318649f6f62e6b37813791a9_target_child_1_filler_child_1 .
+_:a851caee27c77385ceed70a2deb1a071a3e708361318649f6f62e6b37813791a9_target_child_1_filler_list_1 rdf:rest rdf:nil .
+_:a851caee27c77385ceed70a2deb1a071a3e708361318649f6f62e6b37813791a9_target_child_1_filler_child_1 rdf:type owl:Restriction .
+_:a851caee27c77385ceed70a2deb1a071a3e708361318649f6f62e6b37813791a9_target_child_1_filler_child_1 owl:onProperty <https://www.commoncoreontologies.org/ont00001801> .
+_:a851caee27c77385ceed70a2deb1a071a3e708361318649f6f62e6b37813791a9_target_child_1_filler_child_1 owl:someValuesFrom _:a851caee27c77385ceed70a2deb1a071a3e708361318649f6f62e6b37813791a9_target_child_1_filler_child_1_filler .
+_:a851caee27c77385ceed70a2deb1a071a3e708361318649f6f62e6b37813791a9_target_child_1_filler_child_1_filler rdf:type owl:Class .
+_:a851caee27c77385ceed70a2deb1a071a3e708361318649f6f62e6b37813791a9_target_child_1_filler_child_1_filler owl:intersectionOf _:a851caee27c77385ceed70a2deb1a071a3e708361318649f6f62e6b37813791a9_target_child_1_filler_child_1_filler_list_0 .
+_:a851caee27c77385ceed70a2deb1a071a3e708361318649f6f62e6b37813791a9_target_child_1_filler_child_1_filler_list_0 rdf:first <https://www.commoncoreontologies.org/ont00000853> .
+_:a851caee27c77385ceed70a2deb1a071a3e708361318649f6f62e6b37813791a9_target_child_1_filler_child_1_filler_list_0 rdf:rest _:a851caee27c77385ceed70a2deb1a071a3e708361318649f6f62e6b37813791a9_target_child_1_filler_child_1_filler_list_1 .
+_:a851caee27c77385ceed70a2deb1a071a3e708361318649f6f62e6b37813791a9_target_child_1_filler_child_1_filler_list_1 rdf:first _:a851caee27c77385ceed70a2deb1a071a3e708361318649f6f62e6b37813791a9_target_child_1_filler_child_1_filler_child_1 .
+_:a851caee27c77385ceed70a2deb1a071a3e708361318649f6f62e6b37813791a9_target_child_1_filler_child_1_filler_list_1 rdf:rest rdf:nil .
+_:a851caee27c77385ceed70a2deb1a071a3e708361318649f6f62e6b37813791a9_target_child_1_filler_child_1_filler_child_1 rdf:type owl:Restriction .
+_:a851caee27c77385ceed70a2deb1a071a3e708361318649f6f62e6b37813791a9_target_child_1_filler_child_1_filler_child_1 owl:onProperty <https://www.commoncoreontologies.org/ont00001904> .
+_:a851caee27c77385ceed70a2deb1a071a3e708361318649f6f62e6b37813791a9_target_child_1_filler_child_1_filler_child_1 owl:someValuesFrom _:a851caee27c77385ceed70a2deb1a071a3e708361318649f6f62e6b37813791a9_target_child_1_filler_child_1_filler_child_1_filler .
+_:a851caee27c77385ceed70a2deb1a071a3e708361318649f6f62e6b37813791a9_target_child_1_filler_child_1_filler_child_1_filler rdf:type owl:Class .
+_:a851caee27c77385ceed70a2deb1a071a3e708361318649f6f62e6b37813791a9_target_child_1_filler_child_1_filler_child_1_filler owl:intersectionOf _:a851caee27c77385ceed70a2deb1a071a3e708361318649f6f62e6b37813791a9_target_child_1_filler_child_1_filler_child_1_filler_list_0 .
+_:a851caee27c77385ceed70a2deb1a071a3e708361318649f6f62e6b37813791a9_target_child_1_filler_child_1_filler_child_1_filler_list_0 rdf:first <https://www.commoncoreontologies.org/ont00000731> .
+_:a851caee27c77385ceed70a2deb1a071a3e708361318649f6f62e6b37813791a9_target_child_1_filler_child_1_filler_child_1_filler_list_0 rdf:rest _:a851caee27c77385ceed70a2deb1a071a3e708361318649f6f62e6b37813791a9_target_child_1_filler_child_1_filler_child_1_filler_list_1 .
+_:a851caee27c77385ceed70a2deb1a071a3e708361318649f6f62e6b37813791a9_target_child_1_filler_child_1_filler_child_1_filler_list_1 rdf:first _:a851caee27c77385ceed70a2deb1a071a3e708361318649f6f62e6b37813791a9_target_child_1_filler_child_1_filler_child_1_filler_child_1 .
+_:a851caee27c77385ceed70a2deb1a071a3e708361318649f6f62e6b37813791a9_target_child_1_filler_child_1_filler_child_1_filler_list_1 rdf:rest rdf:nil .
+_:a851caee27c77385ceed70a2deb1a071a3e708361318649f6f62e6b37813791a9_target_child_1_filler_child_1_filler_child_1_filler_child_1 rdf:type owl:Restriction .
+_:a851caee27c77385ceed70a2deb1a071a3e708361318649f6f62e6b37813791a9_target_child_1_filler_child_1_filler_child_1_filler_child_1 owl:onProperty <https://www.commoncoreontologies.org/ont00001920> .
+_:a851caee27c77385ceed70a2deb1a071a3e708361318649f6f62e6b37813791a9_target_child_1_filler_child_1_filler_child_1_filler_child_1 owl:someValuesFrom <https://www.commoncoreontologies.org/ont00000118> .
+
+<http://www.w3.org/ns/ssn/systems/ResponseTime> rdfs:subClassOf _:ad7147bf65fde2651641479cec361657f97e01137ad2b760e37061eae25cbe368_target .
+_:ad7147bf65fde2651641479cec361657f97e01137ad2b760e37061eae25cbe368_target rdf:type owl:Class .
+_:ad7147bf65fde2651641479cec361657f97e01137ad2b760e37061eae25cbe368_target owl:intersectionOf _:ad7147bf65fde2651641479cec361657f97e01137ad2b760e37061eae25cbe368_target_list_0 .
+_:ad7147bf65fde2651641479cec361657f97e01137ad2b760e37061eae25cbe368_target_list_0 rdf:first <http://purl.obolibrary.org/obo/BFO_0000034> .
+_:ad7147bf65fde2651641479cec361657f97e01137ad2b760e37061eae25cbe368_target_list_0 rdf:rest _:ad7147bf65fde2651641479cec361657f97e01137ad2b760e37061eae25cbe368_target_list_1 .
+_:ad7147bf65fde2651641479cec361657f97e01137ad2b760e37061eae25cbe368_target_list_1 rdf:first _:ad7147bf65fde2651641479cec361657f97e01137ad2b760e37061eae25cbe368_target_child_1 .
+_:ad7147bf65fde2651641479cec361657f97e01137ad2b760e37061eae25cbe368_target_list_1 rdf:rest rdf:nil .
+_:ad7147bf65fde2651641479cec361657f97e01137ad2b760e37061eae25cbe368_target_child_1 rdf:type owl:Restriction .
+_:ad7147bf65fde2651641479cec361657f97e01137ad2b760e37061eae25cbe368_target_child_1 owl:onProperty <http://purl.obolibrary.org/obo/BFO_0000054> .
+_:ad7147bf65fde2651641479cec361657f97e01137ad2b760e37061eae25cbe368_target_child_1 owl:someValuesFrom _:ad7147bf65fde2651641479cec361657f97e01137ad2b760e37061eae25cbe368_target_child_1_filler .
+_:ad7147bf65fde2651641479cec361657f97e01137ad2b760e37061eae25cbe368_target_child_1_filler rdf:type owl:Class .
+_:ad7147bf65fde2651641479cec361657f97e01137ad2b760e37061eae25cbe368_target_child_1_filler owl:intersectionOf _:ad7147bf65fde2651641479cec361657f97e01137ad2b760e37061eae25cbe368_target_child_1_filler_list_0 .
+_:ad7147bf65fde2651641479cec361657f97e01137ad2b760e37061eae25cbe368_target_child_1_filler_list_0 rdf:first <https://www.commoncoreontologies.org/ont00000228> .
+_:ad7147bf65fde2651641479cec361657f97e01137ad2b760e37061eae25cbe368_target_child_1_filler_list_0 rdf:rest _:ad7147bf65fde2651641479cec361657f97e01137ad2b760e37061eae25cbe368_target_child_1_filler_list_1 .
+_:ad7147bf65fde2651641479cec361657f97e01137ad2b760e37061eae25cbe368_target_child_1_filler_list_1 rdf:first _:ad7147bf65fde2651641479cec361657f97e01137ad2b760e37061eae25cbe368_target_child_1_filler_child_1 .
+_:ad7147bf65fde2651641479cec361657f97e01137ad2b760e37061eae25cbe368_target_child_1_filler_list_1 rdf:rest _:ad7147bf65fde2651641479cec361657f97e01137ad2b760e37061eae25cbe368_target_child_1_filler_list_2 .
+_:ad7147bf65fde2651641479cec361657f97e01137ad2b760e37061eae25cbe368_target_child_1_filler_list_2 rdf:first _:ad7147bf65fde2651641479cec361657f97e01137ad2b760e37061eae25cbe368_target_child_1_filler_child_2 .
+_:ad7147bf65fde2651641479cec361657f97e01137ad2b760e37061eae25cbe368_target_child_1_filler_list_2 rdf:rest _:ad7147bf65fde2651641479cec361657f97e01137ad2b760e37061eae25cbe368_target_child_1_filler_list_3 .
+_:ad7147bf65fde2651641479cec361657f97e01137ad2b760e37061eae25cbe368_target_child_1_filler_list_3 rdf:first _:ad7147bf65fde2651641479cec361657f97e01137ad2b760e37061eae25cbe368_target_child_1_filler_child_3 .
+_:ad7147bf65fde2651641479cec361657f97e01137ad2b760e37061eae25cbe368_target_child_1_filler_list_3 rdf:rest rdf:nil .
+_:ad7147bf65fde2651641479cec361657f97e01137ad2b760e37061eae25cbe368_target_child_1_filler_child_1 rdf:type owl:Restriction .
+_:ad7147bf65fde2651641479cec361657f97e01137ad2b760e37061eae25cbe368_target_child_1_filler_child_1 owl:onProperty <https://www.commoncoreontologies.org/ont00001777> .
+_:ad7147bf65fde2651641479cec361657f97e01137ad2b760e37061eae25cbe368_target_child_1_filler_child_1 owl:someValuesFrom <https://www.commoncoreontologies.org/ont00000978> .
+_:ad7147bf65fde2651641479cec361657f97e01137ad2b760e37061eae25cbe368_target_child_1_filler_child_2 rdf:type owl:Restriction .
+_:ad7147bf65fde2651641479cec361657f97e01137ad2b760e37061eae25cbe368_target_child_1_filler_child_2 owl:onProperty <https://www.commoncoreontologies.org/ont00001777> .
+_:ad7147bf65fde2651641479cec361657f97e01137ad2b760e37061eae25cbe368_target_child_1_filler_child_2 owl:someValuesFrom <https://www.commoncoreontologies.org/ont00000660> .
+_:ad7147bf65fde2651641479cec361657f97e01137ad2b760e37061eae25cbe368_target_child_1_filler_child_3 rdf:type owl:Restriction .
+_:ad7147bf65fde2651641479cec361657f97e01137ad2b760e37061eae25cbe368_target_child_1_filler_child_3 owl:onProperty <http://purl.obolibrary.org/obo/BFO_0000199> .
+_:ad7147bf65fde2651641479cec361657f97e01137ad2b760e37061eae25cbe368_target_child_1_filler_child_3 owl:someValuesFrom _:ad7147bf65fde2651641479cec361657f97e01137ad2b760e37061eae25cbe368_target_child_1_filler_child_3_filler .
+_:ad7147bf65fde2651641479cec361657f97e01137ad2b760e37061eae25cbe368_target_child_1_filler_child_3_filler rdf:type owl:Class .
+_:ad7147bf65fde2651641479cec361657f97e01137ad2b760e37061eae25cbe368_target_child_1_filler_child_3_filler owl:intersectionOf _:ad7147bf65fde2651641479cec361657f97e01137ad2b760e37061eae25cbe368_target_child_1_filler_child_3_filler_list_0 .
+_:ad7147bf65fde2651641479cec361657f97e01137ad2b760e37061eae25cbe368_target_child_1_filler_child_3_filler_list_0 rdf:first <http://purl.obolibrary.org/obo/BFO_0000008> .
+_:ad7147bf65fde2651641479cec361657f97e01137ad2b760e37061eae25cbe368_target_child_1_filler_child_3_filler_list_0 rdf:rest _:ad7147bf65fde2651641479cec361657f97e01137ad2b760e37061eae25cbe368_target_child_1_filler_child_3_filler_list_1 .
+_:ad7147bf65fde2651641479cec361657f97e01137ad2b760e37061eae25cbe368_target_child_1_filler_child_3_filler_list_1 rdf:first _:ad7147bf65fde2651641479cec361657f97e01137ad2b760e37061eae25cbe368_target_child_1_filler_child_3_filler_child_1 .
+_:ad7147bf65fde2651641479cec361657f97e01137ad2b760e37061eae25cbe368_target_child_1_filler_child_3_filler_list_1 rdf:rest rdf:nil .
+_:ad7147bf65fde2651641479cec361657f97e01137ad2b760e37061eae25cbe368_target_child_1_filler_child_3_filler_child_1 rdf:type owl:Restriction .
+_:ad7147bf65fde2651641479cec361657f97e01137ad2b760e37061eae25cbe368_target_child_1_filler_child_3_filler_child_1 owl:onProperty <https://www.commoncoreontologies.org/ont00001920> .
+_:ad7147bf65fde2651641479cec361657f97e01137ad2b760e37061eae25cbe368_target_child_1_filler_child_3_filler_child_1 owl:someValuesFrom <https://www.commoncoreontologies.org/ont00000118> .
+
+<http://www.w3.org/ns/ssn/systems/Selectivity> rdfs:subClassOf _:a3638f72bc407bf83119efc46ddbf7364798b8e5afa31a906bc1d736b62d980b1_target .
+_:a3638f72bc407bf83119efc46ddbf7364798b8e5afa31a906bc1d736b62d980b1_target rdf:type owl:Class .
+_:a3638f72bc407bf83119efc46ddbf7364798b8e5afa31a906bc1d736b62d980b1_target owl:intersectionOf _:a3638f72bc407bf83119efc46ddbf7364798b8e5afa31a906bc1d736b62d980b1_target_list_0 .
+_:a3638f72bc407bf83119efc46ddbf7364798b8e5afa31a906bc1d736b62d980b1_target_list_0 rdf:first <http://purl.obolibrary.org/obo/BFO_0000034> .
+_:a3638f72bc407bf83119efc46ddbf7364798b8e5afa31a906bc1d736b62d980b1_target_list_0 rdf:rest _:a3638f72bc407bf83119efc46ddbf7364798b8e5afa31a906bc1d736b62d980b1_target_list_1 .
+_:a3638f72bc407bf83119efc46ddbf7364798b8e5afa31a906bc1d736b62d980b1_target_list_1 rdf:first _:a3638f72bc407bf83119efc46ddbf7364798b8e5afa31a906bc1d736b62d980b1_target_child_1 .
+_:a3638f72bc407bf83119efc46ddbf7364798b8e5afa31a906bc1d736b62d980b1_target_list_1 rdf:rest rdf:nil .
+_:a3638f72bc407bf83119efc46ddbf7364798b8e5afa31a906bc1d736b62d980b1_target_child_1 rdf:type owl:Restriction .
+_:a3638f72bc407bf83119efc46ddbf7364798b8e5afa31a906bc1d736b62d980b1_target_child_1 owl:onProperty <http://purl.obolibrary.org/obo/BFO_0000054> .
+_:a3638f72bc407bf83119efc46ddbf7364798b8e5afa31a906bc1d736b62d980b1_target_child_1 owl:someValuesFrom _:a3638f72bc407bf83119efc46ddbf7364798b8e5afa31a906bc1d736b62d980b1_target_child_1_filler .
+_:a3638f72bc407bf83119efc46ddbf7364798b8e5afa31a906bc1d736b62d980b1_target_child_1_filler rdf:type owl:Class .
+_:a3638f72bc407bf83119efc46ddbf7364798b8e5afa31a906bc1d736b62d980b1_target_child_1_filler owl:intersectionOf _:a3638f72bc407bf83119efc46ddbf7364798b8e5afa31a906bc1d736b62d980b1_target_child_1_filler_list_0 .
+_:a3638f72bc407bf83119efc46ddbf7364798b8e5afa31a906bc1d736b62d980b1_target_child_1_filler_list_0 rdf:first <https://www.commoncoreontologies.org/ont00000228> .
+_:a3638f72bc407bf83119efc46ddbf7364798b8e5afa31a906bc1d736b62d980b1_target_child_1_filler_list_0 rdf:rest _:a3638f72bc407bf83119efc46ddbf7364798b8e5afa31a906bc1d736b62d980b1_target_child_1_filler_list_1 .
+_:a3638f72bc407bf83119efc46ddbf7364798b8e5afa31a906bc1d736b62d980b1_target_child_1_filler_list_1 rdf:first _:a3638f72bc407bf83119efc46ddbf7364798b8e5afa31a906bc1d736b62d980b1_target_child_1_filler_child_1 .
+_:a3638f72bc407bf83119efc46ddbf7364798b8e5afa31a906bc1d736b62d980b1_target_child_1_filler_list_1 rdf:rest rdf:nil .
+_:a3638f72bc407bf83119efc46ddbf7364798b8e5afa31a906bc1d736b62d980b1_target_child_1_filler_child_1 rdf:type owl:Restriction .
+_:a3638f72bc407bf83119efc46ddbf7364798b8e5afa31a906bc1d736b62d980b1_target_child_1_filler_child_1 owl:onProperty <http://purl.obolibrary.org/obo/BFO_0000057> .
+_:a3638f72bc407bf83119efc46ddbf7364798b8e5afa31a906bc1d736b62d980b1_target_child_1_filler_child_1 owl:someValuesFrom _:a3638f72bc407bf83119efc46ddbf7364798b8e5afa31a906bc1d736b62d980b1_target_child_1_filler_child_1_filler .
+_:a3638f72bc407bf83119efc46ddbf7364798b8e5afa31a906bc1d736b62d980b1_target_child_1_filler_child_1_filler rdf:type owl:Class .
+_:a3638f72bc407bf83119efc46ddbf7364798b8e5afa31a906bc1d736b62d980b1_target_child_1_filler_child_1_filler owl:intersectionOf _:a3638f72bc407bf83119efc46ddbf7364798b8e5afa31a906bc1d736b62d980b1_target_child_1_filler_child_1_filler_list_0 .
+_:a3638f72bc407bf83119efc46ddbf7364798b8e5afa31a906bc1d736b62d980b1_target_child_1_filler_child_1_filler_list_0 rdf:first <http://purl.obolibrary.org/obo/BFO_0000002> .
+_:a3638f72bc407bf83119efc46ddbf7364798b8e5afa31a906bc1d736b62d980b1_target_child_1_filler_child_1_filler_list_0 rdf:rest _:a3638f72bc407bf83119efc46ddbf7364798b8e5afa31a906bc1d736b62d980b1_target_child_1_filler_child_1_filler_list_1 .
+_:a3638f72bc407bf83119efc46ddbf7364798b8e5afa31a906bc1d736b62d980b1_target_child_1_filler_child_1_filler_list_1 rdf:first _:a3638f72bc407bf83119efc46ddbf7364798b8e5afa31a906bc1d736b62d980b1_target_child_1_filler_child_1_filler_child_1 .
+_:a3638f72bc407bf83119efc46ddbf7364798b8e5afa31a906bc1d736b62d980b1_target_child_1_filler_child_1_filler_list_1 rdf:rest rdf:nil .
+_:a3638f72bc407bf83119efc46ddbf7364798b8e5afa31a906bc1d736b62d980b1_target_child_1_filler_child_1_filler_child_1 rdf:type owl:Restriction .
+_:a3638f72bc407bf83119efc46ddbf7364798b8e5afa31a906bc1d736b62d980b1_target_child_1_filler_child_1_filler_child_1 owl:onProperty <https://www.commoncoreontologies.org/ont00001920> .
+_:a3638f72bc407bf83119efc46ddbf7364798b8e5afa31a906bc1d736b62d980b1_target_child_1_filler_child_1_filler_child_1 owl:someValuesFrom <https://www.commoncoreontologies.org/ont00000118> .
+
+<http://www.w3.org/ns/ssn/systems/Sensitivity> rdfs:subClassOf _:af7079e239ac89c931c0bf767439ded105c7d1760b7b6e0346551ef3c46d3f759_target .
+_:af7079e239ac89c931c0bf767439ded105c7d1760b7b6e0346551ef3c46d3f759_target rdf:type owl:Class .
+_:af7079e239ac89c931c0bf767439ded105c7d1760b7b6e0346551ef3c46d3f759_target owl:intersectionOf _:af7079e239ac89c931c0bf767439ded105c7d1760b7b6e0346551ef3c46d3f759_target_list_0 .
+_:af7079e239ac89c931c0bf767439ded105c7d1760b7b6e0346551ef3c46d3f759_target_list_0 rdf:first <http://purl.obolibrary.org/obo/BFO_0000034> .
+_:af7079e239ac89c931c0bf767439ded105c7d1760b7b6e0346551ef3c46d3f759_target_list_0 rdf:rest _:af7079e239ac89c931c0bf767439ded105c7d1760b7b6e0346551ef3c46d3f759_target_list_1 .
+_:af7079e239ac89c931c0bf767439ded105c7d1760b7b6e0346551ef3c46d3f759_target_list_1 rdf:first _:af7079e239ac89c931c0bf767439ded105c7d1760b7b6e0346551ef3c46d3f759_target_child_1 .
+_:af7079e239ac89c931c0bf767439ded105c7d1760b7b6e0346551ef3c46d3f759_target_list_1 rdf:rest rdf:nil .
+_:af7079e239ac89c931c0bf767439ded105c7d1760b7b6e0346551ef3c46d3f759_target_child_1 rdf:type owl:Restriction .
+_:af7079e239ac89c931c0bf767439ded105c7d1760b7b6e0346551ef3c46d3f759_target_child_1 owl:onProperty <http://purl.obolibrary.org/obo/BFO_0000054> .
+_:af7079e239ac89c931c0bf767439ded105c7d1760b7b6e0346551ef3c46d3f759_target_child_1 owl:someValuesFrom _:af7079e239ac89c931c0bf767439ded105c7d1760b7b6e0346551ef3c46d3f759_target_child_1_filler .
+_:af7079e239ac89c931c0bf767439ded105c7d1760b7b6e0346551ef3c46d3f759_target_child_1_filler rdf:type owl:Class .
+_:af7079e239ac89c931c0bf767439ded105c7d1760b7b6e0346551ef3c46d3f759_target_child_1_filler owl:intersectionOf _:af7079e239ac89c931c0bf767439ded105c7d1760b7b6e0346551ef3c46d3f759_target_child_1_filler_list_0 .
+_:af7079e239ac89c931c0bf767439ded105c7d1760b7b6e0346551ef3c46d3f759_target_child_1_filler_list_0 rdf:first <http://purl.obolibrary.org/obo/BFO_0000015> .
+_:af7079e239ac89c931c0bf767439ded105c7d1760b7b6e0346551ef3c46d3f759_target_child_1_filler_list_0 rdf:rest _:af7079e239ac89c931c0bf767439ded105c7d1760b7b6e0346551ef3c46d3f759_target_child_1_filler_list_1 .
+_:af7079e239ac89c931c0bf767439ded105c7d1760b7b6e0346551ef3c46d3f759_target_child_1_filler_list_1 rdf:first _:af7079e239ac89c931c0bf767439ded105c7d1760b7b6e0346551ef3c46d3f759_target_child_1_filler_child_1 .
+_:af7079e239ac89c931c0bf767439ded105c7d1760b7b6e0346551ef3c46d3f759_target_child_1_filler_list_1 rdf:rest rdf:nil .
+_:af7079e239ac89c931c0bf767439ded105c7d1760b7b6e0346551ef3c46d3f759_target_child_1_filler_child_1 rdf:type owl:Restriction .
+_:af7079e239ac89c931c0bf767439ded105c7d1760b7b6e0346551ef3c46d3f759_target_child_1_filler_child_1 owl:onProperty <https://www.commoncoreontologies.org/ont00001801> .
+_:af7079e239ac89c931c0bf767439ded105c7d1760b7b6e0346551ef3c46d3f759_target_child_1_filler_child_1 owl:someValuesFrom _:af7079e239ac89c931c0bf767439ded105c7d1760b7b6e0346551ef3c46d3f759_target_child_1_filler_child_1_filler .
+_:af7079e239ac89c931c0bf767439ded105c7d1760b7b6e0346551ef3c46d3f759_target_child_1_filler_child_1_filler rdf:type owl:Class .
+_:af7079e239ac89c931c0bf767439ded105c7d1760b7b6e0346551ef3c46d3f759_target_child_1_filler_child_1_filler owl:intersectionOf _:af7079e239ac89c931c0bf767439ded105c7d1760b7b6e0346551ef3c46d3f759_target_child_1_filler_child_1_filler_list_0 .
+_:af7079e239ac89c931c0bf767439ded105c7d1760b7b6e0346551ef3c46d3f759_target_child_1_filler_child_1_filler_list_0 rdf:first <https://www.commoncoreontologies.org/ont00000853> .
+_:af7079e239ac89c931c0bf767439ded105c7d1760b7b6e0346551ef3c46d3f759_target_child_1_filler_child_1_filler_list_0 rdf:rest _:af7079e239ac89c931c0bf767439ded105c7d1760b7b6e0346551ef3c46d3f759_target_child_1_filler_child_1_filler_list_1 .
+_:af7079e239ac89c931c0bf767439ded105c7d1760b7b6e0346551ef3c46d3f759_target_child_1_filler_child_1_filler_list_1 rdf:first _:af7079e239ac89c931c0bf767439ded105c7d1760b7b6e0346551ef3c46d3f759_target_child_1_filler_child_1_filler_child_1 .
+_:af7079e239ac89c931c0bf767439ded105c7d1760b7b6e0346551ef3c46d3f759_target_child_1_filler_child_1_filler_list_1 rdf:rest rdf:nil .
+_:af7079e239ac89c931c0bf767439ded105c7d1760b7b6e0346551ef3c46d3f759_target_child_1_filler_child_1_filler_child_1 rdf:type owl:Restriction .
+_:af7079e239ac89c931c0bf767439ded105c7d1760b7b6e0346551ef3c46d3f759_target_child_1_filler_child_1_filler_child_1 owl:onProperty <https://www.commoncoreontologies.org/ont00001904> .
+_:af7079e239ac89c931c0bf767439ded105c7d1760b7b6e0346551ef3c46d3f759_target_child_1_filler_child_1_filler_child_1 owl:someValuesFrom _:af7079e239ac89c931c0bf767439ded105c7d1760b7b6e0346551ef3c46d3f759_target_child_1_filler_child_1_filler_child_1_filler .
+_:af7079e239ac89c931c0bf767439ded105c7d1760b7b6e0346551ef3c46d3f759_target_child_1_filler_child_1_filler_child_1_filler rdf:type owl:Class .
+_:af7079e239ac89c931c0bf767439ded105c7d1760b7b6e0346551ef3c46d3f759_target_child_1_filler_child_1_filler_child_1_filler owl:intersectionOf _:af7079e239ac89c931c0bf767439ded105c7d1760b7b6e0346551ef3c46d3f759_target_child_1_filler_child_1_filler_child_1_filler_list_0 .
+_:af7079e239ac89c931c0bf767439ded105c7d1760b7b6e0346551ef3c46d3f759_target_child_1_filler_child_1_filler_child_1_filler_list_0 rdf:first <https://www.commoncoreontologies.org/ont00001022> .
+_:af7079e239ac89c931c0bf767439ded105c7d1760b7b6e0346551ef3c46d3f759_target_child_1_filler_child_1_filler_child_1_filler_list_0 rdf:rest _:af7079e239ac89c931c0bf767439ded105c7d1760b7b6e0346551ef3c46d3f759_target_child_1_filler_child_1_filler_child_1_filler_list_1 .
+_:af7079e239ac89c931c0bf767439ded105c7d1760b7b6e0346551ef3c46d3f759_target_child_1_filler_child_1_filler_child_1_filler_list_1 rdf:first _:af7079e239ac89c931c0bf767439ded105c7d1760b7b6e0346551ef3c46d3f759_target_child_1_filler_child_1_filler_child_1_filler_child_1 .
+_:af7079e239ac89c931c0bf767439ded105c7d1760b7b6e0346551ef3c46d3f759_target_child_1_filler_child_1_filler_child_1_filler_list_1 rdf:rest rdf:nil .
+_:af7079e239ac89c931c0bf767439ded105c7d1760b7b6e0346551ef3c46d3f759_target_child_1_filler_child_1_filler_child_1_filler_child_1 rdf:type owl:Restriction .
+_:af7079e239ac89c931c0bf767439ded105c7d1760b7b6e0346551ef3c46d3f759_target_child_1_filler_child_1_filler_child_1_filler_child_1 owl:onProperty <https://www.commoncoreontologies.org/ont00001920> .
+_:af7079e239ac89c931c0bf767439ded105c7d1760b7b6e0346551ef3c46d3f759_target_child_1_filler_child_1_filler_child_1_filler_child_1 owl:someValuesFrom <https://www.commoncoreontologies.org/ont00000118> .
+
+<http://www.w3.org/ns/ssn/systems/SurvivalProperty> rdfs:subClassOf _:a6c917d0118060a0a5c8175a486c2880f4948c998bfc384d1494925e0e9e26390_target .
+_:a6c917d0118060a0a5c8175a486c2880f4948c998bfc384d1494925e0e9e26390_target rdf:type owl:Class .
+_:a6c917d0118060a0a5c8175a486c2880f4948c998bfc384d1494925e0e9e26390_target owl:intersectionOf _:a6c917d0118060a0a5c8175a486c2880f4948c998bfc384d1494925e0e9e26390_target_list_0 .
+_:a6c917d0118060a0a5c8175a486c2880f4948c998bfc384d1494925e0e9e26390_target_list_0 rdf:first <http://purl.obolibrary.org/obo/BFO_0000034> .
+_:a6c917d0118060a0a5c8175a486c2880f4948c998bfc384d1494925e0e9e26390_target_list_0 rdf:rest _:a6c917d0118060a0a5c8175a486c2880f4948c998bfc384d1494925e0e9e26390_target_list_1 .
+_:a6c917d0118060a0a5c8175a486c2880f4948c998bfc384d1494925e0e9e26390_target_list_1 rdf:first _:a6c917d0118060a0a5c8175a486c2880f4948c998bfc384d1494925e0e9e26390_target_child_1 .
+_:a6c917d0118060a0a5c8175a486c2880f4948c998bfc384d1494925e0e9e26390_target_list_1 rdf:rest rdf:nil .
+_:a6c917d0118060a0a5c8175a486c2880f4948c998bfc384d1494925e0e9e26390_target_child_1 rdf:type owl:Restriction .
+_:a6c917d0118060a0a5c8175a486c2880f4948c998bfc384d1494925e0e9e26390_target_child_1 owl:onProperty <http://purl.obolibrary.org/obo/BFO_0000054> .
+_:a6c917d0118060a0a5c8175a486c2880f4948c998bfc384d1494925e0e9e26390_target_child_1 owl:someValuesFrom _:a6c917d0118060a0a5c8175a486c2880f4948c998bfc384d1494925e0e9e26390_target_child_1_filler .
+_:a6c917d0118060a0a5c8175a486c2880f4948c998bfc384d1494925e0e9e26390_target_child_1_filler rdf:type owl:Class .
+_:a6c917d0118060a0a5c8175a486c2880f4948c998bfc384d1494925e0e9e26390_target_child_1_filler owl:intersectionOf _:a6c917d0118060a0a5c8175a486c2880f4948c998bfc384d1494925e0e9e26390_target_child_1_filler_list_0 .
+_:a6c917d0118060a0a5c8175a486c2880f4948c998bfc384d1494925e0e9e26390_target_child_1_filler_list_0 rdf:first <http://purl.obolibrary.org/obo/BFO_0000015> .
+_:a6c917d0118060a0a5c8175a486c2880f4948c998bfc384d1494925e0e9e26390_target_child_1_filler_list_0 rdf:rest _:a6c917d0118060a0a5c8175a486c2880f4948c998bfc384d1494925e0e9e26390_target_child_1_filler_list_1 .
+_:a6c917d0118060a0a5c8175a486c2880f4948c998bfc384d1494925e0e9e26390_target_child_1_filler_list_1 rdf:first _:a6c917d0118060a0a5c8175a486c2880f4948c998bfc384d1494925e0e9e26390_target_child_1_filler_child_1 .
+_:a6c917d0118060a0a5c8175a486c2880f4948c998bfc384d1494925e0e9e26390_target_child_1_filler_list_1 rdf:rest rdf:nil .
+_:a6c917d0118060a0a5c8175a486c2880f4948c998bfc384d1494925e0e9e26390_target_child_1_filler_child_1 rdf:type owl:Restriction .
+_:a6c917d0118060a0a5c8175a486c2880f4948c998bfc384d1494925e0e9e26390_target_child_1_filler_child_1 owl:onProperty <https://www.commoncoreontologies.org/ont00001819> .
+_:a6c917d0118060a0a5c8175a486c2880f4948c998bfc384d1494925e0e9e26390_target_child_1_filler_child_1 owl:someValuesFrom _:a6c917d0118060a0a5c8175a486c2880f4948c998bfc384d1494925e0e9e26390_target_child_1_filler_child_1_filler .
+_:a6c917d0118060a0a5c8175a486c2880f4948c998bfc384d1494925e0e9e26390_target_child_1_filler_child_1_filler rdf:type owl:Class .
+_:a6c917d0118060a0a5c8175a486c2880f4948c998bfc384d1494925e0e9e26390_target_child_1_filler_child_1_filler owl:intersectionOf _:a6c917d0118060a0a5c8175a486c2880f4948c998bfc384d1494925e0e9e26390_target_child_1_filler_child_1_filler_list_0 .
+_:a6c917d0118060a0a5c8175a486c2880f4948c998bfc384d1494925e0e9e26390_target_child_1_filler_child_1_filler_list_0 rdf:first <http://purl.obolibrary.org/obo/BFO_0000015> .
+_:a6c917d0118060a0a5c8175a486c2880f4948c998bfc384d1494925e0e9e26390_target_child_1_filler_child_1_filler_list_0 rdf:rest _:a6c917d0118060a0a5c8175a486c2880f4948c998bfc384d1494925e0e9e26390_target_child_1_filler_child_1_filler_list_1 .
+_:a6c917d0118060a0a5c8175a486c2880f4948c998bfc384d1494925e0e9e26390_target_child_1_filler_child_1_filler_list_1 rdf:first _:a6c917d0118060a0a5c8175a486c2880f4948c998bfc384d1494925e0e9e26390_target_child_1_filler_child_1_filler_child_1 .
+_:a6c917d0118060a0a5c8175a486c2880f4948c998bfc384d1494925e0e9e26390_target_child_1_filler_child_1_filler_list_1 rdf:rest rdf:nil .
+_:a6c917d0118060a0a5c8175a486c2880f4948c998bfc384d1494925e0e9e26390_target_child_1_filler_child_1_filler_child_1 rdf:type owl:Restriction .
+_:a6c917d0118060a0a5c8175a486c2880f4948c998bfc384d1494925e0e9e26390_target_child_1_filler_child_1_filler_child_1 owl:onProperty <http://purl.obolibrary.org/obo/BFO_0000055> .
+_:a6c917d0118060a0a5c8175a486c2880f4948c998bfc384d1494925e0e9e26390_target_child_1_filler_child_1_filler_child_1 owl:someValuesFrom _:a6c917d0118060a0a5c8175a486c2880f4948c998bfc384d1494925e0e9e26390_target_child_1_filler_child_1_filler_child_1_filler .
+_:a6c917d0118060a0a5c8175a486c2880f4948c998bfc384d1494925e0e9e26390_target_child_1_filler_child_1_filler_child_1_filler rdf:type owl:Class .
+_:a6c917d0118060a0a5c8175a486c2880f4948c998bfc384d1494925e0e9e26390_target_child_1_filler_child_1_filler_child_1_filler owl:intersectionOf _:a6c917d0118060a0a5c8175a486c2880f4948c998bfc384d1494925e0e9e26390_target_child_1_filler_child_1_filler_child_1_filler_list_0 .
+_:a6c917d0118060a0a5c8175a486c2880f4948c998bfc384d1494925e0e9e26390_target_child_1_filler_child_1_filler_child_1_filler_list_0 rdf:first <https://www.commoncoreontologies.org/ont00000177> .
+_:a6c917d0118060a0a5c8175a486c2880f4948c998bfc384d1494925e0e9e26390_target_child_1_filler_child_1_filler_child_1_filler_list_0 rdf:rest _:a6c917d0118060a0a5c8175a486c2880f4948c998bfc384d1494925e0e9e26390_target_child_1_filler_child_1_filler_child_1_filler_list_1 .
+_:a6c917d0118060a0a5c8175a486c2880f4948c998bfc384d1494925e0e9e26390_target_child_1_filler_child_1_filler_child_1_filler_list_1 rdf:first _:a6c917d0118060a0a5c8175a486c2880f4948c998bfc384d1494925e0e9e26390_target_child_1_filler_child_1_filler_child_1_filler_child_1 .
+_:a6c917d0118060a0a5c8175a486c2880f4948c998bfc384d1494925e0e9e26390_target_child_1_filler_child_1_filler_child_1_filler_list_1 rdf:rest rdf:nil .
+_:a6c917d0118060a0a5c8175a486c2880f4948c998bfc384d1494925e0e9e26390_target_child_1_filler_child_1_filler_child_1_filler_child_1 rdf:type owl:Restriction .
+_:a6c917d0118060a0a5c8175a486c2880f4948c998bfc384d1494925e0e9e26390_target_child_1_filler_child_1_filler_child_1_filler_child_1 owl:onProperty <https://www.commoncoreontologies.org/ont00001920> .
+_:a6c917d0118060a0a5c8175a486c2880f4948c998bfc384d1494925e0e9e26390_target_child_1_filler_child_1_filler_child_1_filler_child_1 owl:someValuesFrom <https://www.commoncoreontologies.org/ont00000319> .
+
+<http://www.w3.org/ns/ssn/systems/SurvivalRange> rdfs:subClassOf _:ae941d1a04c368c1f5129efef4a5d369aae978e8850e6eecfab01bc9244eca46a_target .
+_:ae941d1a04c368c1f5129efef4a5d369aae978e8850e6eecfab01bc9244eca46a_target rdf:type owl:Class .
+_:ae941d1a04c368c1f5129efef4a5d369aae978e8850e6eecfab01bc9244eca46a_target owl:intersectionOf _:ae941d1a04c368c1f5129efef4a5d369aae978e8850e6eecfab01bc9244eca46a_target_list_0 .
+_:ae941d1a04c368c1f5129efef4a5d369aae978e8850e6eecfab01bc9244eca46a_target_list_0 rdf:first <http://purl.obolibrary.org/obo/BFO_0000034> .
+_:ae941d1a04c368c1f5129efef4a5d369aae978e8850e6eecfab01bc9244eca46a_target_list_0 rdf:rest _:ae941d1a04c368c1f5129efef4a5d369aae978e8850e6eecfab01bc9244eca46a_target_list_1 .
+_:ae941d1a04c368c1f5129efef4a5d369aae978e8850e6eecfab01bc9244eca46a_target_list_1 rdf:first _:ae941d1a04c368c1f5129efef4a5d369aae978e8850e6eecfab01bc9244eca46a_target_child_1 .
+_:ae941d1a04c368c1f5129efef4a5d369aae978e8850e6eecfab01bc9244eca46a_target_list_1 rdf:rest rdf:nil .
+_:ae941d1a04c368c1f5129efef4a5d369aae978e8850e6eecfab01bc9244eca46a_target_child_1 rdf:type owl:Restriction .
+_:ae941d1a04c368c1f5129efef4a5d369aae978e8850e6eecfab01bc9244eca46a_target_child_1 owl:onProperty <http://purl.obolibrary.org/obo/BFO_0000054> .
+_:ae941d1a04c368c1f5129efef4a5d369aae978e8850e6eecfab01bc9244eca46a_target_child_1 owl:someValuesFrom _:ae941d1a04c368c1f5129efef4a5d369aae978e8850e6eecfab01bc9244eca46a_target_child_1_filler .
+_:ae941d1a04c368c1f5129efef4a5d369aae978e8850e6eecfab01bc9244eca46a_target_child_1_filler rdf:type owl:Class .
+_:ae941d1a04c368c1f5129efef4a5d369aae978e8850e6eecfab01bc9244eca46a_target_child_1_filler owl:intersectionOf _:ae941d1a04c368c1f5129efef4a5d369aae978e8850e6eecfab01bc9244eca46a_target_child_1_filler_list_0 .
+_:ae941d1a04c368c1f5129efef4a5d369aae978e8850e6eecfab01bc9244eca46a_target_child_1_filler_list_0 rdf:first <http://purl.obolibrary.org/obo/BFO_0000015> .
+_:ae941d1a04c368c1f5129efef4a5d369aae978e8850e6eecfab01bc9244eca46a_target_child_1_filler_list_0 rdf:rest _:ae941d1a04c368c1f5129efef4a5d369aae978e8850e6eecfab01bc9244eca46a_target_child_1_filler_list_1 .
+_:ae941d1a04c368c1f5129efef4a5d369aae978e8850e6eecfab01bc9244eca46a_target_child_1_filler_list_1 rdf:first _:ae941d1a04c368c1f5129efef4a5d369aae978e8850e6eecfab01bc9244eca46a_target_child_1_filler_child_1 .
+_:ae941d1a04c368c1f5129efef4a5d369aae978e8850e6eecfab01bc9244eca46a_target_child_1_filler_list_1 rdf:rest rdf:nil .
+_:ae941d1a04c368c1f5129efef4a5d369aae978e8850e6eecfab01bc9244eca46a_target_child_1_filler_child_1 rdf:type owl:Restriction .
+_:ae941d1a04c368c1f5129efef4a5d369aae978e8850e6eecfab01bc9244eca46a_target_child_1_filler_child_1 owl:onProperty <https://www.commoncoreontologies.org/ont00001819> .
+_:ae941d1a04c368c1f5129efef4a5d369aae978e8850e6eecfab01bc9244eca46a_target_child_1_filler_child_1 owl:someValuesFrom _:ae941d1a04c368c1f5129efef4a5d369aae978e8850e6eecfab01bc9244eca46a_target_child_1_filler_child_1_filler .
+_:ae941d1a04c368c1f5129efef4a5d369aae978e8850e6eecfab01bc9244eca46a_target_child_1_filler_child_1_filler rdf:type owl:Class .
+_:ae941d1a04c368c1f5129efef4a5d369aae978e8850e6eecfab01bc9244eca46a_target_child_1_filler_child_1_filler owl:intersectionOf _:ae941d1a04c368c1f5129efef4a5d369aae978e8850e6eecfab01bc9244eca46a_target_child_1_filler_child_1_filler_list_0 .
+_:ae941d1a04c368c1f5129efef4a5d369aae978e8850e6eecfab01bc9244eca46a_target_child_1_filler_child_1_filler_list_0 rdf:first <http://purl.obolibrary.org/obo/BFO_0000015> .
+_:ae941d1a04c368c1f5129efef4a5d369aae978e8850e6eecfab01bc9244eca46a_target_child_1_filler_child_1_filler_list_0 rdf:rest _:ae941d1a04c368c1f5129efef4a5d369aae978e8850e6eecfab01bc9244eca46a_target_child_1_filler_child_1_filler_list_1 .
+_:ae941d1a04c368c1f5129efef4a5d369aae978e8850e6eecfab01bc9244eca46a_target_child_1_filler_child_1_filler_list_1 rdf:first _:ae941d1a04c368c1f5129efef4a5d369aae978e8850e6eecfab01bc9244eca46a_target_child_1_filler_child_1_filler_child_1 .
+_:ae941d1a04c368c1f5129efef4a5d369aae978e8850e6eecfab01bc9244eca46a_target_child_1_filler_child_1_filler_list_1 rdf:rest rdf:nil .
+_:ae941d1a04c368c1f5129efef4a5d369aae978e8850e6eecfab01bc9244eca46a_target_child_1_filler_child_1_filler_child_1 rdf:type owl:Restriction .
+_:ae941d1a04c368c1f5129efef4a5d369aae978e8850e6eecfab01bc9244eca46a_target_child_1_filler_child_1_filler_child_1 owl:onProperty <http://purl.obolibrary.org/obo/BFO_0000055> .
+_:ae941d1a04c368c1f5129efef4a5d369aae978e8850e6eecfab01bc9244eca46a_target_child_1_filler_child_1_filler_child_1 owl:someValuesFrom _:ae941d1a04c368c1f5129efef4a5d369aae978e8850e6eecfab01bc9244eca46a_target_child_1_filler_child_1_filler_child_1_filler .
+_:ae941d1a04c368c1f5129efef4a5d369aae978e8850e6eecfab01bc9244eca46a_target_child_1_filler_child_1_filler_child_1_filler rdf:type owl:Class .
+_:ae941d1a04c368c1f5129efef4a5d369aae978e8850e6eecfab01bc9244eca46a_target_child_1_filler_child_1_filler_child_1_filler owl:intersectionOf _:ae941d1a04c368c1f5129efef4a5d369aae978e8850e6eecfab01bc9244eca46a_target_child_1_filler_child_1_filler_child_1_filler_list_0 .
+_:ae941d1a04c368c1f5129efef4a5d369aae978e8850e6eecfab01bc9244eca46a_target_child_1_filler_child_1_filler_child_1_filler_list_0 rdf:first <https://www.commoncoreontologies.org/ont00000177> .
+_:ae941d1a04c368c1f5129efef4a5d369aae978e8850e6eecfab01bc9244eca46a_target_child_1_filler_child_1_filler_child_1_filler_list_0 rdf:rest _:ae941d1a04c368c1f5129efef4a5d369aae978e8850e6eecfab01bc9244eca46a_target_child_1_filler_child_1_filler_child_1_filler_list_1 .
+_:ae941d1a04c368c1f5129efef4a5d369aae978e8850e6eecfab01bc9244eca46a_target_child_1_filler_child_1_filler_child_1_filler_list_1 rdf:first _:ae941d1a04c368c1f5129efef4a5d369aae978e8850e6eecfab01bc9244eca46a_target_child_1_filler_child_1_filler_child_1_filler_child_1 .
+_:ae941d1a04c368c1f5129efef4a5d369aae978e8850e6eecfab01bc9244eca46a_target_child_1_filler_child_1_filler_child_1_filler_list_1 rdf:rest rdf:nil .
+_:ae941d1a04c368c1f5129efef4a5d369aae978e8850e6eecfab01bc9244eca46a_target_child_1_filler_child_1_filler_child_1_filler_child_1 rdf:type owl:Restriction .
+_:ae941d1a04c368c1f5129efef4a5d369aae978e8850e6eecfab01bc9244eca46a_target_child_1_filler_child_1_filler_child_1_filler_child_1 owl:onProperty <https://www.commoncoreontologies.org/ont00001920> .
+_:ae941d1a04c368c1f5129efef4a5d369aae978e8850e6eecfab01bc9244eca46a_target_child_1_filler_child_1_filler_child_1_filler_child_1 owl:someValuesFrom <https://www.commoncoreontologies.org/ont00000319> .
+
+<http://www.w3.org/ns/ssn/systems/SystemCapability> rdfs:subClassOf _:a765b6d8892fe2096feba40fd405da8b82eb8e3ea275470c3970146781ba79ecc_target .
+_:a765b6d8892fe2096feba40fd405da8b82eb8e3ea275470c3970146781ba79ecc_target rdf:type owl:Class .
+_:a765b6d8892fe2096feba40fd405da8b82eb8e3ea275470c3970146781ba79ecc_target owl:intersectionOf _:a765b6d8892fe2096feba40fd405da8b82eb8e3ea275470c3970146781ba79ecc_target_list_0 .
+_:a765b6d8892fe2096feba40fd405da8b82eb8e3ea275470c3970146781ba79ecc_target_list_0 rdf:first _:a765b6d8892fe2096feba40fd405da8b82eb8e3ea275470c3970146781ba79ecc_target_child_0 .
+_:a765b6d8892fe2096feba40fd405da8b82eb8e3ea275470c3970146781ba79ecc_target_list_0 rdf:rest _:a765b6d8892fe2096feba40fd405da8b82eb8e3ea275470c3970146781ba79ecc_target_list_1 .
+_:a765b6d8892fe2096feba40fd405da8b82eb8e3ea275470c3970146781ba79ecc_target_list_1 rdf:first _:a765b6d8892fe2096feba40fd405da8b82eb8e3ea275470c3970146781ba79ecc_target_child_1 .
+_:a765b6d8892fe2096feba40fd405da8b82eb8e3ea275470c3970146781ba79ecc_target_list_1 rdf:rest rdf:nil .
+_:a765b6d8892fe2096feba40fd405da8b82eb8e3ea275470c3970146781ba79ecc_target_child_0 rdf:type owl:Class .
+_:a765b6d8892fe2096feba40fd405da8b82eb8e3ea275470c3970146781ba79ecc_target_child_0 owl:unionOf _:a765b6d8892fe2096feba40fd405da8b82eb8e3ea275470c3970146781ba79ecc_target_child_0_list_0 .
+_:a765b6d8892fe2096feba40fd405da8b82eb8e3ea275470c3970146781ba79ecc_target_child_0_list_0 rdf:first <http://purl.obolibrary.org/obo/BFO_0000020> .
+_:a765b6d8892fe2096feba40fd405da8b82eb8e3ea275470c3970146781ba79ecc_target_child_0_list_0 rdf:rest _:a765b6d8892fe2096feba40fd405da8b82eb8e3ea275470c3970146781ba79ecc_target_child_0_list_1 .
+_:a765b6d8892fe2096feba40fd405da8b82eb8e3ea275470c3970146781ba79ecc_target_child_0_list_1 rdf:first <http://purl.obolibrary.org/obo/BFO_0000144> .
+_:a765b6d8892fe2096feba40fd405da8b82eb8e3ea275470c3970146781ba79ecc_target_child_0_list_1 rdf:rest rdf:nil .
+_:a765b6d8892fe2096feba40fd405da8b82eb8e3ea275470c3970146781ba79ecc_target_child_1 rdf:type owl:Restriction .
+_:a765b6d8892fe2096feba40fd405da8b82eb8e3ea275470c3970146781ba79ecc_target_child_1 owl:onProperty <https://www.commoncoreontologies.org/ont00001884> .
+_:a765b6d8892fe2096feba40fd405da8b82eb8e3ea275470c3970146781ba79ecc_target_child_1 owl:someValuesFrom <https://www.commoncoreontologies.org/ont00000127> .
+
+<http://www.w3.org/ns/ssn/systems/SystemLifetime> rdfs:subClassOf _:a30d80749b62ad19d41ee9ffc6b0176426ab98d2d0b773aad7d4fdf16ee823ac0_target .
+_:a30d80749b62ad19d41ee9ffc6b0176426ab98d2d0b773aad7d4fdf16ee823ac0_target rdf:type owl:Class .
+_:a30d80749b62ad19d41ee9ffc6b0176426ab98d2d0b773aad7d4fdf16ee823ac0_target owl:intersectionOf _:a30d80749b62ad19d41ee9ffc6b0176426ab98d2d0b773aad7d4fdf16ee823ac0_target_list_0 .
+_:a30d80749b62ad19d41ee9ffc6b0176426ab98d2d0b773aad7d4fdf16ee823ac0_target_list_0 rdf:first <http://purl.obolibrary.org/obo/BFO_0000034> .
+_:a30d80749b62ad19d41ee9ffc6b0176426ab98d2d0b773aad7d4fdf16ee823ac0_target_list_0 rdf:rest _:a30d80749b62ad19d41ee9ffc6b0176426ab98d2d0b773aad7d4fdf16ee823ac0_target_list_1 .
+_:a30d80749b62ad19d41ee9ffc6b0176426ab98d2d0b773aad7d4fdf16ee823ac0_target_list_1 rdf:first _:a30d80749b62ad19d41ee9ffc6b0176426ab98d2d0b773aad7d4fdf16ee823ac0_target_child_1 .
+_:a30d80749b62ad19d41ee9ffc6b0176426ab98d2d0b773aad7d4fdf16ee823ac0_target_list_1 rdf:rest rdf:nil .
+_:a30d80749b62ad19d41ee9ffc6b0176426ab98d2d0b773aad7d4fdf16ee823ac0_target_child_1 rdf:type owl:Restriction .
+_:a30d80749b62ad19d41ee9ffc6b0176426ab98d2d0b773aad7d4fdf16ee823ac0_target_child_1 owl:onProperty <http://purl.obolibrary.org/obo/BFO_0000054> .
+_:a30d80749b62ad19d41ee9ffc6b0176426ab98d2d0b773aad7d4fdf16ee823ac0_target_child_1 owl:someValuesFrom _:a30d80749b62ad19d41ee9ffc6b0176426ab98d2d0b773aad7d4fdf16ee823ac0_target_child_1_filler .
+_:a30d80749b62ad19d41ee9ffc6b0176426ab98d2d0b773aad7d4fdf16ee823ac0_target_child_1_filler rdf:type owl:Class .
+_:a30d80749b62ad19d41ee9ffc6b0176426ab98d2d0b773aad7d4fdf16ee823ac0_target_child_1_filler owl:intersectionOf _:a30d80749b62ad19d41ee9ffc6b0176426ab98d2d0b773aad7d4fdf16ee823ac0_target_child_1_filler_list_0 .
+_:a30d80749b62ad19d41ee9ffc6b0176426ab98d2d0b773aad7d4fdf16ee823ac0_target_child_1_filler_list_0 rdf:first <https://www.commoncoreontologies.org/ont00001213> .
+_:a30d80749b62ad19d41ee9ffc6b0176426ab98d2d0b773aad7d4fdf16ee823ac0_target_child_1_filler_list_0 rdf:rest _:a30d80749b62ad19d41ee9ffc6b0176426ab98d2d0b773aad7d4fdf16ee823ac0_target_child_1_filler_list_1 .
+_:a30d80749b62ad19d41ee9ffc6b0176426ab98d2d0b773aad7d4fdf16ee823ac0_target_child_1_filler_list_1 rdf:first _:a30d80749b62ad19d41ee9ffc6b0176426ab98d2d0b773aad7d4fdf16ee823ac0_target_child_1_filler_child_1 .
+_:a30d80749b62ad19d41ee9ffc6b0176426ab98d2d0b773aad7d4fdf16ee823ac0_target_child_1_filler_list_1 rdf:rest rdf:nil .
+_:a30d80749b62ad19d41ee9ffc6b0176426ab98d2d0b773aad7d4fdf16ee823ac0_target_child_1_filler_child_1 rdf:type owl:Restriction .
+_:a30d80749b62ad19d41ee9ffc6b0176426ab98d2d0b773aad7d4fdf16ee823ac0_target_child_1_filler_child_1 owl:onProperty <https://www.commoncoreontologies.org/ont00001819> .
+_:a30d80749b62ad19d41ee9ffc6b0176426ab98d2d0b773aad7d4fdf16ee823ac0_target_child_1_filler_child_1 owl:someValuesFrom _:a30d80749b62ad19d41ee9ffc6b0176426ab98d2d0b773aad7d4fdf16ee823ac0_target_child_1_filler_child_1_filler .
+_:a30d80749b62ad19d41ee9ffc6b0176426ab98d2d0b773aad7d4fdf16ee823ac0_target_child_1_filler_child_1_filler rdf:type owl:Class .
+_:a30d80749b62ad19d41ee9ffc6b0176426ab98d2d0b773aad7d4fdf16ee823ac0_target_child_1_filler_child_1_filler owl:intersectionOf _:a30d80749b62ad19d41ee9ffc6b0176426ab98d2d0b773aad7d4fdf16ee823ac0_target_child_1_filler_child_1_filler_list_0 .
+_:a30d80749b62ad19d41ee9ffc6b0176426ab98d2d0b773aad7d4fdf16ee823ac0_target_child_1_filler_child_1_filler_list_0 rdf:first <http://purl.obolibrary.org/obo/BFO_0000015> .
+_:a30d80749b62ad19d41ee9ffc6b0176426ab98d2d0b773aad7d4fdf16ee823ac0_target_child_1_filler_child_1_filler_list_0 rdf:rest _:a30d80749b62ad19d41ee9ffc6b0176426ab98d2d0b773aad7d4fdf16ee823ac0_target_child_1_filler_child_1_filler_list_1 .
+_:a30d80749b62ad19d41ee9ffc6b0176426ab98d2d0b773aad7d4fdf16ee823ac0_target_child_1_filler_child_1_filler_list_1 rdf:first _:a30d80749b62ad19d41ee9ffc6b0176426ab98d2d0b773aad7d4fdf16ee823ac0_target_child_1_filler_child_1_filler_child_1 .
+_:a30d80749b62ad19d41ee9ffc6b0176426ab98d2d0b773aad7d4fdf16ee823ac0_target_child_1_filler_child_1_filler_list_1 rdf:rest rdf:nil .
+_:a30d80749b62ad19d41ee9ffc6b0176426ab98d2d0b773aad7d4fdf16ee823ac0_target_child_1_filler_child_1_filler_child_1 rdf:type owl:Restriction .
+_:a30d80749b62ad19d41ee9ffc6b0176426ab98d2d0b773aad7d4fdf16ee823ac0_target_child_1_filler_child_1_filler_child_1 owl:onProperty <http://purl.obolibrary.org/obo/BFO_0000055> .
+_:a30d80749b62ad19d41ee9ffc6b0176426ab98d2d0b773aad7d4fdf16ee823ac0_target_child_1_filler_child_1_filler_child_1 owl:someValuesFrom _:a30d80749b62ad19d41ee9ffc6b0176426ab98d2d0b773aad7d4fdf16ee823ac0_target_child_1_filler_child_1_filler_child_1_filler .
+_:a30d80749b62ad19d41ee9ffc6b0176426ab98d2d0b773aad7d4fdf16ee823ac0_target_child_1_filler_child_1_filler_child_1_filler rdf:type owl:Class .
+_:a30d80749b62ad19d41ee9ffc6b0176426ab98d2d0b773aad7d4fdf16ee823ac0_target_child_1_filler_child_1_filler_child_1_filler owl:intersectionOf _:a30d80749b62ad19d41ee9ffc6b0176426ab98d2d0b773aad7d4fdf16ee823ac0_target_child_1_filler_child_1_filler_child_1_filler_list_0 .
+_:a30d80749b62ad19d41ee9ffc6b0176426ab98d2d0b773aad7d4fdf16ee823ac0_target_child_1_filler_child_1_filler_child_1_filler_list_0 rdf:first <https://www.commoncoreontologies.org/ont00000177> .
+_:a30d80749b62ad19d41ee9ffc6b0176426ab98d2d0b773aad7d4fdf16ee823ac0_target_child_1_filler_child_1_filler_child_1_filler_list_0 rdf:rest _:a30d80749b62ad19d41ee9ffc6b0176426ab98d2d0b773aad7d4fdf16ee823ac0_target_child_1_filler_child_1_filler_child_1_filler_list_1 .
+_:a30d80749b62ad19d41ee9ffc6b0176426ab98d2d0b773aad7d4fdf16ee823ac0_target_child_1_filler_child_1_filler_child_1_filler_list_1 rdf:first _:a30d80749b62ad19d41ee9ffc6b0176426ab98d2d0b773aad7d4fdf16ee823ac0_target_child_1_filler_child_1_filler_child_1_filler_child_1 .
+_:a30d80749b62ad19d41ee9ffc6b0176426ab98d2d0b773aad7d4fdf16ee823ac0_target_child_1_filler_child_1_filler_child_1_filler_list_1 rdf:rest rdf:nil .
+_:a30d80749b62ad19d41ee9ffc6b0176426ab98d2d0b773aad7d4fdf16ee823ac0_target_child_1_filler_child_1_filler_child_1_filler_child_1 rdf:type owl:Restriction .
+_:a30d80749b62ad19d41ee9ffc6b0176426ab98d2d0b773aad7d4fdf16ee823ac0_target_child_1_filler_child_1_filler_child_1_filler_child_1 owl:onProperty <https://www.commoncoreontologies.org/ont00001920> .
+_:a30d80749b62ad19d41ee9ffc6b0176426ab98d2d0b773aad7d4fdf16ee823ac0_target_child_1_filler_child_1_filler_child_1_filler_child_1 owl:someValuesFrom <https://www.commoncoreontologies.org/ont00000319> .
+
+<http://www.w3.org/ns/ssn/systems/SystemProperty> rdfs:subClassOf _:a69c3b2b4c146ceb3fddb1d600e12d656e8fe35fcf169d0c4fafa9dff68822b1e_target .
+_:a69c3b2b4c146ceb3fddb1d600e12d656e8fe35fcf169d0c4fafa9dff68822b1e_target rdf:type owl:Class .
+_:a69c3b2b4c146ceb3fddb1d600e12d656e8fe35fcf169d0c4fafa9dff68822b1e_target owl:intersectionOf _:a69c3b2b4c146ceb3fddb1d600e12d656e8fe35fcf169d0c4fafa9dff68822b1e_target_list_0 .
+_:a69c3b2b4c146ceb3fddb1d600e12d656e8fe35fcf169d0c4fafa9dff68822b1e_target_list_0 rdf:first _:a69c3b2b4c146ceb3fddb1d600e12d656e8fe35fcf169d0c4fafa9dff68822b1e_target_child_0 .
+_:a69c3b2b4c146ceb3fddb1d600e12d656e8fe35fcf169d0c4fafa9dff68822b1e_target_list_0 rdf:rest _:a69c3b2b4c146ceb3fddb1d600e12d656e8fe35fcf169d0c4fafa9dff68822b1e_target_list_1 .
+_:a69c3b2b4c146ceb3fddb1d600e12d656e8fe35fcf169d0c4fafa9dff68822b1e_target_list_1 rdf:first _:a69c3b2b4c146ceb3fddb1d600e12d656e8fe35fcf169d0c4fafa9dff68822b1e_target_child_1 .
+_:a69c3b2b4c146ceb3fddb1d600e12d656e8fe35fcf169d0c4fafa9dff68822b1e_target_list_1 rdf:rest rdf:nil .
+_:a69c3b2b4c146ceb3fddb1d600e12d656e8fe35fcf169d0c4fafa9dff68822b1e_target_child_0 rdf:type owl:Class .
+_:a69c3b2b4c146ceb3fddb1d600e12d656e8fe35fcf169d0c4fafa9dff68822b1e_target_child_0 owl:unionOf _:a69c3b2b4c146ceb3fddb1d600e12d656e8fe35fcf169d0c4fafa9dff68822b1e_target_child_0_list_0 .
+_:a69c3b2b4c146ceb3fddb1d600e12d656e8fe35fcf169d0c4fafa9dff68822b1e_target_child_0_list_0 rdf:first <http://purl.obolibrary.org/obo/BFO_0000020> .
+_:a69c3b2b4c146ceb3fddb1d600e12d656e8fe35fcf169d0c4fafa9dff68822b1e_target_child_0_list_0 rdf:rest _:a69c3b2b4c146ceb3fddb1d600e12d656e8fe35fcf169d0c4fafa9dff68822b1e_target_child_0_list_1 .
+_:a69c3b2b4c146ceb3fddb1d600e12d656e8fe35fcf169d0c4fafa9dff68822b1e_target_child_0_list_1 rdf:first <http://purl.obolibrary.org/obo/BFO_0000144> .
+_:a69c3b2b4c146ceb3fddb1d600e12d656e8fe35fcf169d0c4fafa9dff68822b1e_target_child_0_list_1 rdf:rest rdf:nil .
+_:a69c3b2b4c146ceb3fddb1d600e12d656e8fe35fcf169d0c4fafa9dff68822b1e_target_child_1 rdf:type owl:Restriction .
+_:a69c3b2b4c146ceb3fddb1d600e12d656e8fe35fcf169d0c4fafa9dff68822b1e_target_child_1 owl:onProperty <https://www.commoncoreontologies.org/ont00001920> .
+_:a69c3b2b4c146ceb3fddb1d600e12d656e8fe35fcf169d0c4fafa9dff68822b1e_target_child_1 owl:someValuesFrom <https://www.commoncoreontologies.org/ont00000118> .
+
+<http://www.w3.org/ns/ssn/systems/hasOperatingProperty> rdfs:subPropertyOf <http://purl.obolibrary.org/obo/BFO_0000194> .
+
+<http://www.w3.org/ns/ssn/systems/hasOperatingRange> rdfs:domain <http://www.w3.org/ns/ssn/System> .
+
+<http://www.w3.org/ns/ssn/systems/hasOperatingRange> rdfs:range <http://www.w3.org/ns/ssn/systems/OperatingRange> .
+
+<http://www.w3.org/ns/ssn/systems/hasSurvivalProperty> rdfs:subPropertyOf <http://purl.obolibrary.org/obo/BFO_0000194> .
+
+<http://www.w3.org/ns/ssn/systems/hasSurvivalRange> rdfs:domain <http://www.w3.org/ns/ssn/System> .
+
+<http://www.w3.org/ns/ssn/systems/hasSurvivalRange> rdfs:range <http://www.w3.org/ns/ssn/systems/SurvivalRange> .
+
+<http://www.w3.org/ns/ssn/systems/hasSystemCapability> rdfs:domain <http://www.w3.org/ns/ssn/System> .
+
+<http://www.w3.org/ns/ssn/systems/hasSystemCapability> rdfs:range <http://www.w3.org/ns/ssn/systems/SystemCapability> .
+
+<http://www.w3.org/ns/ssn/systems/hasSystemProperty> rdfs:subPropertyOf <http://purl.obolibrary.org/obo/BFO_0000194> .
+
+<http://www.w3.org/ns/ssn/systems/inCondition> rdfs:domain _:a1149dc67a0411aa63c8ac06b3be6ecee8eaf03d62268b48079df3ca3c134dc62_target .
+_:a1149dc67a0411aa63c8ac06b3be6ecee8eaf03d62268b48079df3ca3c134dc62_target rdf:type owl:Class .
+_:a1149dc67a0411aa63c8ac06b3be6ecee8eaf03d62268b48079df3ca3c134dc62_target owl:unionOf _:a1149dc67a0411aa63c8ac06b3be6ecee8eaf03d62268b48079df3ca3c134dc62_target_list_0 .
+_:a1149dc67a0411aa63c8ac06b3be6ecee8eaf03d62268b48079df3ca3c134dc62_target_list_0 rdf:first <http://www.w3.org/ns/ssn/systems/SystemCapability> .
+_:a1149dc67a0411aa63c8ac06b3be6ecee8eaf03d62268b48079df3ca3c134dc62_target_list_0 rdf:rest _:a1149dc67a0411aa63c8ac06b3be6ecee8eaf03d62268b48079df3ca3c134dc62_target_list_1 .
+_:a1149dc67a0411aa63c8ac06b3be6ecee8eaf03d62268b48079df3ca3c134dc62_target_list_1 rdf:first <http://www.w3.org/ns/ssn/systems/OperatingRange> .
+_:a1149dc67a0411aa63c8ac06b3be6ecee8eaf03d62268b48079df3ca3c134dc62_target_list_1 rdf:rest _:a1149dc67a0411aa63c8ac06b3be6ecee8eaf03d62268b48079df3ca3c134dc62_target_list_2 .
+_:a1149dc67a0411aa63c8ac06b3be6ecee8eaf03d62268b48079df3ca3c134dc62_target_list_2 rdf:first <http://www.w3.org/ns/ssn/systems/SurvivalRange> .
+_:a1149dc67a0411aa63c8ac06b3be6ecee8eaf03d62268b48079df3ca3c134dc62_target_list_2 rdf:rest rdf:nil .
+
+<http://www.w3.org/ns/ssn/systems/qualityOfObservation> rdfs:subPropertyOf <https://www.commoncoreontologies.org/ont00001986> .
+
+<http://www.w3.org/ns/ssn/wasOriginatedBy> rdfs:subPropertyOf <https://www.commoncoreontologies.org/ont00001962> .

--- a/releases/current-ssn-sosa/ssn-sosa-alignment-core.ttl
+++ b/releases/current-ssn-sosa/ssn-sosa-alignment-core.ttl
@@ -1,5 +1,7 @@
 # GENERATED FILE: produced from mappings/SSN2BFO-COMS.xlsx and governed product dispositions; do not edit directly.
 
+@prefix adms: <http://www.w3.org/ns/adms#> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
@@ -8,7 +10,14 @@
 @prefix ssn: <http://www.w3.org/ns/ssn/> .
 @prefix ssn-system: <http://www.w3.org/ns/ssn/systems/> .
 
-<http://www.sks.ai/SSN2BFO/current-ssn-sosa/alignment-core> rdf:type owl:Ontology .
+<http://www.sks.ai/SSN2BFO/current-ssn-sosa/alignment-core> a owl:Ontology ;
+    rdfs:label "SSN/SOSA Alignment Core"@en ;
+    dcterms:description "Directly asserts the governed target-neutral SSN/SOSA alignment axioms shared by the modular products and imports no ontology."@en ;
+    dcterms:type <http://www.sks.ai/SSN2BFO/product-type/alignment-core> ;
+    adms:status <http://www.sks.ai/SSN2BFO/authority-status/maintained-authoritative-development> ;
+    dcterms:license <https://creativecommons.org/publicdomain/zero/1.0/> ;
+    rdfs:seeAlso <https://github.com/BFO-Mappings/SSN-to-BFO> ;
+    rdfs:comment "Generated from governed COMS and publication metadata; do not edit this ontology directly."@en .
 
 <http://www.w3.org/ns/sosa/isFeatureOfInterestOf> rdfs:range _:a046c9120e36b99488082b91da7f607659195e4d0af549e456e88766fe7643f9a_target .
 _:a046c9120e36b99488082b91da7f607659195e4d0af549e456e88766fe7643f9a_target rdf:type owl:Class .

--- a/releases/current-ssn-sosa/ssn-sosa-bfo-mapping.ttl
+++ b/releases/current-ssn-sosa/ssn-sosa-bfo-mapping.ttl
@@ -1,6 +1,8 @@
 # GENERATED FILE: produced from mappings/SSN2BFO-COMS.xlsx and governed product dispositions; do not edit directly.
 
 @prefix bfo: <http://purl.obolibrary.org/obo/> .
+@prefix adms: <http://www.w3.org/ns/adms#> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
@@ -9,7 +11,14 @@
 @prefix ssn: <http://www.w3.org/ns/ssn/> .
 @prefix ssn-system: <http://www.w3.org/ns/ssn/systems/> .
 
-<http://www.sks.ai/SSN2BFO/current-ssn-sosa/bfo-mapping> rdf:type owl:Ontology ;
+<http://www.sks.ai/SSN2BFO/current-ssn-sosa/bfo-mapping> a owl:Ontology ;
+    rdfs:label "SSN/SOSA Strict BFO Mapping"@en ;
+    dcterms:description "Directly asserts governed BFO-bearing axioms without weakening and imports the SSN/SOSA alignment core."@en ;
+    dcterms:type <http://www.sks.ai/SSN2BFO/product-type/strict-bfo-mapping> ;
+    adms:status <http://www.sks.ai/SSN2BFO/authority-status/maintained-authoritative-development> ;
+    dcterms:license <https://creativecommons.org/publicdomain/zero/1.0/> ;
+    rdfs:seeAlso <https://github.com/BFO-Mappings/SSN-to-BFO> ;
+    rdfs:comment "Generated from governed COMS and publication metadata; do not edit this ontology directly."@en ;
     owl:imports <http://www.sks.ai/SSN2BFO/current-ssn-sosa/alignment-core> .
 
 <http://www.w3.org/ns/ssn/isPropertyOf> rdfs:domain _:a0caeec31770247fe2efeb443e85fefe9b4e1648a7d9569adc35d2972b77682b1_target .

--- a/releases/current-ssn-sosa/ssn-sosa-bfo-projection.ttl
+++ b/releases/current-ssn-sosa/ssn-sosa-bfo-projection.ttl
@@ -1,7 +1,17 @@
 # GENERATED FILE: produced from mappings/SSN2BFO-COMS.xlsx and governed product dispositions; do not edit directly.
 
+@prefix adms: <http://www.w3.org/ns/adms#> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
-<http://www.sks.ai/SSN2BFO/current-ssn-sosa/bfo-projection> rdf:type owl:Ontology ;
+<http://www.sks.ai/SSN2BFO/current-ssn-sosa/bfo-projection> a owl:Ontology ;
+    rdfs:label "SSN/SOSA BFO Projection"@en ;
+    dcterms:description "Imports the strict BFO mapping and is the designated product for approved weaker but sound BFO consequences; no direct projection axiom is currently approved."@en ;
+    dcterms:type <http://www.sks.ai/SSN2BFO/product-type/bfo-projection> ;
+    adms:status <http://www.sks.ai/SSN2BFO/authority-status/maintained-authoritative-development> ;
+    dcterms:license <https://creativecommons.org/publicdomain/zero/1.0/> ;
+    rdfs:seeAlso <https://github.com/BFO-Mappings/SSN-to-BFO> ;
+    rdfs:comment "Generated from governed COMS and publication metadata; do not edit this ontology directly."@en ;
     owl:imports <http://www.sks.ai/SSN2BFO/current-ssn-sosa/bfo-mapping> .

--- a/releases/current-ssn-sosa/ssn-sosa-cco-extension.ttl
+++ b/releases/current-ssn-sosa/ssn-sosa-cco-extension.ttl
@@ -2,6 +2,8 @@
 
 @prefix cco: <https://www.commoncoreontologies.org/> .
 @prefix bfo: <http://purl.obolibrary.org/obo/> .
+@prefix adms: <http://www.w3.org/ns/adms#> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
@@ -10,7 +12,14 @@
 @prefix ssn: <http://www.w3.org/ns/ssn/> .
 @prefix ssn-system: <http://www.w3.org/ns/ssn/systems/> .
 
-<http://www.sks.ai/SSN2BFO/current-ssn-sosa/cco-extension> rdf:type owl:Ontology ;
+<http://www.sks.ai/SSN2BFO/current-ssn-sosa/cco-extension> a owl:Ontology ;
+    rdfs:label "SSN/SOSA CCO Extension"@en ;
+    dcterms:description "Directly asserts governed CCO-bearing and mixed BFO/CCO axioms unchanged and imports the strict BFO mapping."@en ;
+    dcterms:type <http://www.sks.ai/SSN2BFO/product-type/cco-extension> ;
+    adms:status <http://www.sks.ai/SSN2BFO/authority-status/maintained-authoritative-development> ;
+    dcterms:license <https://creativecommons.org/publicdomain/zero/1.0/> ;
+    rdfs:seeAlso <https://github.com/BFO-Mappings/SSN-to-BFO> ;
+    rdfs:comment "Generated from governed COMS and publication metadata; do not edit this ontology directly."@en ;
     owl:imports <http://www.sks.ai/SSN2BFO/current-ssn-sosa/bfo-mapping> .
 
 <http://www.w3.org/ns/ssn/systems/ActuationRange> rdfs:subClassOf _:a04f2e1c545b6c6f252d9cf377e1e1f325bafa846d37c6b75a975a692ea059963_target .

--- a/reports/coms-automatic-validation-setup.md
+++ b/reports/coms-automatic-validation-setup.md
@@ -51,7 +51,9 @@ make coms-status
 
 Development validation checks the governed license, repository, generated warning, `adms:status` predicate, and maintained-authoritative-development status without claiming a formal release identity. The existing release identifier and version-IRI helpers remain separately testable, but formal release metadata is not stored in the maintained development TOML.
 
-The COMS freshness transaction hashes the metadata source, so a metadata edit makes generated evidence stale until the normal transaction succeeds. Schema-2 values are validated governance only in this change: ontology RDF metadata emission remains deferred to the next implementation PR, and all maintained TTL bytes must remain unchanged.
+The COMS freshness transaction hashes the metadata source, so a metadata edit makes all generated evidence stale until the normal transaction succeeds. The transaction loads schema-2 metadata once and deterministically emits the same ordered seven-predicate development metadata model in the integrated root and all four modules: `rdfs:label`, `dcterms:description`, `dcterms:type`, `adms:status`, `dcterms:license`, `rdfs:seeAlso`, and `rdfs:comment`. Exact RDF term kinds, `@en` tags, ontology subjects, imports, and the absence of release-only fields are validated before publication.
+
+Direct triple partitions are checked independently: integrated `1 + 4 + 7 + 1112 = 1124`, alignment core `1 + 0 + 7 + 53 = 61`, strict BFO `1 + 1 + 7 + 125 = 134`, import-only BFO projection `1 + 1 + 7 + 0 = 9`, and CCO extension `1 + 1 + 7 + 934 = 943`, where the terms are ontology declaration, imports, metadata annotations, and governed/structural logical triples. Metadata-adjusted closure counts are 1,212 for alignment core, 14,986 for strict BFO, 204/202 for the projection project graph, 1,138/1,136 for the CCO project graph, 15,928 for the CCO fixed closure, and 15,912 for the integrated fixed closure.
 
 ## Mapping And Property-Typing Rows
 
@@ -77,16 +79,16 @@ Each complete check:
 3. Runs the existing generator against temporary outputs.
 4. Uses the generator's established validation for allowed predicates, source and target resolution, class/property compatibility, exact label-to-IRI resolution, Manchester expressions, domain/range property typing, property chains, duplicates, contradictions, and explicit blank mappings.
 5. Runs the maintained SPARQL source inventory and unmapped-term coverage queries.
-6. Parses the temporary generated candidate.
+6. Parses the temporary generated candidate and validates its exact seven development annotations separately from its 1 declaration, 4 imports, and 1,112 logical triples.
 7. Builds the full local candidate closure from CCO, SOSA, SOSA Sampling, SSN, SSN Systems, and the generated candidate.
 8. Applies the established import and SOSA functional/inverse-functional cleanup.
 9. Runs HermiT and requires zero `owl:Nothing` and zero unexpected named unsatisfiable classes.
 10. Requires all generated reports and validates hash-based source metadata.
 11. Derives and reconciles all per-product row and canonical-axiom dispositions, including target-vocabulary categories and canonical JSON serialization.
-12. Generates and validates the import-free 29-axiom SSN/SOSA alignment core, including root reconciliation and a fixed local source-ontology HermiT closure.
-13. Generates and validates the 19-axiom strict BFO mapping, its sole alignment-core import, the 48-axiom project-module closure, and the explicit network-free pinned merged CCO/BFO HermiT closure.
-14. Generates and validates the 57-axiom CCO extension, its sole strict-BFO import, the complete 105-axiom project-module closure, and the explicit network-free pinned merged CCO/BFO HermiT closure.
-15. Reconciles all 105 BFO-projection dispositions, generates the intentional zero-direct-axiom import-only module, validates its 48-axiom strict/core project closure, and reuses the same-transaction strict-BFO reasoning result after exact closure-equivalence validation.
+12. Generates and validates the import-free 29-axiom SSN/SOSA alignment core, its exact seven annotations, root reconciliation, and a 1,212-triple fixed local source-ontology HermiT closure.
+13. Generates and validates the 19-axiom strict BFO mapping, its exact seven annotations, sole alignment-core import, 48-axiom project-module closure, and 14,986-triple network-free pinned merged CCO/BFO HermiT closure.
+14. Generates and validates the 57-axiom CCO extension, its exact seven annotations, sole strict-BFO import, complete 105-axiom project-module closure, and 15,928-triple network-free pinned merged CCO/BFO HermiT closure.
+15. Reconciles all 105 BFO-projection dispositions, generates the intentional zero-direct-axiom import-only module with exactly seven annotations, validates its 48-axiom strict/core project closure, and reuses the same-transaction strict-BFO reasoning result after exact closure-equivalence validation.
 16. Runs `git diff --check`.
 
 The generated validation report records the workbook SHA-256, generator-file SHA-256, UTC generation timestamp, maintained ontology path, and generated ontology SHA-256. Freshness never relies on timestamps alone.

--- a/reports/coms-generation-validation.md
+++ b/reports/coms-generation-validation.md
@@ -9,24 +9,24 @@ Freshness is determined from content hashes, not file timestamps.
 | Item | Value |
 |---|---|
 | workbook SHA-256 | `febb8b58b4a701cead90697412a9721112c4e6dfd3af47d3c3a77c93754690e0` |
-| generator SHA-256 | `c27277bddc98d0ee84189a260b32805f3b0df73bba2068fd08a448b74e378cfd` |
+| generator SHA-256 | `f07691a85c6d1465a29d518e5b2ef47921cc03d4872cb55fd7bd7d53c38bb132` |
 | row-identity module SHA-256 | `9af9f9ed5b9321040428960e1293cffe27ebb48cc7a68a71f53f84cf18a60425` |
 | product-disposition module SHA-256 | `987fa4809e5780831f9e50e0b5cacc52888284fc7eae82a0928056c45c14a7d8` |
-| modular-products module SHA-256 | `fe48deac6bc9d529ec058564f99da817d520fed03ce96bbcc4563d5a54b1da6d` |
+| modular-products module SHA-256 | `9a76a72faee266d8e70def06d5afd4237a8adb6155337002d0c0727604fd12a6` |
 | publication metadata SHA-256 | `fab670a686e002e6bc704cda75bf59c20dc5eaa8da78c94273c242021ccaf873` |
-| generation timestamp (UTC) | `2026-07-16T03:10:03+00:00` |
+| generation timestamp (UTC) | `2026-07-16T17:08:10+00:00` |
 | maintained ontology path | `SSN2BFO.ttl` |
-| generated ontology SHA-256 | `fd6eadf1bcbd4bfc6dc06df58915116d8f909bc8c3238592b1f13509cec47d16` |
+| generated ontology SHA-256 | `25b5828424e48396db546b2c3732befec2defcd3159c2a132a2f73343d1f17e0` |
 | maintained product-disposition path | `reports/coms-product-dispositions.json` |
-| product-disposition JSON SHA-256 | `5a32d3205d93ef481b78a860507d296f1cf9b1a962dcfaedd84cc1380ad8c8a5` |
+| product-disposition JSON SHA-256 | `2e409800614a17e150b1ec119b4855c9391a286ad11bac1946408fb7c717e0a8` |
 | maintained alignment-core path | `releases/current-ssn-sosa/ssn-sosa-alignment-core.ttl` |
-| alignment-core Turtle SHA-256 | `95f71184b90224906b0ba703d0ea60fd2f8b993b3853b803c66b88b91ba0b01c` |
+| alignment-core Turtle SHA-256 | `17695ef17379924449153b2c92ffaed6b57d497a1b2d1e854f584614cebec770` |
 | maintained strict-BFO path | `releases/current-ssn-sosa/ssn-sosa-bfo-mapping.ttl` |
-| strict-BFO Turtle SHA-256 | `15f080145c6803d174a00cf9e13c971925b40485049744dba6e0847093016ea7` |
+| strict-BFO Turtle SHA-256 | `676b31620df10db5c26c46bcc44b2dfd5939d606b16e0fa8a910926e8497c3af` |
 | maintained BFO-projection path | `releases/current-ssn-sosa/ssn-sosa-bfo-projection.ttl` |
-| BFO-projection Turtle SHA-256 | `7914e0afb6212df20e02686e1b11b71d109e0b81095ddf33ff120b01768cc71c` |
+| BFO-projection Turtle SHA-256 | `b5c1163eb6ab24c2e111e9e76c7b97acb20d897c9d1abc3daa555628206da5b0` |
 | maintained CCO-extension path | `releases/current-ssn-sosa/ssn-sosa-cco-extension.ttl` |
-| CCO-extension Turtle SHA-256 | `fe6986d79ec2f5f67553fbee1364fa98ebd7ba3205196f0368ac246646fcdf7c` |
+| CCO-extension Turtle SHA-256 | `fc98e6fafa1a3a5c8612fd9b8e4e571e9a382faa3f9ca9801e64533b91f00aaf` |
 
 ## Workbook
 
@@ -300,18 +300,20 @@ This is the maintained authoritative development artifact at the approved produc
 - Named target expressions: 26
 - Union target expressions: 3
 - Logical RDF triples: 53
-- Ontology-header triples: 1
-- Total RDF triples: 54
-- Imports: 0
+- Ontology declaration triples: 1
+- Import triples: 0
+- Descriptive metadata annotations: 7
+- Total RDF triples: 61
 - BFO/CCO/RO and unexpected logical-vocabulary audit: PASS
 - Integrated-root canonical-axiom reconciliation: PASS
 - Deterministic serialization: PASS
 - Fixed local source closure: `imports/sosa.ttl`, `imports/sosa-sampling.ttl`, `imports/ssn.ttl`, `imports/ssn-systems.ttl`
+- Source-closure triple count: 1212
 - Source-closure HermiT return code: 0
 - Source-closure reasoned output produced: yes
 - Source-closure named unsatisfiable classes: 0
 - Source-closure HermiT result: PASS
-- Full publication metadata and formal release identity remain deferred.
+- Formal-release metadata and identity remain deferred.
 
 ## Strict BFO Mapping
 
@@ -327,8 +329,10 @@ This is the maintained authoritative development artifact at the approved produc
 - Domain axioms: 1
 - Range axioms: 1
 - Logical RDF triples: 125
-- Ontology-header and import triples: 2
-- Total RDF triples: 127
+- Ontology declaration triples: 1
+- Import triples: 1
+- Descriptive metadata annotations: 7
+- Total RDF triples: 134
 - Import: `http://www.sks.ai/SSN2BFO/current-ssn-sosa/alignment-core`
 - Imported alignment-core governed axioms: 29
 - Project-module closure governed axioms: 48
@@ -337,14 +341,14 @@ This is the maintained authoritative development artifact at the approved produc
 - Integrated-root and project-module canonical-axiom reconciliation: PASS
 - Deterministic serialization: PASS
 - Pinned merged CCO/BFO validation closure: `imports/sosa.ttl`, `imports/sosa-sampling.ttl`, `imports/ssn.ttl`, `imports/ssn-systems.ttl`, `imports/cco.ttl`
-- Pinned closure triple count: 14972
+- Pinned closure triple count: 14986
 - HermiT return code: 0
 - Reasoned output produced: yes
 - Named unsatisfiable classes: 0
 - HermiT result: PASS
 - The validation dependency `imports/cco.ttl` is not imported by the published strict graph and does not authorize CCO mappings or transformations.
 - The 57 CCO-bearing or mixed mappings remain deferred; no transformation or projection is implemented.
-- Full publication metadata and formal release identity remain deferred.
+- Formal-release metadata and identity remain deferred.
 
 ## BFO Projection
 
@@ -356,7 +360,8 @@ This is the maintained authoritative development artifact at the approved produc
 - Direct logical mapping triples: 0
 - Ontology declaration triples: 1
 - Import triples: 1
-- Total RDF triples: 2
+- Descriptive metadata annotations: 7
+- Total RDF triples: 9
 - Import: `http://www.sks.ai/SSN2BFO/current-ssn-sosa/bfo-mapping`
 - Target-neutral provided transitively: 29
 - BFO-bearing provided through import: 19
@@ -365,13 +370,13 @@ This is the maintained authoritative development artifact at the approved produc
 - Imported strict-BFO governed axioms: 19
 - Transitively imported alignment-core governed axioms: 29
 - Project-module closure governed axioms: 48
-- Project graph triples retaining imports: 183
-- Import-stripped local project graph triples: 181
+- Project graph triples retaining imports: 204
+- Import-stripped local project graph triples: 202
 - Strict/alignment-core governed overlap: 0
 - CCO-extension governed axioms in projection closure: 0
 - Direct graph and integrated-root/project-module reconciliation: PASS
 - Deterministic serialization: PASS
-- Reused strict-BFO closure triple count: 14972
+- Reused strict-BFO closure triple count: 14986
 - Reused strict-BFO HermiT return code: 0
 - Reused strict-BFO reasoned output produced: yes
 - Reused strict-BFO named unsatisfiable classes: 0
@@ -380,7 +385,7 @@ This is the maintained authoritative development artifact at the approved produc
 - Zero direct projection axioms is intentional and complete for the current governed policy.
 - No transformation rule, weakened consequence, or projected axiom is approved.
 - Future direct projected axioms require governed transformation rules and proof obligations.
-- Full publication metadata and formal release identity remain deferred.
+- Formal-release metadata and identity remain deferred.
 
 ## CCO Extension
 
@@ -396,8 +401,10 @@ This is the maintained authoritative development artifact at the approved produc
 - Direct subproperty axioms: 16
 - Property-chain axioms: 3
 - Logical RDF triples: 934
-- Ontology-header and import triples: 2
-- Total RDF triples: 936
+- Ontology declaration triples: 1
+- Import triples: 1
+- Descriptive metadata annotations: 7
+- Total RDF triples: 943
 - Import: `http://www.sks.ai/SSN2BFO/current-ssn-sosa/bfo-mapping`
 - Imported strict-BFO governed axioms: 19
 - Transitively imported alignment-core governed axioms: 29
@@ -407,19 +414,23 @@ This is the maintained authoritative development artifact at the approved produc
 - Integrated-root and project-module canonical-axiom reconciliation: PASS
 - Deterministic serialization: PASS
 - Pinned merged CCO/BFO validation closure: `imports/sosa.ttl`, `imports/sosa-sampling.ttl`, `imports/ssn.ttl`, `imports/ssn-systems.ttl`, `imports/cco.ttl`
-- Pinned closure triple count: 15907
+- Pinned closure triple count: 15928
 - HermiT return code: 0
 - Reasoned output produced: yes
 - Named unsatisfiable classes: 0
 - HermiT result: PASS
 - The validation dependency `imports/cco.ttl` is not imported by the published CCO-extension graph and is not mapping authority.
 - No transformation or weakened projection is implemented.
-- Full publication metadata and formal release identity remain deferred.
+- Formal-release metadata and identity remain deferred.
 
 ## Generated Ontology
 
 - Path: `SSN2BFO.ttl`
-- Generated ontology triple count: 1117
+- Ontology declaration triples: 1
+- Import triples: 4
+- Descriptive metadata annotations: 7
+- Governed/structural logical triples: 1112
+- Generated ontology triple count: 1124
 - `SSN2BFO.ttl` is generated from `mappings/SSN2BFO-COMS.xlsx` and must not be edited directly.
 - `coms:Reasoning` remained spreadsheet-only and was not emitted into the ontology.
 
@@ -430,7 +441,7 @@ This is the maintained authoritative development artifact at the approved produc
 | ROBOT command | `robot` (resolved from `PATH`) |
 | candidate closure graph path | temporary validation artifact (`coms-candidate-full-closure.ttl`) |
 | reasoned output path | temporary validation artifact (`coms-candidate-full-closure-reasoned.ttl`) |
-| full candidate closure triple count | 15905 |
+| full candidate closure triple count | 15912 |
 | HermiT return code | 0 |
 | reasoned output produced | yes |
 | `owl:Nothing` count | 0 |
@@ -585,4 +596,4 @@ This section records mapping and domain/range property-typing rows after parsing
 
 ## Runtime
 
-- Runtime seconds: 9.23
+- Runtime seconds: 11.29

--- a/reports/coms-product-dispositions.json
+++ b/reports/coms-product-dispositions.json
@@ -2,7 +2,7 @@
   "schema_version": 1,
   "canonicalization_version": "coms-row-expression-v1",
   "workbook_sha256": "febb8b58b4a701cead90697412a9721112c4e6dfd3af47d3c3a77c93754690e0",
-  "generator_sha256": "c27277bddc98d0ee84189a260b32805f3b0df73bba2068fd08a448b74e378cfd",
+  "generator_sha256": "f07691a85c6d1465a29d518e5b2ef47921cc03d4872cb55fd7bd7d53c38bb132",
   "row_identity_module_sha256": "9af9f9ed5b9321040428960e1293cffe27ebb48cc7a68a71f53f84cf18a60425",
   "disposition_module_sha256": "987fa4809e5780831f9e50e0b5cacc52888284fc7eae82a0928056c45c14a7d8",
   "publication_metadata_sha256": "fab670a686e002e6bc704cda75bf59c20dc5eaa8da78c94273c242021ccaf873",

--- a/reports/publication-product-and-import-policy.md
+++ b/reports/publication-product-and-import-policy.md
@@ -500,7 +500,9 @@ The five product records remain in canonical order and govern the existing path,
 
 The product-type IRIs are controlled `dcterms:type` values. They do not require declaration triples or a separate vocabulary ontology. The development authority status uses `adms:status` with the governed maintained-authoritative-development IRI. Descriptions remain lifecycle-neutral and do not repeat that status.
 
-Schema version 2 governs and validates these values but does not yet emit them as RDF. The next metadata-emission implementation must generate RDF transactionally from the TOML rather than hand-editing products, and it must preserve every governed logical axiom set and the approved import graph byte-for-byte except for the newly approved annotation triples.
+Schema version 2 governs, validates, and transactionally emits exactly seven development annotations on each maintained ontology subject, in canonical order: `rdfs:label`, `dcterms:description`, `dcterms:type`, `adms:status`, `dcterms:license`, `rdfs:seeAlso`, and `rdfs:comment`. Labels, descriptions, and warnings are language-tagged with the governed default `en`; product type, status, license, and repository objects are IRIs. The integrated and modular emitters consume one shared immutable metadata model loaded once per nine-output transaction. The exact metadata set is validated separately from declarations, imports, and governed/structural logical triples.
+
+Development serialization is deterministic and preserves the existing generated-file Turtle comments in addition to the machine-readable warning. Metadata prefix and ontology-header ordering are explicit, and stripping the ontology declaration, approved project imports, and exact seven annotations must reproduce the governed logical graph. Metadata is never counted as a governed axiom, mapping triple, structural expression triple, projection axiom, or copied declaration.
 
 Creator and contributor governance, ORCIDs, agents, provenance, source and dependency identities, local validation paths, dependency hashes, workbook or generator provenance, release identifiers and dates, Git tags, commit bindings, artifact hashes, manifests, and formal-release RDF remain deferred. Local filesystem paths and hashes must never be emitted as ontology RDF identifiers or publication metadata. Contributor metadata must not be inferred automatically from Git authors.
 
@@ -740,7 +742,7 @@ No implementation step may change the COMS workbook merely to simplify product g
 - [ ] No row or complex expression is silently omitted or flattened.
 - [ ] Formal releases use `YYYY-MM-DD` or `YYYY-MM-DD.N`, matching `v<version>` tags, and immutable version IRIs under `http://www.sks.ai/SSN2BFO/releases/<version>/`.
 - [ ] No version IRI is reused for different bytes.
-- [ ] Metadata is generated from `config/publication-metadata.toml`, parsed with Python 3.12 `tomllib`, and is not hand-edited into products.
+- [x] Development metadata is generated from `config/publication-metadata.toml`, parsed with standard-library `tomllib`, and is not hand-edited into products.
 - [ ] Development generation does not claim an immutable release version IRI.
 - [ ] Every production file strictly parses and contains its asserted axioms; annotation-only pseudo-mappings fail validation.
 - [ ] Product-specific vocabulary and import audits pass.

--- a/tests/test_bfo_projection.py
+++ b/tests/test_bfo_projection.py
@@ -20,10 +20,15 @@ import generate_mapping_from_coms as coms  # noqa: E402
 import modular_products as modular  # noqa: E402
 from coms_row_identity import RowLocation  # noqa: E402
 from product_dispositions import ProductDisposition, load_disposition_document  # noqa: E402
-from publication_metadata import load_metadata  # noqa: E402
+from publication_metadata import (  # noqa: E402
+    load_metadata,
+    ontology_metadata_rdf_triples,
+    strip_emitted_ontology_header,
+    validate_emitted_ontology_metadata,
+)
 
 
-EXPECTED_SHA256 = "7914e0afb6212df20e02686e1b11b71d109e0b81095ddf33ff120b01768cc71c"
+EXPECTED_SHA256 = "b5c1163eb6ab24c2e111e9e76c7b97acb20d897c9d1abc3daa555628206da5b0"
 PROJECTION_IRI = URIRef(
     "http://www.sks.ai/SSN2BFO/current-ssn-sosa/bfo-projection"
 )
@@ -61,17 +66,17 @@ class BfoProjectionTests(unittest.TestCase):
             cls.audits,
             cls.disposition,
         )
-        cls.strict_bytes = (
-            REPO_ROOT / "releases/current-ssn-sosa/ssn-sosa-bfo-mapping.ttl"
-        ).read_bytes()
-        cls.core_bytes = (
-            REPO_ROOT / "releases/current-ssn-sosa/ssn-sosa-alignment-core.ttl"
-        ).read_bytes()
+        cls.strict_result = modular.build_strict_bfo_mapping(
+            cls.strict_selected, cls.metadata
+        )
+        cls.core_result = modular.build_alignment_core(cls.core_selected, cls.metadata)
+        cls.strict_bytes = cls.strict_result.serialized_bytes
+        cls.core_bytes = cls.core_result.serialized_bytes
         cls.root_graph = Graph().parse(REPO_ROOT / "SSN2BFO.ttl", format="turtle")
         cls.reasoning = modular.ModularReasoningResult(
             source_product_key="strict_bfo_mapping",
             source_product_sha256=hashlib.sha256(cls.strict_bytes).hexdigest(),
-            closure_triple_count=14972,
+            closure_triple_count=14986,
             return_code=0,
             reasoned_output_produced=True,
             owl_nothing_count=0,
@@ -320,20 +325,43 @@ class BfoProjectionTests(unittest.TestCase):
             modular.build_bfo_projection((self.strict_selected[0],), self.metadata)
         self.assertEqual(self.error_codes(raised.exception), {"UNAPPROVED_PROJECTION_AXIOM"})
 
-    def test_direct_graph_has_only_the_governed_header_and_import(self) -> None:
+    def test_direct_graph_has_only_governed_metadata_header_and_import(self) -> None:
         graph = Graph().parse(
             data=self.result.serialized_bytes.decode("utf-8"), format="turtle"
         )
-        self.assertEqual(len(graph), 2)
+        self.assertEqual(len(graph), 9)
         self.assertEqual(self.result.governed_axiom_count, 0)
         self.assertEqual(self.result.logical_triple_count, 0)
+        self.assertEqual(self.result.ontology_declaration_triple_count, 1)
         self.assertEqual(self.result.import_triple_count, 1)
+        self.assertEqual(self.result.metadata_annotation_count, 7)
         self.assertEqual(
             set(graph),
             {
                 (PROJECTION_IRI, RDF.type, OWL.Ontology),
                 (PROJECTION_IRI, OWL.imports, STRICT_IRI),
+                *ontology_metadata_rdf_triples(self.metadata, "bfo_projection"),
             },
+        )
+        self.assertEqual(
+            validate_emitted_ontology_metadata(
+                graph,
+                self.metadata,
+                "bfo_projection",
+                (str(STRICT_IRI),),
+            ),
+            (),
+        )
+        self.assertEqual(
+            len(
+                strip_emitted_ontology_header(
+                    graph,
+                    self.metadata,
+                    "bfo_projection",
+                    (str(STRICT_IRI),),
+                )
+            ),
+            0,
         )
         self.assertFalse(any(isinstance(value, BNode) for value in graph.all_nodes()))
         text = self.result.serialized_bytes.decode("utf-8")
@@ -407,11 +435,11 @@ class BfoProjectionTests(unittest.TestCase):
             & {value.axiom_id for value in self.core_selected},
             set(),
         )
-        self.assertEqual(len(project), 183)
+        self.assertEqual(len(project), 204)
         self.assertEqual(len(list(project.triples((None, OWL.imports, None)))), 2)
         for triple in list(project.triples((None, OWL.imports, None))):
             project.remove(triple)
-        self.assertEqual(len(project), 181)
+        self.assertEqual(len(project), 202)
         self.assertFalse(
             any(
                 isinstance(value, URIRef)
@@ -471,23 +499,36 @@ print(hashlib.sha256(data).hexdigest())
         )
         self.assertEqual(completed.stdout.strip(), EXPECTED_SHA256)
 
+    def test_reordered_canonical_header_is_rejected_by_product_validator(self) -> None:
+        lines = self.result.serialized_bytes.splitlines()
+        label = next(i for i, line in enumerate(lines) if line.startswith(b"    rdfs:label "))
+        description = next(
+            i for i, line in enumerate(lines) if line.startswith(b"    dcterms:description ")
+        )
+        lines[label], lines[description] = lines[description], lines[label]
+        codes = {value.code for value in self.validate(b"\n".join(lines) + b"\n")}
+        self.assertIn("NONCANONICAL_ONTOLOGY_HEADER", codes)
+
     def test_existing_module_bytes_remain_protected(self) -> None:
         self.assertEqual(
             hashlib.sha256(self.core_bytes).hexdigest(),
-            "95f71184b90224906b0ba703d0ea60fd2f8b993b3853b803c66b88b91ba0b01c",
+            "17695ef17379924449153b2c92ffaed6b57d497a1b2d1e854f584614cebec770",
         )
         self.assertEqual(
             hashlib.sha256(self.strict_bytes).hexdigest(),
-            "15f080145c6803d174a00cf9e13c971925b40485049744dba6e0847093016ea7",
+            "676b31620df10db5c26c46bcc44b2dfd5939d606b16e0fa8a910926e8497c3af",
         )
         self.assertEqual(
-            hashlib.sha256(
-                (
-                    REPO_ROOT
-                    / "releases/current-ssn-sosa/ssn-sosa-cco-extension.ttl"
-                ).read_bytes()
-            ).hexdigest(),
-            "fe6986d79ec2f5f67553fbee1364fa98ebd7ba3205196f0368ac246646fcdf7c",
+            modular.build_cco_extension(
+                modular.select_product_axioms(
+                    "cco_extension",
+                    self.canonical_rows,
+                    self.audits,
+                    self.disposition,
+                ),
+                self.metadata,
+            ).sha256,
+            "fc98e6fafa1a3a5c8612fd9b8e4e571e9a382faa3f9ca9801e64533b91f00aaf",
         )
 
 

--- a/tests/test_cco_extension.py
+++ b/tests/test_cco_extension.py
@@ -21,7 +21,12 @@ import generate_mapping_from_coms as coms  # noqa: E402
 import modular_products as modular  # noqa: E402
 from coms_row_identity import RowLocation  # noqa: E402
 from product_dispositions import ProductDisposition, load_disposition_document  # noqa: E402
-from publication_metadata import load_metadata  # noqa: E402
+from publication_metadata import (  # noqa: E402
+    load_metadata,
+    ontology_metadata_rdf_triples,
+    strip_emitted_ontology_header,
+    validate_emitted_ontology_metadata,
+)
 
 
 EXPECTED_INVENTORY = tuple(
@@ -321,7 +326,38 @@ class CcoExtensionTests(unittest.TestCase):
         self.assertEqual(set(graph.subjects(RDF.type, OWL.Ontology)), {ontology})
         self.assertEqual(set(graph.triples((None, OWL.imports, None))), {(ontology, OWL.imports, strict)})
         self.assertEqual(self.cco_result.logical_triple_count, 934)
-        self.assertEqual(len(graph), 936)
+        self.assertEqual(self.cco_result.ontology_declaration_triple_count, 1)
+        self.assertEqual(self.cco_result.import_triple_count, 1)
+        self.assertEqual(self.cco_result.metadata_annotation_count, 7)
+        self.assertEqual(len(graph), 943)
+        self.assertEqual(
+            set(ontology_metadata_rdf_triples(self.metadata, "cco_extension")),
+            set(graph.triples((ontology, None, None)))
+            - {
+                (ontology, RDF.type, OWL.Ontology),
+                (ontology, OWL.imports, strict),
+            },
+        )
+        self.assertEqual(
+            validate_emitted_ontology_metadata(
+                graph,
+                self.metadata,
+                "cco_extension",
+                (str(strict),),
+            ),
+            (),
+        )
+        self.assertEqual(
+            len(
+                strip_emitted_ontology_header(
+                    graph,
+                    self.metadata,
+                    "cco_extension",
+                    (str(strict),),
+                )
+            ),
+            934,
+        )
         self.assertEqual(len(set(graph.subjects(OWL.unionOf, None))), 7)
         self.assertEqual(len(set(graph.subjects(OWL.intersectionOf, None))), 86)
         self.assertEqual(len(set(graph.subjects(OWL.someValuesFrom, None))), 95)
@@ -370,12 +406,28 @@ class CcoExtensionTests(unittest.TestCase):
         self.assertTrue(self.cco_result.serialized_bytes.endswith(b"\n"))
         self.assertFalse(self.cco_result.serialized_bytes.endswith(b"\n\n"))
         self.assertEqual(
+            self.cco_result.sha256,
+            "fc98e6fafa1a3a5c8612fd9b8e4e571e9a382faa3f9ca9801e64533b91f00aaf",
+        )
+        self.assertEqual(
             hashlib.sha256(self.core_result.serialized_bytes).hexdigest(),
-            "95f71184b90224906b0ba703d0ea60fd2f8b993b3853b803c66b88b91ba0b01c",
+            "17695ef17379924449153b2c92ffaed6b57d497a1b2d1e854f584614cebec770",
         )
         self.assertEqual(
             hashlib.sha256(self.strict_result.serialized_bytes).hexdigest(),
-            "15f080145c6803d174a00cf9e13c971925b40485049744dba6e0847093016ea7",
+            "676b31620df10db5c26c46bcc44b2dfd5939d606b16e0fa8a910926e8497c3af",
+        )
+
+    def test_reordered_canonical_header_is_rejected_by_product_validator(self) -> None:
+        lines = self.cco_result.serialized_bytes.splitlines()
+        label = next(i for i, line in enumerate(lines) if line.startswith(b"    rdfs:label "))
+        description = next(
+            i for i, line in enumerate(lines) if line.startswith(b"    dcterms:description ")
+        )
+        lines[label], lines[description] = lines[description], lines[label]
+        self.assertIn(
+            "NONCANONICAL_ONTOLOGY_HEADER",
+            self.validate_bytes(b"\n".join(lines) + b"\n"),
         )
 
     def test_fresh_process_generation_is_byte_deterministic(self) -> None:
@@ -420,11 +472,11 @@ class CcoExtensionTests(unittest.TestCase):
         graph = Graph().parse(data=self.cco_result.serialized_bytes.decode(), format="turtle")
         graph.parse(data=self.strict_result.serialized_bytes.decode(), format="turtle")
         graph.parse(data=self.core_result.serialized_bytes.decode(), format="turtle")
-        self.assertEqual(len(graph), 1117)
+        self.assertEqual(len(graph), 1138)
         for triple in list(graph.triples((None, OWL.imports, None))):
             graph.remove(triple)
-        self.assertEqual(len(graph), 1115)
-        self.assertEqual(len(self.fixed_closure), 15907)
+        self.assertEqual(len(graph), 1136)
+        self.assertEqual(len(self.fixed_closure), 15928)
         self.assertFalse(any(True for _ in self.fixed_closure.triples((None, OWL.imports, None))))
 
     def test_pinned_closure_hermit_is_clean(self) -> None:
@@ -442,7 +494,7 @@ class CcoExtensionTests(unittest.TestCase):
         self.assertTrue(result.passed, result.robot_output)
         self.assertEqual(result.return_code, 0)
         self.assertTrue(result.reasoned_output_produced)
-        self.assertEqual(result.closure_triple_count, 15907)
+        self.assertEqual(result.closure_triple_count, 15928)
         self.assertEqual(result.unsat_classes, [])
 
 

--- a/tests/test_generate_mapping_from_coms.py
+++ b/tests/test_generate_mapping_from_coms.py
@@ -3,7 +3,11 @@
 
 from __future__ import annotations
 
+import hashlib
+import inspect
 import json
+import os
+import subprocess
 import sys
 import tempfile
 import unittest
@@ -12,8 +16,9 @@ from types import SimpleNamespace
 from unittest import mock
 
 import openpyxl
-from rdflib import BNode, Graph, RDF, RDFS, OWL, URIRef
+from rdflib import BNode, Graph, Literal, RDF, RDFS, OWL, URIRef
 from rdflib.collection import Collection
+from rdflib.compare import isomorphic
 
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -24,7 +29,12 @@ import coms_row_identity as identity  # noqa: E402
 import generate_mapping_from_coms as coms  # noqa: E402
 import modular_products as modular  # noqa: E402
 import product_dispositions as dispositions  # noqa: E402
-from publication_metadata import load_metadata  # noqa: E402
+from publication_metadata import (  # noqa: E402
+    load_metadata,
+    ontology_metadata_rdf_triples,
+    strip_emitted_ontology_header,
+    validate_emitted_ontology_metadata,
+)
 
 
 SUBJECT = "sosa:hasFeatureOfInterest"
@@ -44,6 +54,7 @@ class ComsDomainRangeTests(unittest.TestCase):
         self.temp_dir = tempfile.TemporaryDirectory(prefix="coms-domain-range-test-")
         self.addCleanup(self.temp_dir.cleanup)
         self.root = Path(self.temp_dir.name)
+        self.metadata = load_metadata(REPO_ROOT / "config/publication-metadata.toml")
 
     @staticmethod
     def row_id_for(index: int) -> str:
@@ -86,7 +97,7 @@ class ComsDomainRangeTests(unittest.TestCase):
     def generate(self, rows: list[tuple[str, ...]], *, row_ids: list[str] | None = None):
         processed, stats = self.process(rows, row_ids=row_ids)
         output = self.root / "candidate.ttl"
-        graph = coms.generate_ontology(processed, output)
+        graph = coms.generate_ontology(processed, output, self.metadata)
         return graph, processed, stats
 
     def assert_generation_error(
@@ -196,6 +207,7 @@ class ComsDomainRangeTests(unittest.TestCase):
             processed,
             path,
             dispositions.RequiredInputHashes(*["0" * 64] * 5),
+            self.metadata,
         )
         self.assertEqual(document.summary.governed_row_count, 1)
         self.assertEqual(document.summary.authoritative_axiom_count, 1)
@@ -486,10 +498,10 @@ class ComsDomainRangeTests(unittest.TestCase):
         rows = [(SUBJECT, "rdfs:domain", "sosa:Observation")]
         first, _ = self.process(rows, row_ids=[self.row_id_for(1)])
         first_output = self.root / "first.ttl"
-        coms.generate_ontology(first, first_output)
+        coms.generate_ontology(first, first_output, self.metadata)
         second, _ = self.process(rows, row_ids=[self.row_id_for(2)])
         second_output = self.root / "second.ttl"
-        coms.generate_ontology(second, second_output)
+        coms.generate_ontology(second, second_output, self.metadata)
         self.assertEqual(first_output.read_bytes(), second_output.read_bytes())
 
     def test_generation_does_not_mutate_workbook(self) -> None:
@@ -499,7 +511,9 @@ class ComsDomainRangeTests(unittest.TestCase):
         before = workbook_path.read_bytes()
         workbook_rows, stats = coms.read_workbook(workbook_path)
         processed = coms.validate_and_process_rows(workbook_rows, coms.Resolver(), stats)
-        coms.generate_ontology(processed, self.root / "nonmutating.ttl")
+        coms.generate_ontology(
+            processed, self.root / "nonmutating.ttl", self.metadata
+        )
         self.assertEqual(before, workbook_path.read_bytes())
 
     def test_named_class_domain(self) -> None:
@@ -696,8 +710,8 @@ class ComsGenerationReportTests(unittest.TestCase):
         return coms.HermitResult(
             graph_path=self.root / "closure.ttl",
             reasoned_path=self.root / "reasoned.ttl",
-            generated_triple_count=1117,
-            closure_triple_count=15905,
+            generated_triple_count=1124,
+            closure_triple_count=15912,
             return_code=0 if available else None,
             reasoned_output_produced=available,
             owl_nothing_count=0 if available else None,
@@ -879,10 +893,13 @@ class ComsGenerationReportTests(unittest.TestCase):
             named_target_count=26,
             union_target_count=3,
             logical_triple_count=53,
-            ontology_header_triple_count=1,
-            total_triple_count=54,
+            ontology_declaration_triple_count=1,
+            import_triple_count=0,
+            metadata_annotation_count=7,
+            total_triple_count=61,
         )
         hermit = SimpleNamespace(
+            closure_triple_count=1212,
             return_code=0,
             reasoned_output_produced=True,
             unsat_classes=[],
@@ -905,7 +922,11 @@ class ComsGenerationReportTests(unittest.TestCase):
         self.assertIn("Domain axioms: 15", report)
         self.assertIn("Range axioms: 14", report)
         self.assertIn("Logical RDF triples: 53", report)
-        self.assertIn("Total RDF triples: 54", report)
+        self.assertIn("Ontology declaration triples: 1", report)
+        self.assertIn("Import triples: 0", report)
+        self.assertIn("Descriptive metadata annotations: 7", report)
+        self.assertIn("Total RDF triples: 61", report)
+        self.assertIn("Source-closure triple count: 1212", report)
         self.assertIn("Source-closure HermiT result: PASS", report)
 
     def test_generation_report_includes_strict_bfo_results(self) -> None:
@@ -923,11 +944,13 @@ class ComsGenerationReportTests(unittest.TestCase):
             domain_axiom_count=1,
             range_axiom_count=1,
             logical_triple_count=125,
-            ontology_header_triple_count=2,
-            total_triple_count=127,
+            ontology_declaration_triple_count=1,
+            import_triple_count=1,
+            metadata_annotation_count=7,
+            total_triple_count=134,
         )
         hermit = SimpleNamespace(
-            closure_triple_count=14972,
+            closure_triple_count=14986,
             return_code=0,
             reasoned_output_produced=True,
             unsat_classes=[],
@@ -942,7 +965,9 @@ class ComsGenerationReportTests(unittest.TestCase):
         self.assertIn("## Strict BFO Mapping", report)
         self.assertIn("Direct governed authoritative axioms: 19", report)
         self.assertIn("Project-module closure governed axioms: 48", report)
-        self.assertIn("Pinned closure triple count: 14972", report)
+        self.assertIn("Descriptive metadata annotations: 7", report)
+        self.assertIn("Total RDF triples: 134", report)
+        self.assertIn("Pinned closure triple count: 14986", report)
         self.assertIn("HermiT result: PASS", report)
 
     def test_generation_report_includes_cco_extension_results(self) -> None:
@@ -964,11 +989,13 @@ class ComsGenerationReportTests(unittest.TestCase):
             direct_subproperty_axiom_count=16,
             property_chain_axiom_count=3,
             logical_triple_count=934,
-            ontology_header_triple_count=2,
-            total_triple_count=936,
+            ontology_declaration_triple_count=1,
+            import_triple_count=1,
+            metadata_annotation_count=7,
+            total_triple_count=943,
         )
         hermit = SimpleNamespace(
-            closure_triple_count=15907,
+            closure_triple_count=15928,
             return_code=0,
             reasoned_output_produced=True,
             unsat_classes=[],
@@ -985,7 +1012,9 @@ class ComsGenerationReportTests(unittest.TestCase):
         self.assertIn("CCO-bearing axioms: 25", report)
         self.assertIn("Mixed BFO/CCO axioms: 32", report)
         self.assertIn("Project-module closure governed axioms: 105", report)
-        self.assertIn("Pinned closure triple count: 15907", report)
+        self.assertIn("Descriptive metadata annotations: 7", report)
+        self.assertIn("Total RDF triples: 943", report)
+        self.assertIn("Pinned closure triple count: 15928", report)
 
     def test_generation_report_includes_import_only_bfo_projection_results(self) -> None:
         result = SimpleNamespace(
@@ -996,8 +1025,10 @@ class ComsGenerationReportTests(unittest.TestCase):
             ),
             governed_axiom_count=0,
             logical_triple_count=0,
+            ontology_declaration_triple_count=1,
             import_triple_count=1,
-            total_triple_count=2,
+            metadata_annotation_count=7,
+            total_triple_count=9,
         )
         reconciliation = modular.ProductDispositionReconciliation(
             product_key="bfo_projection",
@@ -1021,7 +1052,7 @@ class ComsGenerationReportTests(unittest.TestCase):
         reasoning = modular.ModularReasoningResult(
             source_product_key="strict_bfo_mapping",
             source_product_sha256="strict-bfo-hash",
-            closure_triple_count=14972,
+            closure_triple_count=14986,
             return_code=0,
             reasoned_output_produced=True,
             owl_nothing_count=0,
@@ -1041,9 +1072,10 @@ class ComsGenerationReportTests(unittest.TestCase):
         )
         self.assertIn("Direct governed projection axioms: 0", report)
         self.assertIn("Direct logical mapping triples: 0", report)
-        self.assertIn("Total RDF triples: 2", report)
+        self.assertIn("Descriptive metadata annotations: 7", report)
+        self.assertIn("Total RDF triples: 9", report)
         self.assertIn("Project-module closure governed axioms: 48", report)
-        self.assertIn("Reused strict-BFO closure triple count: 14972", report)
+        self.assertIn("Reused strict-BFO closure triple count: 14986", report)
         self.assertIn("Projection-specific HermiT invocation: none", report)
         self.assertIn("Zero direct projection axioms is intentional", report)
 
@@ -1073,7 +1105,7 @@ class ComsAuthorityMigrationTests(unittest.TestCase):
         path.write_text(content, encoding="utf-8")
 
     @staticmethod
-    def generated_cco_extension_bytes() -> bytes:
+    def generated_product_bytes(product_key: str) -> bytes:
         rows, stats = coms.read_workbook(REPO_ROOT / "mappings/SSN2BFO-COMS.xlsx")
         processed = coms.validate_and_process_rows(rows, coms.Resolver(), stats)
         canonical_rows = tuple(
@@ -1085,14 +1117,37 @@ class ComsAuthorityMigrationTests(unittest.TestCase):
         )
         metadata = load_metadata(REPO_ROOT / "config/publication-metadata.toml")
         selected = modular.select_product_axioms(
-            "cco_extension", canonical_rows, audits, disposition
+            product_key, canonical_rows, audits, disposition
         )
-        return modular.build_cco_extension(selected, metadata).serialized_bytes
+        builders = {
+            "alignment_core": modular.build_alignment_core,
+            "strict_bfo_mapping": modular.build_strict_bfo_mapping,
+            "cco_extension": modular.build_cco_extension,
+        }
+        return builders[product_key](selected, metadata).serialized_bytes
+
+    @classmethod
+    def generated_cco_extension_bytes(cls) -> bytes:
+        return cls.generated_product_bytes("cco_extension")
 
     @staticmethod
     def generated_bfo_projection_bytes() -> bytes:
         metadata = load_metadata(REPO_ROOT / "config/publication-metadata.toml")
         return modular.build_bfo_projection((), metadata).serialized_bytes
+
+    @staticmethod
+    def reordered_root_import_bytes(canonical: bytes) -> bytes:
+        canonical_imports = (
+            b"    owl:imports sampling:,\n"
+            b"        ssn:,\n"
+        )
+        reordered_imports = (
+            b"    owl:imports ssn:,\n"
+            b"        sampling:,\n"
+        )
+        if canonical.count(canonical_imports) != 1:
+            raise AssertionError("canonical integrated-root import block is missing or duplicated")
+        return canonical.replace(canonical_imports, reordered_imports, 1)
 
     def test_root_ontology_is_the_maintained_output(self) -> None:
         self.assertEqual(checker.MAINTAINED_OUTPUTS["candidate"], REPO_ROOT / "SSN2BFO.ttl")
@@ -1120,6 +1175,121 @@ class ComsAuthorityMigrationTests(unittest.TestCase):
             checker.MAINTAINED_OUTPUTS["cco_extension"],
             REPO_ROOT / "releases/current-ssn-sosa/ssn-sosa-cco-extension.ttl",
         )
+
+    def test_maintained_root_has_exact_metadata_and_logical_partition(self) -> None:
+        maintained_path = REPO_ROOT / "SSN2BFO.ttl"
+        metadata = load_metadata(REPO_ROOT / "config/publication-metadata.toml")
+        maintained_graph = Graph().parse(maintained_path, format="turtle")
+
+        self.assertEqual(
+            validate_emitted_ontology_metadata(
+                maintained_graph,
+                metadata,
+                "integrated",
+                checker.ROOT_ORDERED_IMPORTS,
+            ),
+            (),
+        )
+        self.assertEqual(len(maintained_graph), 1124)
+        logical_graph = strip_emitted_ontology_header(
+            maintained_graph,
+            metadata,
+            "integrated",
+            checker.ROOT_ORDERED_IMPORTS,
+        )
+        self.assertEqual(len(logical_graph), 1112)
+        self.assertNotEqual(
+            hashlib.sha256(maintained_path.read_bytes()).hexdigest(),
+            "fd6eadf1bcbd4bfc6dc06df58915116d8f909bc8c3238592b1f13509cec47d16",
+        )
+
+        rows, stats = coms.read_workbook(REPO_ROOT / "mappings/SSN2BFO-COMS.xlsx")
+        processed = coms.validate_and_process_rows(rows, coms.Resolver(), stats)
+        regenerated_path = self.root / "regenerated-root.ttl"
+        regenerated_graph = coms.generate_ontology(
+            processed,
+            regenerated_path,
+            metadata,
+            require_current_counts=True,
+        )
+        self.assertEqual(len(regenerated_graph), 1124)
+        self.assertEqual(regenerated_path.read_bytes(), maintained_path.read_bytes())
+        self.assertEqual(
+            hashlib.sha256(maintained_path.read_bytes()).hexdigest(),
+            "25b5828424e48396db546b2c3732befec2defcd3159c2a132a2f73343d1f17e0",
+        )
+        governed_axiom_ids = {
+            f"sha256:{axiom.sha256}"
+            for item in processed
+            for axiom in item.identity_audit.authoritative_axioms
+        }
+        self.assertEqual(set(modular._canonical_graph_axioms(regenerated_graph)), governed_axiom_ids)
+        self.assertEqual(len(governed_axiom_ids), 105)
+
+    def test_integrated_root_bytes_are_explicit_and_repeatable_without_rdflib_serialization(self) -> None:
+        rows, stats = coms.read_workbook(REPO_ROOT / "mappings/SSN2BFO-COMS.xlsx")
+        processed = coms.validate_and_process_rows(rows, coms.Resolver(), stats)
+        publication_metadata = load_metadata(
+            REPO_ROOT / "config/publication-metadata.toml"
+        )
+        first = self.root / "root-first.ttl"
+        second = self.root / "nested/root-second.ttl"
+        with mock.patch.object(
+            coms.Graph,
+            "serialize",
+            side_effect=AssertionError("RDFLib serialization must not determine maintained bytes"),
+        ) as serializer:
+            coms.generate_ontology(
+                processed, first, publication_metadata, require_current_counts=True
+            )
+            coms.generate_ontology(
+                processed, second, publication_metadata, require_current_counts=True
+            )
+        serializer.assert_not_called()
+        self.assertEqual(first.read_bytes(), second.read_bytes())
+        self.assertEqual(
+            hashlib.sha256(first.read_bytes()).hexdigest(),
+            "25b5828424e48396db546b2c3732befec2defcd3159c2a132a2f73343d1f17e0",
+        )
+        self.assertNotIn(".serialize(", inspect.getsource(coms._root_turtle_bytes))
+        self.assertNotIn(".serialize(", inspect.getsource(coms.generate_ontology))
+
+    def test_integrated_root_is_fresh_process_stable_across_hash_seeds_and_paths(self) -> None:
+        code = (
+            "from pathlib import Path; import hashlib,sys; "
+            "import generate_mapping_from_coms as g; "
+            "from publication_metadata import load_metadata; "
+            "rows,stats=g.read_workbook(Path('mappings/SSN2BFO-COMS.xlsx')); "
+            "processed=g.validate_and_process_rows(rows,g.Resolver(),stats); "
+            "output=Path(sys.argv[1]); "
+            "g.generate_ontology(processed,output,load_metadata(Path('config/publication-metadata.toml')),require_current_counts=True); "
+            "print(hashlib.sha256(output.read_bytes()).hexdigest())"
+        )
+        expected = "25b5828424e48396db546b2c3732befec2defcd3159c2a132a2f73343d1f17e0"
+        observed: dict[str, str] = {}
+        for seed in ("0", "1", "42", "random"):
+            with tempfile.TemporaryDirectory(prefix=f"root-seed-{seed}-") as directory:
+                output = Path(directory) / "different/path/SSN2BFO.ttl"
+                environment = dict(os.environ)
+                environment.update(
+                    {
+                        "PYTHONPATH": str(REPO_ROOT / "tools"),
+                        "PYTHONHASHSEED": seed,
+                        "LC_ALL": "C",
+                        "LANG": "C",
+                    }
+                )
+                process = subprocess.run(
+                    [sys.executable, "-c", code, str(output)],
+                    cwd=REPO_ROOT,
+                    env=environment,
+                    text=True,
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.PIPE,
+                    check=True,
+                )
+                observed[seed] = process.stdout.strip()
+        self.assertEqual(observed, {seed: expected for seed in observed})
 
     def test_legacy_ontology_is_the_comparison_baseline(self) -> None:
         generated_path = self.root / "generated.ttl"
@@ -1538,6 +1708,413 @@ class ComsAuthorityMigrationTests(unittest.TestCase):
             self.assertEqual(path.read_bytes(), content)
         self.assertEqual(list(cache_dir.glob("run-*")), [])
 
+    def test_publication_metadata_source_hash_participates_in_freshness(self) -> None:
+        outputs = self.maintained_outputs()
+        for name, path in outputs.items():
+            source = checker.MAINTAINED_OUTPUTS[name]
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_bytes(source.read_bytes())
+        before = {path: path.read_bytes() for path in outputs.values()}
+        changed_metadata = self.root / "config/publication-metadata.toml"
+        changed_metadata.parent.mkdir(parents=True, exist_ok=True)
+        changed_metadata.write_text(
+            checker.PUBLICATION_METADATA.read_text(encoding="utf-8").replace(
+                'project_title = "SSN-to-BFO"',
+                'project_title = "SSN-to-BFO metadata freshness probe"',
+                1,
+            ),
+            encoding="utf-8",
+        )
+        workbook_hash = checker.sha256_file(checker.WORKBOOK)
+        generator_hash = checker.sha256_file(checker.GENERATOR)
+        with (
+            mock.patch.object(checker, "REPO_ROOT", self.root),
+            mock.patch.object(checker, "MAINTAINED_OUTPUTS", outputs),
+            mock.patch.object(checker, "PUBLICATION_METADATA", changed_metadata),
+        ):
+            errors = checker.freshness_errors(workbook_hash, generator_hash)
+        self.assertIn("publication metadata hash differs from the generated report", errors)
+        self.assertIn("product-disposition publication_metadata_sha256 is stale", errors)
+        self.assertEqual({path: path.read_bytes() for path in outputs.values()}, before)
+
+    def test_first_successful_metadata_migration_replaces_all_five_ttls_together(self) -> None:
+        outputs = self.maintained_outputs()
+        for name, path in outputs.items():
+            self.write(path, f"pre-metadata-{name}\n")
+        before = {path: path.read_bytes() for path in outputs.values()}
+        generated_ttls = {
+            "candidate": (REPO_ROOT / "SSN2BFO.ttl").read_bytes(),
+            "alignment_core": self.generated_product_bytes("alignment_core"),
+            "strict_bfo_mapping": self.generated_product_bytes("strict_bfo_mapping"),
+            "bfo_projection": self.generated_bfo_projection_bytes(),
+            "cco_extension": self.generated_cco_extension_bytes(),
+        }
+        metadata = load_metadata(REPO_ROOT / "config/publication-metadata.toml")
+        expected_imports = {
+            "candidate": checker.ROOT_ORDERED_IMPORTS,
+            "alignment_core": (),
+            "strict_bfo_mapping": (
+                "http://www.sks.ai/SSN2BFO/current-ssn-sosa/alignment-core",
+            ),
+            "bfo_projection": (
+                "http://www.sks.ai/SSN2BFO/current-ssn-sosa/bfo-mapping",
+            ),
+            "cco_extension": (
+                "http://www.sks.ai/SSN2BFO/current-ssn-sosa/bfo-mapping",
+            ),
+        }
+        product_keys = {
+            "candidate": "integrated",
+            "alignment_core": "alignment_core",
+            "strict_bfo_mapping": "strict_bfo_mapping",
+            "bfo_projection": "bfo_projection",
+            "cco_extension": "cco_extension",
+        }
+        cache_dir = self.root / ".cache/coms"
+        transaction_dirs: list[Path] = []
+        validated = False
+
+        def fake_run_generator(paths: dict[str, Path], _log: list[str]) -> None:
+            transaction_dirs.append(paths["candidate"].parents[1])
+            for name in outputs:
+                paths[name].parent.mkdir(parents=True, exist_ok=True)
+                paths[name].write_bytes(
+                    generated_ttls.get(name, f"generated-{name}\n".encode("utf-8"))
+                )
+            self.write(paths["summary"], "{}\n")
+
+        def validate_metadata(paths: dict[str, Path], *_args, **_kwargs):
+            nonlocal validated
+            for name, product_key in product_keys.items():
+                graph = Graph().parse(paths[name], format="turtle")
+                checker.validate_product_metadata(
+                    graph,
+                    metadata,
+                    product_key,
+                    expected_imports[name],
+                )
+            validated = True
+            return {}
+
+        production_replace = checker.replace_outputs_atomically
+
+        def observe_replace(paths: dict[str, Path], transaction_dir: Path, log: list[str]) -> None:
+            self.assertTrue(validated)
+            self.assertEqual(
+                {path: path.read_bytes() for path in outputs.values()}, before
+            )
+            production_replace(paths, transaction_dir, log)
+
+        with (
+            mock.patch.object(checker, "REPO_ROOT", self.root),
+            mock.patch.object(checker, "CACHE_DIR", cache_dir),
+            mock.patch.object(checker, "LAST_SUCCESS", cache_dir / "last-success.json"),
+            mock.patch.object(checker, "LAST_FAILURE", cache_dir / "last-failure.log"),
+            mock.patch.object(checker, "MAINTAINED_OUTPUTS", outputs),
+            mock.patch.object(checker, "verify_workbook", return_value="workbook-hash"),
+            mock.patch.object(checker, "compile_generator", return_value="generator-hash"),
+            mock.patch.object(checker, "freshness_errors", return_value=["metadata migration"]),
+            mock.patch.object(checker, "run_generator", side_effect=fake_run_generator),
+            mock.patch.object(checker, "validate_temporary_outputs", side_effect=validate_metadata),
+            mock.patch.object(checker, "git_diff_check"),
+            mock.patch.object(checker, "output_differences", return_value=list(outputs)),
+            mock.patch.object(checker, "replace_outputs_atomically", side_effect=observe_replace),
+            mock.patch.object(checker, "record_success"),
+            mock.patch.object(checker, "write_failure_log"),
+        ):
+            self.assertEqual(checker.main([]), 0)
+        for name, content in generated_ttls.items():
+            self.assertEqual(outputs[name].read_bytes(), content)
+        self.assertEqual(len(transaction_dirs), 1)
+        self.assertFalse(transaction_dirs[0].exists())
+
+    def test_checker_rejects_noncanonical_headers_for_all_five_candidates(self) -> None:
+        metadata = load_metadata(REPO_ROOT / "config/publication-metadata.toml")
+        canonical = {
+            "candidate": (REPO_ROOT / "SSN2BFO.ttl").read_bytes(),
+            "alignment_core": self.generated_product_bytes("alignment_core"),
+            "strict_bfo_mapping": self.generated_product_bytes("strict_bfo_mapping"),
+            "bfo_projection": self.generated_bfo_projection_bytes(),
+            "cco_extension": self.generated_cco_extension_bytes(),
+        }
+        product_keys = {
+            output_name: product_key
+            for output_name, product_key, *_rest in checker.SERIALIZED_HEADER_PRODUCTS
+        }
+        paths = {
+            name: self.root / "serialized-header-candidates" / f"{name}.ttl"
+            for name in canonical
+        }
+
+        for mutated_name in canonical:
+            with self.subTest(product=product_keys[mutated_name]):
+                for name, content in canonical.items():
+                    paths[name].parent.mkdir(parents=True, exist_ok=True)
+                    paths[name].write_bytes(content)
+                lines = canonical[mutated_name].splitlines()
+                label_index = next(
+                    index
+                    for index, line in enumerate(lines)
+                    if line.startswith(b"    rdfs:label ")
+                )
+                description_index = next(
+                    index
+                    for index, line in enumerate(lines)
+                    if line.startswith(b"    dcterms:description ")
+                )
+                lines[label_index], lines[description_index] = (
+                    lines[description_index],
+                    lines[label_index],
+                )
+                mutated = b"\n".join(lines) + b"\n"
+                paths[mutated_name].write_bytes(mutated)
+                self.assertTrue(
+                    isomorphic(
+                        Graph().parse(data=canonical[mutated_name].decode(), format="turtle"),
+                        Graph().parse(data=mutated.decode(), format="turtle"),
+                    )
+                )
+                with self.assertRaises(checker.CheckFailure) as raised:
+                    checker.validate_candidate_serialized_headers(paths, metadata)
+                self.assertIn("NONCANONICAL_ONTOLOGY_HEADER", str(raised.exception))
+                self.assertIn(product_keys[mutated_name], str(raised.exception))
+
+    def test_checker_uses_generator_root_import_order_with_matching_turtle_terms(self) -> None:
+        expected_imports = (
+            "http://www.w3.org/ns/sosa/sampling/",
+            "http://www.w3.org/ns/ssn/",
+            "http://www.w3.org/ns/ssn/systems/",
+            "https://www.commoncoreontologies.org/2024-11-06/CommonCoreOntologiesMerged",
+        )
+        self.assertIs(checker.ROOT_ORDERED_IMPORTS, coms.ROOT_ORDERED_IMPORTS)
+        self.assertFalse(hasattr(checker, "ROOT_IMPORTS"))
+        self.assertEqual(coms.ROOT_ORDERED_IMPORTS, expected_imports)
+        self.assertEqual(len(coms.ROOT_ORDERED_IMPORTS), 4)
+        self.assertEqual(len(coms.ROOT_IMPORT_TURTLE_TERMS), 4)
+
+        integrated = next(
+            value
+            for value in checker.SERIALIZED_HEADER_PRODUCTS
+            if value[1] == "integrated"
+        )
+        self.assertIs(integrated[2], coms.ROOT_ORDERED_IMPORTS)
+        self.assertIs(integrated[5], coms.ROOT_IMPORT_TURTLE_TERMS)
+
+        prefix_block = "\n".join(
+            f"@prefix {prefix}: <{namespace}> ."
+            for prefix, namespace in coms.ROOT_PREFIXES
+        )
+        for expected_iri, turtle_term in zip(
+            coms.ROOT_ORDERED_IMPORTS,
+            coms.ROOT_IMPORT_TURTLE_TERMS,
+            strict=True,
+        ):
+            with self.subTest(turtle_term=turtle_term):
+                graph = Graph().parse(
+                    data=(
+                        f"{prefix_block}\n"
+                        f"<urn:test:ontology> owl:imports {turtle_term} .\n"
+                    ),
+                    format="turtle",
+                )
+                self.assertEqual(
+                    tuple(str(value) for value in graph.objects(None, OWL.imports)),
+                    (expected_iri,),
+                )
+
+    def test_checker_rejects_reordered_integrated_root_imports(self) -> None:
+        metadata = load_metadata(REPO_ROOT / "config/publication-metadata.toml")
+        canonical = {
+            "candidate": (REPO_ROOT / "SSN2BFO.ttl").read_bytes(),
+            "alignment_core": self.generated_product_bytes("alignment_core"),
+            "strict_bfo_mapping": self.generated_product_bytes("strict_bfo_mapping"),
+            "bfo_projection": self.generated_bfo_projection_bytes(),
+            "cco_extension": self.generated_cco_extension_bytes(),
+        }
+        paths = {
+            name: self.root / "reordered-root-imports" / f"{name}.ttl"
+            for name in canonical
+        }
+        for name, content in canonical.items():
+            paths[name].parent.mkdir(parents=True, exist_ok=True)
+            paths[name].write_bytes(content)
+
+        reordered = self.reordered_root_import_bytes(canonical["candidate"])
+        paths["candidate"].write_bytes(reordered)
+        self.assertTrue(
+            isomorphic(
+                Graph().parse(data=canonical["candidate"].decode(), format="turtle"),
+                Graph().parse(data=reordered.decode(), format="turtle"),
+            )
+        )
+        with self.assertRaises(checker.CheckFailure) as raised:
+            checker.validate_candidate_serialized_headers(paths, metadata)
+        self.assertIn("NONCANONICAL_ONTOLOGY_HEADER", str(raised.exception))
+        self.assertIn("integrated", str(raised.exception))
+
+    def test_reordered_integrated_root_imports_block_all_nine_outputs(self) -> None:
+        outputs = self.maintained_outputs()
+        for name, path in outputs.items():
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_bytes(checker.MAINTAINED_OUTPUTS[name].read_bytes())
+        before = {path: path.read_bytes() for path in outputs.values()}
+        before_mtimes = {path: path.stat().st_mtime_ns for path in outputs.values()}
+        cache_dir = self.root / ".cache/coms-reordered-root-imports"
+        transaction_dirs: list[Path] = []
+        production_run_generator = checker.run_generator
+        production_validate = checker.validate_temporary_outputs
+        workbook_hash = checker.sha256_file(checker.WORKBOOK)
+        generator_hash = checker.sha256_file(checker.GENERATOR)
+
+        def generate_then_reorder_imports(
+            paths: dict[str, Path], log: list[str]
+        ) -> None:
+            production_run_generator(paths, log)
+            transaction_dirs.append(paths["candidate"].parents[1])
+            canonical = paths["candidate"].read_bytes()
+            reordered = self.reordered_root_import_bytes(canonical)
+            self.assertTrue(
+                isomorphic(
+                    Graph().parse(data=canonical.decode(), format="turtle"),
+                    Graph().parse(data=reordered.decode(), format="turtle"),
+                )
+            )
+            old_hash = hashlib.sha256(canonical).hexdigest()
+            new_hash = hashlib.sha256(reordered).hexdigest()
+            paths["candidate"].write_bytes(reordered)
+            summary = json.loads(paths["summary"].read_text(encoding="utf-8"))
+            summary["generated_candidate_sha256"] = new_hash
+            paths["summary"].write_text(
+                json.dumps(summary, indent=2, sort_keys=True) + "\n",
+                encoding="utf-8",
+            )
+            report = paths["generation_report"].read_text(encoding="utf-8")
+            self.assertIn(old_hash, report)
+            paths["generation_report"].write_text(
+                report.replace(old_hash, new_hash),
+                encoding="utf-8",
+            )
+
+        with (
+            mock.patch.object(checker, "REPO_ROOT", self.root),
+            mock.patch.object(checker, "CACHE_DIR", cache_dir),
+            mock.patch.object(checker, "LAST_SUCCESS", cache_dir / "last-success.json"),
+            mock.patch.object(checker, "LAST_FAILURE", cache_dir / "last-failure.log"),
+            mock.patch.object(checker, "MAINTAINED_OUTPUTS", outputs),
+            mock.patch.object(checker, "verify_workbook", return_value=workbook_hash),
+            mock.patch.object(checker, "compile_generator", return_value=generator_hash),
+            mock.patch.object(checker, "freshness_errors", return_value=["metadata migration"]),
+            mock.patch.object(
+                checker, "run_generator", side_effect=generate_then_reorder_imports
+            ),
+            mock.patch.object(checker, "replace_outputs_atomically") as replace,
+        ):
+            self.assertIs(checker.validate_temporary_outputs, production_validate)
+            self.assertEqual(checker.main([]), 1)
+        replace.assert_not_called()
+        self.assertEqual(
+            {path: path.read_bytes() for path in outputs.values()},
+            before,
+        )
+        self.assertEqual(
+            {path: path.stat().st_mtime_ns for path in outputs.values()},
+            before_mtimes,
+        )
+        self.assertEqual(len(transaction_dirs), 1)
+        self.assertFalse(transaction_dirs[0].exists())
+        self.assertEqual(list(cache_dir.glob("run-*")), [])
+        failure_log = (cache_dir / "last-failure.log").read_text(encoding="utf-8")
+        self.assertIn("NONCANONICAL_ONTOLOGY_HEADER", failure_log)
+
+    def test_reordered_header_blocks_all_nine_outputs_via_production_validation(self) -> None:
+        outputs = self.maintained_outputs()
+        for name, path in outputs.items():
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_bytes(checker.MAINTAINED_OUTPUTS[name].read_bytes())
+        before = {path: path.read_bytes() for path in outputs.values()}
+        before_mtimes = {path: path.stat().st_mtime_ns for path in outputs.values()}
+        cache_dir = self.root / ".cache/coms-noncanonical-header"
+        transaction_dirs: list[Path] = []
+        production_run_generator = checker.run_generator
+        production_validate = checker.validate_temporary_outputs
+        workbook_hash = checker.sha256_file(checker.WORKBOOK)
+        generator_hash = checker.sha256_file(checker.GENERATOR)
+
+        def generate_then_reorder_header(
+            paths: dict[str, Path], log: list[str]
+        ) -> None:
+            production_run_generator(paths, log)
+            transaction_dirs.append(paths["candidate"].parents[1])
+            canonical = paths["alignment_core"].read_bytes()
+            lines = canonical.splitlines()
+            label_index = next(
+                index
+                for index, line in enumerate(lines)
+                if line.startswith(b"    rdfs:label ")
+            )
+            description_index = next(
+                index
+                for index, line in enumerate(lines)
+                if line.startswith(b"    dcterms:description ")
+            )
+            lines[label_index], lines[description_index] = (
+                lines[description_index],
+                lines[label_index],
+            )
+            reordered = b"\n".join(lines) + b"\n"
+            self.assertTrue(
+                isomorphic(
+                    Graph().parse(data=canonical.decode(), format="turtle"),
+                    Graph().parse(data=reordered.decode(), format="turtle"),
+                )
+            )
+            old_hash = hashlib.sha256(canonical).hexdigest()
+            new_hash = hashlib.sha256(reordered).hexdigest()
+            paths["alignment_core"].write_bytes(reordered)
+            summary = json.loads(paths["summary"].read_text(encoding="utf-8"))
+            summary["alignment_core_sha256"] = new_hash
+            paths["summary"].write_text(
+                json.dumps(summary, indent=2, sort_keys=True) + "\n",
+                encoding="utf-8",
+            )
+            report = paths["generation_report"].read_text(encoding="utf-8")
+            self.assertIn(old_hash, report)
+            paths["generation_report"].write_text(
+                report.replace(old_hash, new_hash),
+                encoding="utf-8",
+            )
+
+        with (
+            mock.patch.object(checker, "REPO_ROOT", self.root),
+            mock.patch.object(checker, "CACHE_DIR", cache_dir),
+            mock.patch.object(checker, "LAST_SUCCESS", cache_dir / "last-success.json"),
+            mock.patch.object(checker, "LAST_FAILURE", cache_dir / "last-failure.log"),
+            mock.patch.object(checker, "MAINTAINED_OUTPUTS", outputs),
+            mock.patch.object(checker, "verify_workbook", return_value=workbook_hash),
+            mock.patch.object(checker, "compile_generator", return_value=generator_hash),
+            mock.patch.object(checker, "freshness_errors", return_value=["metadata migration"]),
+            mock.patch.object(
+                checker, "run_generator", side_effect=generate_then_reorder_header
+            ),
+            mock.patch.object(checker, "replace_outputs_atomically") as replace,
+        ):
+            self.assertIs(checker.validate_temporary_outputs, production_validate)
+            self.assertEqual(checker.main([]), 1)
+        replace.assert_not_called()
+        self.assertEqual(
+            {path: path.read_bytes() for path in outputs.values()},
+            before,
+        )
+        self.assertEqual(
+            {path: path.stat().st_mtime_ns for path in outputs.values()},
+            before_mtimes,
+        )
+        self.assertEqual(len(transaction_dirs), 1)
+        self.assertFalse(transaction_dirs[0].exists())
+        self.assertEqual(list(cache_dir.glob("run-*")), [])
+        failure_log = (cache_dir / "last-failure.log").read_text(encoding="utf-8")
+        self.assertIn("NONCANONICAL_ONTOLOGY_HEADER", failure_log)
+
     def test_first_successful_update_creates_initially_absent_bfo_projection(self) -> None:
         outputs = self.maintained_outputs()
         existing = {
@@ -1570,25 +2147,19 @@ class ComsAuthorityMigrationTests(unittest.TestCase):
             nonlocal validated
             self.assertFalse(outputs["bfo_projection"].exists())
             graph = coms.Graph().parse(paths["bfo_projection"], format="turtle")
+            metadata = load_metadata(REPO_ROOT / "config/publication-metadata.toml")
+            ontology = URIRef(
+                "http://www.sks.ai/SSN2BFO/current-ssn-sosa/bfo-projection"
+            )
+            imported = URIRef(
+                "http://www.sks.ai/SSN2BFO/current-ssn-sosa/bfo-mapping"
+            )
             self.assertEqual(
                 set(graph),
                 {
-                    (
-                        URIRef(
-                            "http://www.sks.ai/SSN2BFO/current-ssn-sosa/bfo-projection"
-                        ),
-                        RDF.type,
-                        OWL.Ontology,
-                    ),
-                    (
-                        URIRef(
-                            "http://www.sks.ai/SSN2BFO/current-ssn-sosa/bfo-projection"
-                        ),
-                        OWL.imports,
-                        URIRef(
-                            "http://www.sks.ai/SSN2BFO/current-ssn-sosa/bfo-mapping"
-                        ),
-                    ),
+                    (ontology, RDF.type, OWL.Ontology),
+                    (ontology, OWL.imports, imported),
+                    *ontology_metadata_rdf_triples(metadata, "bfo_projection"),
                 },
             )
             validated = True
@@ -1639,7 +2210,7 @@ class ComsAuthorityMigrationTests(unittest.TestCase):
             events, ["generated", "validated", "replace-start", "replace-complete"]
         )
         self.assertEqual(outputs["bfo_projection"].read_bytes(), projection_bytes)
-        self.assertEqual(len(Graph().parse(outputs["bfo_projection"], format="turtle")), 2)
+        self.assertEqual(len(Graph().parse(outputs["bfo_projection"], format="turtle")), 9)
         self.assertTrue(all(path.is_file() for path in outputs.values()))
         self.assertEqual(len(transaction_dirs), 1)
         self.assertFalse(transaction_dirs[0].exists())
@@ -1660,10 +2231,7 @@ class ComsAuthorityMigrationTests(unittest.TestCase):
             name: f"new-{name}\n".encode("utf-8")
             for name in existing
         }
-        alignment_core_bytes = (
-            REPO_ROOT
-            / "releases/current-ssn-sosa/ssn-sosa-alignment-core.ttl"
-        ).read_bytes()
+        alignment_core_bytes = self.generated_product_bytes("alignment_core")
         ontology_iri = URIRef(
             "http://www.sks.ai/SSN2BFO/current-ssn-sosa/alignment-core"
         )
@@ -1693,7 +2261,7 @@ class ComsAuthorityMigrationTests(unittest.TestCase):
                 set(graph.triples((None, RDFS.range, None)))
             )
             self.assertEqual(governed_axioms, 29)
-            self.assertEqual(len(graph), 54)
+            self.assertEqual(len(graph), 61)
             validation_complete = True
             events.append("validated")
             return {}
@@ -1748,7 +2316,7 @@ class ComsAuthorityMigrationTests(unittest.TestCase):
             + len(set(final_graph.triples((None, RDFS.range, None)))),
             29,
         )
-        self.assertEqual(len(final_graph), 54)
+        self.assertEqual(len(final_graph), 61)
         self.assertTrue(all(path.is_file() for path in outputs.values()))
         self.assertEqual(len(transaction_dirs), 1)
         self.assertFalse(transaction_dirs[0].exists())
@@ -1765,9 +2333,7 @@ class ComsAuthorityMigrationTests(unittest.TestCase):
         expected_generated = {
             name: f"new-{name}\n".encode("utf-8") for name in existing
         }
-        strict_bytes = (
-            REPO_ROOT / "releases/current-ssn-sosa/ssn-sosa-bfo-mapping.ttl"
-        ).read_bytes()
+        strict_bytes = self.generated_product_bytes("strict_bfo_mapping")
         ontology_iri = URIRef(
             "http://www.sks.ai/SSN2BFO/current-ssn-sosa/bfo-mapping"
         )
@@ -1797,7 +2363,7 @@ class ComsAuthorityMigrationTests(unittest.TestCase):
                 set(graph.triples((None, OWL.imports, None))),
                 {(ontology_iri, OWL.imports, alignment_iri)},
             )
-            self.assertEqual(len(graph), 127)
+            self.assertEqual(len(graph), 134)
             validation_complete = True
             return {}
 
@@ -1874,7 +2440,7 @@ class ComsAuthorityMigrationTests(unittest.TestCase):
                 set(graph.triples((None, OWL.imports, None))),
                 {(ontology_iri, OWL.imports, strict_iri)},
             )
-            self.assertEqual(len(graph), 936)
+            self.assertEqual(len(graph), 943)
             validation_complete = True
             return {}
 
@@ -2317,6 +2883,7 @@ class ComsAuthorityMigrationTests(unittest.TestCase):
         cache_dir = self.root / ".cache/coms"
         transaction_dirs: list[Path] = []
         observed_candidates: list[bytes] = []
+        failures: list[str] = []
         disposition_source = REPO_ROOT / "reports/coms-product-dispositions.json"
         disposition = checker.load_disposition_document(disposition_source)
         disposition_bytes = disposition_source.read_bytes()
@@ -2330,6 +2897,7 @@ class ComsAuthorityMigrationTests(unittest.TestCase):
             paths["disposition_report"].write_bytes(disposition_bytes)
             malformed_core = b"@prefix owl: <http://www.w3.org/2002/07/owl#> .\n[\n"
             paths["alignment_core"].write_bytes(malformed_core)
+            observed_candidates.append(paths["alignment_core"].read_bytes())
             self.write(
                 paths["summary"],
                 json.dumps(
@@ -2357,8 +2925,10 @@ class ComsAuthorityMigrationTests(unittest.TestCase):
                             ),
                             "governed_axiom_count": 29,
                             "logical_triple_count": 53,
-                            "ontology_header_triple_count": 1,
-                            "total_triple_count": 54,
+                            "ontology_declaration_triple_count": 1,
+                            "import_triple_count": 0,
+                            "metadata_annotation_count": 7,
+                            "total_triple_count": 61,
                             "domain_axiom_count": 15,
                             "range_axiom_count": 14,
                             "named_target_count": 26,
@@ -2372,13 +2942,6 @@ class ComsAuthorityMigrationTests(unittest.TestCase):
                 + "\n",
             )
 
-        original_parse = checker.Graph.parse
-
-        def observe_parse(graph, source=None, *args, **kwargs):
-            if source == checker.transaction_paths(transaction_dirs[0])["alignment_core"]:
-                observed_candidates.append(Path(source).read_bytes())
-            return original_parse(graph, source, *args, **kwargs)
-
         with (
             mock.patch.object(checker, "REPO_ROOT", self.root),
             mock.patch.object(checker, "CACHE_DIR", cache_dir),
@@ -2389,13 +2952,18 @@ class ComsAuthorityMigrationTests(unittest.TestCase):
             mock.patch.object(checker, "compile_generator", return_value=generator_hash),
             mock.patch.object(checker, "freshness_errors", return_value=["stale"]),
             mock.patch.object(checker, "run_generator", side_effect=fake_run_generator),
-            mock.patch.object(checker.Graph, "parse", new=observe_parse),
-            mock.patch.object(checker, "write_failure_log"),
+            mock.patch.object(
+                checker,
+                "write_failure_log",
+                side_effect=lambda _mode, _log, exc: failures.append(str(exc)),
+            ),
         ):
             self.assertEqual(checker.main([]), 1)
 
         self.assertEqual(len(observed_candidates), 1)
         self.assertIn(b"[", observed_candidates[0])
+        self.assertIn("TURTLE_PARSE", failures[0])
+        self.assertIn("products.alignment_core.serialized_ontology", failures[0])
         for path, expected in before.items():
             self.assertEqual(path.read_bytes(), expected)
         self.assertEqual(len(transaction_dirs), 1)
@@ -2409,12 +2977,11 @@ class ComsAuthorityMigrationTests(unittest.TestCase):
         cache_dir = self.root / ".cache/coms"
         transaction_dirs: list[Path] = []
         observed_candidates: list[bytes] = []
+        failures: list[str] = []
         disposition_source = REPO_ROOT / "reports/coms-product-dispositions.json"
         disposition = checker.load_disposition_document(disposition_source)
         disposition_bytes = disposition_source.read_bytes()
-        alignment_bytes = (
-            REPO_ROOT / "releases/current-ssn-sosa/ssn-sosa-alignment-core.ttl"
-        ).read_bytes()
+        alignment_bytes = self.generated_product_bytes("alignment_core")
         workbook_hash = disposition.input_hashes.workbook_sha256
         generator_hash = disposition.input_hashes.generator_sha256
 
@@ -2426,6 +2993,7 @@ class ComsAuthorityMigrationTests(unittest.TestCase):
             paths["alignment_core"].write_bytes(alignment_bytes)
             malformed_strict = b"@prefix owl: <http://www.w3.org/2002/07/owl#> .\n[\n"
             paths["strict_bfo_mapping"].write_bytes(malformed_strict)
+            observed_candidates.append(paths["strict_bfo_mapping"].read_bytes())
             self.write(
                 paths["summary"],
                 json.dumps(
@@ -2445,8 +3013,10 @@ class ComsAuthorityMigrationTests(unittest.TestCase):
                             "stable_ontology_iri": "http://www.sks.ai/SSN2BFO/current-ssn-sosa/alignment-core",
                             "governed_axiom_count": 29,
                             "logical_triple_count": 53,
-                            "ontology_header_triple_count": 1,
-                            "total_triple_count": 54,
+                            "ontology_declaration_triple_count": 1,
+                            "import_triple_count": 0,
+                            "metadata_annotation_count": 7,
+                            "total_triple_count": 61,
                             "domain_axiom_count": 15,
                             "range_axiom_count": 14,
                             "named_target_count": 26,
@@ -2461,9 +3031,10 @@ class ComsAuthorityMigrationTests(unittest.TestCase):
                             "stable_ontology_iri": "http://www.sks.ai/SSN2BFO/current-ssn-sosa/bfo-mapping",
                             "governed_axiom_count": 19,
                             "logical_triple_count": 125,
-                            "ontology_header_triple_count": 2,
+                            "ontology_declaration_triple_count": 1,
                             "import_triple_count": 1,
-                            "total_triple_count": 127,
+                            "metadata_annotation_count": 7,
+                            "total_triple_count": 134,
                             "subclass_axiom_count": 3,
                             "equivalent_class_axiom_count": 3,
                             "direct_subproperty_axiom_count": 9,
@@ -2475,24 +3046,17 @@ class ComsAuthorityMigrationTests(unittest.TestCase):
                             "existential_restriction_count": 6,
                             "rdf_list_count": 14,
                             "project_closure_governed_axiom_count": 48,
-                            "project_graph_triple_count": 181,
-                            "local_project_graph_triple_count": 180,
+                            "project_graph_triple_count": 195,
+                            "local_project_graph_triple_count": 194,
                             "hermit_return_code": 0,
                             "hermit_result": "PASS",
-                            "closure_triple_count": 14972,
+                            "closure_triple_count": 14986,
                             "named_unsat_count": 0,
                         },
                     }
                 )
                 + "\n",
             )
-
-        original_parse = checker.Graph.parse
-
-        def observe_parse(graph, source=None, *args, **kwargs):
-            if source == checker.transaction_paths(transaction_dirs[0])["strict_bfo_mapping"]:
-                observed_candidates.append(Path(source).read_bytes())
-            return original_parse(graph, source, *args, **kwargs)
 
         with (
             mock.patch.object(checker, "REPO_ROOT", self.root),
@@ -2504,12 +3068,17 @@ class ComsAuthorityMigrationTests(unittest.TestCase):
             mock.patch.object(checker, "compile_generator", return_value=generator_hash),
             mock.patch.object(checker, "freshness_errors", return_value=["stale"]),
             mock.patch.object(checker, "run_generator", side_effect=fake_run_generator),
-            mock.patch.object(checker.Graph, "parse", new=observe_parse),
-            mock.patch.object(checker, "write_failure_log"),
+            mock.patch.object(
+                checker,
+                "write_failure_log",
+                side_effect=lambda _mode, _log, exc: failures.append(str(exc)),
+            ),
         ):
             self.assertEqual(checker.main([]), 1)
         self.assertEqual(len(observed_candidates), 1)
         self.assertIn(b"[", observed_candidates[0])
+        self.assertIn("TURTLE_PARSE", failures[0])
+        self.assertIn("products.strict_bfo_mapping.serialized_ontology", failures[0])
         for path, expected in before.items():
             self.assertEqual(path.read_bytes(), expected)
         self.assertEqual(len(transaction_dirs), 1)
@@ -2537,20 +3106,14 @@ class ComsAuthorityMigrationTests(unittest.TestCase):
         core_selected = modular.select_product_axioms(
             "alignment_core", canonical_rows, audits, disposition
         )
-        strict_bytes = (
-            REPO_ROOT / "releases/current-ssn-sosa/ssn-sosa-bfo-mapping.ttl"
-        ).read_bytes()
-        core_bytes = (
-            REPO_ROOT / "releases/current-ssn-sosa/ssn-sosa-alignment-core.ttl"
-        ).read_bytes()
+        strict_bytes = self.generated_product_bytes("strict_bfo_mapping")
+        core_bytes = self.generated_product_bytes("alignment_core")
         valid = self.generated_bfo_projection_bytes()
         valid_text = valid.decode("utf-8")
         reasoning = modular.ModularReasoningResult(
             source_product_key="strict_bfo_mapping",
-            source_product_sha256=checker.sha256_file(
-                REPO_ROOT / "releases/current-ssn-sosa/ssn-sosa-bfo-mapping.ttl"
-            ),
-            closure_triple_count=14972,
+            source_product_sha256=hashlib.sha256(strict_bytes).hexdigest(),
+            closure_triple_count=14986,
             return_code=0,
             reasoned_output_produced=True,
             owl_nothing_count=0,
@@ -2658,15 +3221,12 @@ class ComsAuthorityMigrationTests(unittest.TestCase):
         cache_dir = self.root / ".cache/coms"
         transaction_dirs: list[Path] = []
         observed_candidates: list[bytes] = []
+        failures: list[str] = []
         disposition_source = REPO_ROOT / "reports/coms-product-dispositions.json"
         disposition = checker.load_disposition_document(disposition_source)
         disposition_bytes = disposition_source.read_bytes()
-        alignment_bytes = (
-            REPO_ROOT / "releases/current-ssn-sosa/ssn-sosa-alignment-core.ttl"
-        ).read_bytes()
-        strict_bytes = (
-            REPO_ROOT / "releases/current-ssn-sosa/ssn-sosa-bfo-mapping.ttl"
-        ).read_bytes()
+        alignment_bytes = self.generated_product_bytes("alignment_core")
+        strict_bytes = self.generated_product_bytes("strict_bfo_mapping")
         projection_bytes = self.generated_bfo_projection_bytes()
         workbook_hash = disposition.input_hashes.workbook_sha256
         generator_hash = disposition.input_hashes.generator_sha256
@@ -2681,6 +3241,7 @@ class ComsAuthorityMigrationTests(unittest.TestCase):
             paths["bfo_projection"].write_bytes(projection_bytes)
             malformed_cco = b"@prefix owl: <http://www.w3.org/2002/07/owl#> .\n[\n"
             paths["cco_extension"].write_bytes(malformed_cco)
+            observed_candidates.append(paths["cco_extension"].read_bytes())
             summary = {
                 "status": "PASS",
                 "workbook_sha256": workbook_hash,
@@ -2701,8 +3262,10 @@ class ComsAuthorityMigrationTests(unittest.TestCase):
                     "stable_ontology_iri": "http://www.sks.ai/SSN2BFO/current-ssn-sosa/alignment-core",
                     "governed_axiom_count": 29,
                     "logical_triple_count": 53,
-                    "ontology_header_triple_count": 1,
-                    "total_triple_count": 54,
+                    "ontology_declaration_triple_count": 1,
+                    "import_triple_count": 0,
+                    "metadata_annotation_count": 7,
+                    "total_triple_count": 61,
                     "domain_axiom_count": 15,
                     "range_axiom_count": 14,
                     "named_target_count": 26,
@@ -2719,9 +3282,10 @@ class ComsAuthorityMigrationTests(unittest.TestCase):
                     "stable_ontology_iri": "http://www.sks.ai/SSN2BFO/current-ssn-sosa/bfo-mapping",
                     "governed_axiom_count": 19,
                     "logical_triple_count": 125,
-                    "ontology_header_triple_count": 2,
+                    "ontology_declaration_triple_count": 1,
                     "import_triple_count": 1,
-                    "total_triple_count": 127,
+                    "metadata_annotation_count": 7,
+                    "total_triple_count": 134,
                     "subclass_axiom_count": 3,
                     "equivalent_class_axiom_count": 3,
                     "direct_subproperty_axiom_count": 9,
@@ -2733,11 +3297,11 @@ class ComsAuthorityMigrationTests(unittest.TestCase):
                     "existential_restriction_count": 6,
                     "rdf_list_count": 14,
                     "project_closure_governed_axiom_count": 48,
-                    "project_graph_triple_count": 181,
-                    "local_project_graph_triple_count": 180,
+                    "project_graph_triple_count": 195,
+                    "local_project_graph_triple_count": 194,
                     "hermit_return_code": 0,
                     "hermit_result": "PASS",
-                    "closure_triple_count": 14972,
+                    "closure_triple_count": 14986,
                     "named_unsat_count": 0,
                 },
                 "bfo_projection_sha256": checker.sha256_file(
@@ -2750,18 +3314,19 @@ class ComsAuthorityMigrationTests(unittest.TestCase):
                     "logical_triple_count": 0,
                     "ontology_declaration_triple_count": 1,
                     "import_triple_count": 1,
-                    "total_triple_count": 2,
+                    "metadata_annotation_count": 7,
+                    "total_triple_count": 9,
                     "provided_transitively_count": 29,
                     "provided_through_import_count": 19,
                     "deferred_no_transformation_rule_count": 57,
                     "project_closure_governed_axiom_count": 48,
-                    "project_graph_triple_count": 183,
-                    "local_project_graph_triple_count": 181,
+                    "project_graph_triple_count": 204,
+                    "local_project_graph_triple_count": 202,
                     "reasoning_reused_from": "strict_bfo_mapping",
                     "reasoning_source_sha256": checker.sha256_file(
                         paths["strict_bfo_mapping"]
                     ),
-                    "reasoning_closure_triple_count": 14972,
+                    "reasoning_closure_triple_count": 14986,
                     "reasoning_return_code": 0,
                     "reasoned_output_produced": True,
                     "named_unsat_count": 0,
@@ -2775,9 +3340,10 @@ class ComsAuthorityMigrationTests(unittest.TestCase):
                     "cco_bearing_axiom_count": 25,
                     "mixed_bfo_cco_axiom_count": 32,
                     "logical_triple_count": 934,
-                    "ontology_header_triple_count": 2,
+                    "ontology_declaration_triple_count": 1,
                     "import_triple_count": 1,
-                    "total_triple_count": 936,
+                    "metadata_annotation_count": 7,
+                    "total_triple_count": 943,
                     "subclass_axiom_count": 31,
                     "equivalent_class_axiom_count": 7,
                     "direct_subproperty_axiom_count": 16,
@@ -2787,22 +3353,15 @@ class ComsAuthorityMigrationTests(unittest.TestCase):
                     "existential_restriction_count": 95,
                     "rdf_list_count": 96,
                     "project_closure_governed_axiom_count": 105,
-                    "project_graph_triple_count": 1117,
-                    "local_project_graph_triple_count": 1115,
+                    "project_graph_triple_count": 1138,
+                    "local_project_graph_triple_count": 1136,
                     "hermit_return_code": 0,
                     "hermit_result": "PASS",
-                    "closure_triple_count": 15907,
+                    "closure_triple_count": 15928,
                     "named_unsat_count": 0,
                 },
             }
             self.write(paths["summary"], json.dumps(summary) + "\n")
-
-        original_parse = checker.Graph.parse
-
-        def observe_parse(graph, source=None, *args, **kwargs):
-            if source == checker.transaction_paths(transaction_dirs[0])["cco_extension"]:
-                observed_candidates.append(Path(source).read_bytes())
-            return original_parse(graph, source, *args, **kwargs)
 
         with (
             mock.patch.object(checker, "REPO_ROOT", self.root),
@@ -2814,12 +3373,17 @@ class ComsAuthorityMigrationTests(unittest.TestCase):
             mock.patch.object(checker, "compile_generator", return_value=generator_hash),
             mock.patch.object(checker, "freshness_errors", return_value=["stale"]),
             mock.patch.object(checker, "run_generator", side_effect=fake_run_generator),
-            mock.patch.object(checker.Graph, "parse", new=observe_parse),
-            mock.patch.object(checker, "write_failure_log"),
+            mock.patch.object(
+                checker,
+                "write_failure_log",
+                side_effect=lambda _mode, _log, exc: failures.append(str(exc)),
+            ),
         ):
             self.assertEqual(checker.main([]), 1)
         self.assertEqual(len(observed_candidates), 1)
         self.assertIn(b"[", observed_candidates[0])
+        self.assertIn("TURTLE_PARSE", failures[0])
+        self.assertIn("products.cco_extension.serialized_ontology", failures[0])
         for path, expected in before.items():
             self.assertEqual(path.read_bytes(), expected)
         self.assertEqual(len(transaction_dirs), 1)

--- a/tests/test_modular_products.py
+++ b/tests/test_modular_products.py
@@ -21,7 +21,12 @@ import generate_mapping_from_coms as coms  # noqa: E402
 import modular_products as modular  # noqa: E402
 from coms_row_identity import ExpressionNode, RowLocation  # noqa: E402
 from product_dispositions import ProductDisposition, load_disposition_document  # noqa: E402
-from publication_metadata import load_metadata  # noqa: E402
+from publication_metadata import (  # noqa: E402
+    load_metadata,
+    ontology_metadata_rdf_triples,
+    strip_emitted_ontology_header,
+    validate_emitted_ontology_metadata,
+)
 
 
 EXPECTED_ROW_IDS = frozenset(
@@ -264,7 +269,25 @@ class ModularProductTests(unittest.TestCase):
         self.assertEqual(list(graph.triples((None, OWL.imports, None))), [])
         self.assertEqual(self.result.governed_axiom_count, 29)
         self.assertEqual(self.result.logical_triple_count, 53)
-        self.assertEqual(len(graph), 54)
+        self.assertEqual(self.result.ontology_declaration_triple_count, 1)
+        self.assertEqual(self.result.import_triple_count, 0)
+        self.assertEqual(self.result.metadata_annotation_count, 7)
+        self.assertEqual(len(graph), 61)
+        self.assertEqual(
+            set(ontology_metadata_rdf_triples(self.metadata, "alignment_core")),
+            set(graph.triples((ontology, None, None)))
+            - {(ontology, RDF.type, OWL.Ontology)},
+        )
+        self.assertEqual(
+            validate_emitted_ontology_metadata(
+                graph, self.metadata, "alignment_core", ()
+            ),
+            (),
+        )
+        logical = strip_emitted_ontology_header(
+            graph, self.metadata, "alignment_core", ()
+        )
+        self.assertEqual(len(logical), 53)
         self.assertEqual(len(list(graph.triples((None, RDFS.domain, None)))), 15)
         self.assertEqual(len(list(graph.triples((None, RDFS.range, None)))), 14)
 
@@ -337,6 +360,18 @@ class ModularProductTests(unittest.TestCase):
         self.assertEqual(modular.serialize_modular_product(reverse), self.result.serialized_bytes)
         self.assertTrue(self.result.serialized_bytes.endswith(b"\n"))
         self.assertFalse(self.result.serialized_bytes.endswith(b"\n\n"))
+
+    def test_reordered_canonical_header_is_rejected_by_product_validator(self) -> None:
+        lines = self.result.serialized_bytes.splitlines()
+        label = next(i for i, line in enumerate(lines) if line.startswith(b"    rdfs:label "))
+        description = next(
+            i for i, line in enumerate(lines) if line.startswith(b"    dcterms:description ")
+        )
+        lines[label], lines[description] = lines[description], lines[label]
+        self.assertIn(
+            "NONCANONICAL_ONTOLOGY_HEADER",
+            self.validate_bytes(b"\n".join(lines) + b"\n"),
+        )
 
     def test_fresh_process_generation_is_byte_deterministic(self) -> None:
         code = (
@@ -413,6 +448,9 @@ class ModularProductTests(unittest.TestCase):
         )
         closure = modular.build_fixed_source_closure(self.result.serialized_bytes, paths)
         self.assertEqual(list(closure.triples((None, OWL.imports, None))), [])
+        for triple in coms.CLEANUP_TRIPLES:
+            closure.remove(triple)
+        self.assertEqual(len(closure), 1212)
         self.assertEqual(
             modular.validate_alignment_core(
                 self.result.serialized_bytes,

--- a/tests/test_publication_metadata.py
+++ b/tests/test_publication_metadata.py
@@ -10,13 +10,19 @@ import sys
 import tempfile
 import unittest
 from contextlib import redirect_stderr
+from dataclasses import FrozenInstanceError
 from pathlib import Path
+
+from rdflib import Graph, Literal, RDF, RDFS, OWL, URIRef
+from rdflib.compare import isomorphic
 
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(REPO_ROOT / "tools"))
 
 import check_publication_metadata as checker  # noqa: E402
+import generate_mapping_from_coms as coms  # noqa: E402
+import modular_products as modular  # noqa: E402
 import publication_metadata as metadata  # noqa: E402
 
 
@@ -318,6 +324,446 @@ class ConfigurationTests(MetadataTestCase):
         second = metadata.load_metadata(self.write(render_toml(), "second.toml"))
         self.assertEqual(first, second)
         self.assertEqual(tuple(product.key for product in first.products), metadata.PRODUCT_ORDER)
+
+
+class OntologyMetadataEmissionTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.loaded = metadata.load_metadata(ACTUAL_CONFIG)
+
+    def graph_for(self, product_key: str, imports: tuple[str, ...] = ()) -> Graph:
+        product = next(value for value in self.loaded.products if value.key == product_key)
+        ontology = URIRef(product.stable_ontology_iri)
+        graph = Graph()
+        graph.add((ontology, RDF.type, OWL.Ontology))
+        for imported in imports:
+            graph.add((ontology, OWL.imports, URIRef(imported)))
+        for triple in metadata.ontology_metadata_rdf_triples(self.loaded, product_key):
+            graph.add(triple)
+        return graph
+
+    @staticmethod
+    def serialization_parameters(product_key: str):
+        if product_key == "integrated":
+            return (
+                coms.ROOT_ORDERED_IMPORTS,
+                coms.GENERATED_NOTICE,
+                coms.ROOT_PREFIXES,
+                coms.ROOT_IMPORT_TURTLE_TERMS,
+            )
+        imports = {
+            "alignment_core": (),
+            "strict_bfo_mapping": (modular.ALIGNMENT_CORE_IMPORT_IRI,),
+            "bfo_projection": (modular.STRICT_BFO_IMPORT_IRI,),
+            "cco_extension": (modular.STRICT_BFO_IMPORT_IRI,),
+        }[product_key]
+        prefixes = {
+            "alignment_core": modular.PREFIXES,
+            "strict_bfo_mapping": modular.STRICT_BFO_PREFIXES,
+            "bfo_projection": modular.BFO_PROJECTION_PREFIXES,
+            "cco_extension": modular.CCO_EXTENSION_PREFIXES,
+        }[product_key]
+        return imports, modular.GENERATED_NOTICE, prefixes, None
+
+    def serialized_issues(self, value: bytes, product_key: str):
+        imports, notice, prefixes, import_terms = self.serialization_parameters(product_key)
+        return metadata.validate_serialized_ontology_header(
+            value,
+            self.loaded,
+            product_key,
+            imports,
+            generated_notice=notice,
+            prefixes=prefixes,
+            import_turtle_terms=import_terms,
+        )
+
+    def test_exact_ordered_seven_metadata_triples_for_every_product(self) -> None:
+        expected_predicates = (
+            str(RDFS.label),
+            metadata.DCTERMS_NAMESPACE + "description",
+            metadata.DCTERMS_NAMESPACE + "type",
+            PUBLICATION_VALUES["development_status_property_iri"],
+            metadata.DCTERMS_NAMESPACE + "license",
+            str(RDFS.seeAlso),
+            str(RDFS.comment),
+        )
+        expected_kinds = (
+            metadata.LANGUAGE_LITERAL,
+            metadata.LANGUAGE_LITERAL,
+            metadata.IRI_OBJECT,
+            metadata.IRI_OBJECT,
+            metadata.IRI_OBJECT,
+            metadata.IRI_OBJECT,
+            metadata.LANGUAGE_LITERAL,
+        )
+        for product in self.loaded.products:
+            with self.subTest(product=product.key):
+                values = metadata.ontology_metadata_triples(self.loaded, product.key)
+                self.assertIsInstance(values, tuple)
+                self.assertEqual(len(values), 7)
+                self.assertEqual(tuple(value.predicate_iri for value in values), expected_predicates)
+                self.assertEqual(tuple(value.object_kind for value in values), expected_kinds)
+                self.assertEqual({value.product_key for value in values}, {product.key})
+                self.assertEqual({value.ontology_iri for value in values}, {product.stable_ontology_iri})
+                self.assertEqual(values[0].value, product.label)
+                self.assertEqual(values[1].value, product.description)
+                self.assertEqual(values[2].value, product.product_type_iri)
+                self.assertEqual(values[3].value, PUBLICATION_VALUES["development_status_iri"])
+                self.assertEqual(values[4].value, PUBLICATION_VALUES["license_iri"])
+                self.assertEqual(values[5].value, PUBLICATION_VALUES["repository_iri"])
+                self.assertEqual(values[6].value, PUBLICATION_VALUES["generated_warning"])
+                self.assertEqual(
+                    tuple(value.language for value in values),
+                    ("en", "en", None, None, None, None, "en"),
+                )
+
+    def test_metadata_rendering_is_deterministic_and_immutable(self) -> None:
+        first = metadata.ontology_metadata_triples(self.loaded, "integrated")
+        second = metadata.ontology_metadata_triples(self.loaded, "integrated")
+        self.assertEqual(first, second)
+        self.assertEqual(
+            tuple(value.object_turtle for value in first),
+            tuple(value.object_turtle for value in second),
+        )
+        with self.assertRaises(FrozenInstanceError):
+            first[0].value = "changed"  # type: ignore[misc]
+
+    def test_rdf_terms_preserve_exact_iri_and_language_kinds(self) -> None:
+        triples = metadata.ontology_metadata_rdf_triples(self.loaded, "integrated")
+        objects = tuple(value[2] for value in triples)
+        for index in (0, 1, 6):
+            self.assertIsInstance(objects[index], Literal)
+            self.assertEqual(objects[index].language, "en")
+            self.assertIsNone(objects[index].datatype)
+        for index in (2, 3, 4, 5):
+            self.assertIsInstance(objects[index], URIRef)
+
+    def test_exact_metadata_validation_accepts_each_product(self) -> None:
+        imports = {
+            "integrated": (
+                "http://www.w3.org/ns/ssn/",
+                "http://www.w3.org/ns/sosa/sampling/",
+                "http://www.w3.org/ns/ssn/systems/",
+                "https://www.commoncoreontologies.org/2024-11-06/CommonCoreOntologiesMerged",
+            ),
+            "alignment_core": (),
+            "strict_bfo_mapping": (
+                POLICY_PRODUCTS["alignment_core"]["stable_ontology_iri"],
+            ),
+            "bfo_projection": (
+                POLICY_PRODUCTS["strict_bfo_mapping"]["stable_ontology_iri"],
+            ),
+            "cco_extension": (
+                POLICY_PRODUCTS["strict_bfo_mapping"]["stable_ontology_iri"],
+            ),
+        }
+        for product_key, expected_imports in imports.items():
+            with self.subTest(product=product_key):
+                graph = self.graph_for(product_key, expected_imports)
+                self.assertEqual(
+                    metadata.validate_emitted_ontology_metadata(
+                        graph, self.loaded, product_key, expected_imports
+                    ),
+                    (),
+                )
+                self.assertEqual(
+                    len(
+                        metadata.strip_emitted_ontology_header(
+                            graph, self.loaded, product_key, expected_imports
+                        )
+                    ),
+                    0,
+                )
+
+    def test_validation_rejects_missing_extra_wrong_duplicate_and_misplaced_metadata(self) -> None:
+        product_key = "alignment_core"
+        product = next(value for value in self.loaded.products if value.key == product_key)
+        ontology = URIRef(product.stable_ontology_iri)
+        expected = metadata.ontology_metadata_rdf_triples(self.loaded, product_key)
+        mutations: dict[str, tuple[Graph, str]] = {}
+
+        missing = self.graph_for(product_key)
+        missing.remove(expected[0])
+        mutations["missing"] = (missing, "ONTOLOGY_METADATA_MISMATCH")
+
+        extra = self.graph_for(product_key)
+        extra.add((ontology, URIRef("https://example.org/unapproved"), Literal("extra")))
+        mutations["extra"] = (extra, "UNAPPROVED_ONTOLOGY_METADATA")
+
+        wrong = self.graph_for(product_key)
+        wrong.remove(expected[0])
+        wrong.add((ontology, RDFS.label, Literal("Wrong", lang="en")))
+        mutations["wrong"] = (wrong, "ONTOLOGY_METADATA_MISMATCH")
+
+        duplicate = self.graph_for(product_key)
+        duplicate.add((ontology, RDFS.label, Literal(product.label, lang="fr")))
+        mutations["duplicate"] = (duplicate, "ONTOLOGY_METADATA_MISMATCH")
+
+        misplaced = self.graph_for(product_key)
+        misplaced.add((URIRef("https://example.org/other"), RDFS.label, Literal("Other", lang="en")))
+        mutations["misplaced"] = (misplaced, "MISPLACED_ONTOLOGY_METADATA")
+
+        for name, (graph, expected_code) in mutations.items():
+            with self.subTest(case=name):
+                issues = metadata.validate_emitted_ontology_metadata(
+                    graph, self.loaded, product_key, ()
+                )
+                self.assertIn(expected_code, {issue.code for issue in issues})
+
+    def test_validation_rejects_malformed_term_kinds_languages_and_release_fields(self) -> None:
+        product_key = "alignment_core"
+        product = next(value for value in self.loaded.products if value.key == product_key)
+        ontology = URIRef(product.stable_ontology_iri)
+        expected = metadata.ontology_metadata_rdf_triples(self.loaded, product_key)
+        mutations: dict[str, tuple[Graph, str]] = {}
+
+        literal_for_iri = self.graph_for(product_key)
+        literal_for_iri.remove(expected[2])
+        literal_for_iri.add((ontology, expected[2][1], Literal(product.product_type_iri)))
+        mutations["literal_for_iri"] = (literal_for_iri, "ONTOLOGY_METADATA_MISMATCH")
+
+        iri_for_literal = self.graph_for(product_key)
+        iri_for_literal.remove(expected[0])
+        iri_for_literal.add((ontology, RDFS.label, URIRef("https://example.org/label")))
+        mutations["iri_for_literal"] = (iri_for_literal, "ONTOLOGY_METADATA_MISMATCH")
+
+        missing_language = self.graph_for(product_key)
+        missing_language.remove(expected[1])
+        missing_language.add((ontology, expected[1][1], Literal(product.description)))
+        mutations["missing_language"] = (missing_language, "ONTOLOGY_METADATA_MISMATCH")
+
+        release_only = self.graph_for(product_key)
+        release_only.add((ontology, OWL.versionIRI, URIRef("https://example.org/release")))
+        mutations["release_only"] = (release_only, "RELEASE_METADATA_IN_DEVELOPMENT")
+
+        controlled_declaration = self.graph_for(product_key)
+        controlled_declaration.add((URIRef(product.product_type_iri), RDF.type, OWL.Class))
+        mutations["controlled_declaration"] = (
+            controlled_declaration,
+            "CONTROLLED_IRI_DECLARATION",
+        )
+
+        for name, (graph, expected_code) in mutations.items():
+            with self.subTest(case=name):
+                issues = metadata.validate_emitted_ontology_metadata(
+                    graph, self.loaded, product_key, ()
+                )
+                self.assertIn(expected_code, {issue.code for issue in issues})
+
+    def test_graph_validator_rejects_complete_governed_negative_matrix(self) -> None:
+        product_key = "alignment_core"
+        product = next(value for value in self.loaded.products if value.key == product_key)
+        ontology = URIRef(product.stable_ontology_iri)
+        expected = metadata.ontology_metadata_rdf_triples(self.loaded, product_key)
+        cases: dict[str, tuple[Graph, str]] = {}
+
+        wrong_subject = self.graph_for(product_key)
+        wrong_subject.remove((ontology, RDF.type, OWL.Ontology))
+        wrong_subject.add((URIRef("https://example.org/wrong"), RDF.type, OWL.Ontology))
+        cases["wrong ontology subject"] = (wrong_subject, "ONTOLOGY_DECLARATION_MISMATCH")
+
+        missing_declaration = self.graph_for(product_key)
+        missing_declaration.remove((ontology, RDF.type, OWL.Ontology))
+        cases["missing ontology declaration"] = (
+            missing_declaration,
+            "ONTOLOGY_DECLARATION_MISMATCH",
+        )
+
+        wrong_values = (
+            ("status", 3, URIRef("https://example.org/status")),
+            ("license", 4, URIRef("https://example.org/license")),
+            ("repository", 5, URIRef("https://example.org/repository")),
+            ("warning", 6, Literal("Wrong generated warning", lang="en")),
+        )
+        for name, index, replacement in wrong_values:
+            graph = self.graph_for(product_key)
+            graph.remove(expected[index])
+            graph.add((ontology, expected[index][1], replacement))
+            cases[f"wrong {name} value"] = (graph, "ONTOLOGY_METADATA_MISMATCH")
+
+        for name, controlled_iri in (
+            ("authority status declaration", self.loaded.publication.development_status_iri),
+            ("product type declaration", product.product_type_iri),
+        ):
+            graph = self.graph_for(product_key)
+            graph.add((URIRef(controlled_iri), RDF.type, OWL.NamedIndividual))
+            cases[name] = (graph, "CONTROLLED_IRI_DECLARATION")
+
+        unapproved_values = (
+            ("local filesystem path", "sourcePath", "/tmp/generated.ttl"),
+            ("dependency path", "dependencyPath", "imports/cco.ttl"),
+            ("hash", "sha256", "0" * 64),
+            ("Git tag", "gitTag", "v2026-07-16"),
+            ("commit", "commit", "deadbeef"),
+            ("date", "date", "2026-07-16"),
+        )
+        for name, local_name, value in unapproved_values:
+            graph = self.graph_for(product_key)
+            graph.add((ontology, URIRef(f"https://example.org/{local_name}"), Literal(value)))
+            cases[name] = (graph, "UNAPPROVED_ONTOLOGY_METADATA")
+
+        release_values = (
+            ("dcterms issued", URIRef(metadata.DCTERMS_NAMESPACE + "issued"), Literal("2026-07-16")),
+            ("version IRI", OWL.versionIRI, URIRef("https://example.org/release")),
+            ("version info", OWL.versionInfo, Literal("v2026-07-16")),
+        )
+        for name, predicate, value in release_values:
+            graph = self.graph_for(product_key)
+            graph.add((ontology, predicate, value))
+            cases[name] = (graph, "RELEASE_METADATA_IN_DEVELOPMENT")
+
+        for name, (graph, expected_code) in cases.items():
+            with self.subTest(case=name):
+                issues = metadata.validate_emitted_ontology_metadata(
+                    graph, self.loaded, product_key, ()
+                )
+                self.assertIn(expected_code, {issue.code for issue in issues})
+
+    def test_canonical_serialized_header_is_shared_by_all_five_products(self) -> None:
+        for product in self.loaded.products:
+            with self.subTest(product=product.key):
+                imports, notice, prefixes, import_terms = self.serialization_parameters(product.key)
+                artifact = (REPO_ROOT / product.path).read_bytes()
+                expected = metadata.render_ontology_header_bytes(
+                    self.loaded,
+                    product.key,
+                    imports,
+                    generated_notice=notice,
+                    prefixes=prefixes,
+                    import_turtle_terms=import_terms,
+                )
+                self.assertTrue(artifact.startswith(expected))
+                self.assertEqual(self.serialized_issues(artifact, product.key), ())
+
+    def test_missing_final_newline_is_noncanonical_but_parseable(self) -> None:
+        artifact = (REPO_ROOT / "SSN2BFO.ttl").read_bytes()
+        self.assertTrue(artifact.endswith(b"\n"))
+        candidate = artifact[:-1]
+        self.assertTrue(
+            isomorphic(
+                Graph().parse(data=artifact.decode(), format="turtle"),
+                Graph().parse(data=candidate.decode(), format="turtle"),
+            )
+        )
+        self.assertIn(
+            "NONCANONICAL_ONTOLOGY_HEADER",
+            {issue.code for issue in self.serialized_issues(candidate, "integrated")},
+        )
+
+    def test_extra_header_logical_boundary_newline_is_noncanonical_but_parseable(self) -> None:
+        product_key = "integrated"
+        artifact = (REPO_ROOT / "SSN2BFO.ttl").read_bytes()
+        imports, notice, prefixes, import_terms = self.serialization_parameters(product_key)
+        header = metadata.render_ontology_header_bytes(
+            self.loaded,
+            product_key,
+            imports,
+            generated_notice=notice,
+            prefixes=prefixes,
+            import_turtle_terms=import_terms,
+        )
+        canonical_boundary = header + b"\n"
+        self.assertTrue(artifact.startswith(canonical_boundary))
+        candidate = header + b"\n\n" + artifact[len(canonical_boundary) :]
+        self.assertTrue(
+            isomorphic(
+                Graph().parse(data=artifact.decode(), format="turtle"),
+                Graph().parse(data=candidate.decode(), format="turtle"),
+            )
+        )
+        self.assertIn(
+            "NONCANONICAL_ONTOLOGY_HEADER",
+            {issue.code for issue in self.serialized_issues(candidate, product_key)},
+        )
+
+    def test_semantically_equivalent_reordered_headers_are_noncanonical(self) -> None:
+        for product in self.loaded.products:
+            with self.subTest(product=product.key):
+                artifact = (REPO_ROOT / product.path).read_bytes()
+                lines = artifact.splitlines()
+                label_index = next(
+                    index for index, line in enumerate(lines) if line.startswith(b"    rdfs:label ")
+                )
+                description_index = next(
+                    index
+                    for index, line in enumerate(lines)
+                    if line.startswith(b"    dcterms:description ")
+                )
+                lines[label_index], lines[description_index] = (
+                    lines[description_index],
+                    lines[label_index],
+                )
+                reordered = b"\n".join(lines) + b"\n"
+                self.assertTrue(
+                    isomorphic(
+                        Graph().parse(data=artifact.decode(), format="turtle"),
+                        Graph().parse(data=reordered.decode(), format="turtle"),
+                    )
+                )
+                self.assertIn(
+                    "NONCANONICAL_ONTOLOGY_HEADER",
+                    {issue.code for issue in self.serialized_issues(reordered, product.key)},
+                )
+
+    def test_other_header_order_import_prefix_and_literal_variants_are_rejected(self) -> None:
+        root = (REPO_ROOT / "SSN2BFO.ttl").read_bytes()
+        header_lines = (
+            b"    dcterms:description ",
+            b"    dcterms:type ",
+            b"    adms:status ",
+            b"    dcterms:license ",
+            b"    rdfs:seeAlso ",
+            b"    rdfs:comment ",
+        )
+        for prefix in header_lines:
+            with self.subTest(reordered_predicate=prefix.decode().strip()):
+                lines = root.splitlines()
+                index = next(i for i, line in enumerate(lines) if line.startswith(prefix))
+                lines[index - 1], lines[index] = lines[index], lines[index - 1]
+                candidate = b"\n".join(lines) + b"\n"
+                self.assertIn(
+                    "NONCANONICAL_ONTOLOGY_HEADER",
+                    {issue.code for issue in self.serialized_issues(candidate, "integrated")},
+                )
+
+        reordered_imports = root.replace(b"        ssn:,\n        ssn-system:,", b"        ssn-system:,\n        ssn:,")
+        self.assertIn(
+            "NONCANONICAL_ONTOLOGY_HEADER",
+            {issue.code for issue in self.serialized_issues(reordered_imports, "integrated")},
+        )
+
+        projection = (REPO_ROOT / POLICY_PRODUCTS["bfo_projection"]["path"]).read_bytes()
+        missing_prefix = projection.replace(
+            b"@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .\n",
+            b"",
+            1,
+        )
+        noncanonical_language = projection.replace(b'"@en', b'"@EN', 1)
+        label_line = next(
+            line for line in projection.splitlines() if line.startswith(b"    rdfs:label ")
+        )
+        literal_value = label_line.split(b"rdfs:label ", 1)[1].removesuffix(b" ;")
+        noncanonical_literal = projection.replace(
+            literal_value,
+            b'"""' + literal_value[1:-4] + b'"""@en',
+            1,
+        )
+        for name, candidate in (
+            ("missing canonical prefix", missing_prefix),
+            ("noncanonical language tag", noncanonical_language),
+            ("noncanonical literal", noncanonical_literal),
+        ):
+            with self.subTest(case=name):
+                self.assertIn(
+                    "NONCANONICAL_ONTOLOGY_HEADER",
+                    {issue.code for issue in self.serialized_issues(candidate, "bfo_projection")},
+                )
+
+        malformed = projection.replace(label_line, b'    rdfs:label "unterminated@en ;', 1)
+        self.assertIn(
+            "TURTLE_PARSE",
+            {issue.code for issue in self.serialized_issues(malformed, "bfo_projection")},
+        )
 
 
 class IdentitySafetyTests(MetadataTestCase):

--- a/tests/test_strict_bfo_mapping.py
+++ b/tests/test_strict_bfo_mapping.py
@@ -22,7 +22,12 @@ import generate_mapping_from_coms as coms  # noqa: E402
 import modular_products as modular  # noqa: E402
 from coms_row_identity import RowLocation  # noqa: E402
 from product_dispositions import ProductDisposition, load_disposition_document  # noqa: E402
-from publication_metadata import load_metadata  # noqa: E402
+from publication_metadata import (  # noqa: E402
+    load_metadata,
+    ontology_metadata_rdf_triples,
+    strip_emitted_ontology_header,
+    validate_emitted_ontology_metadata,
+)
 
 
 EXPECTED_ROW_IDS = frozenset(
@@ -289,7 +294,38 @@ class StrictBfoMappingTests(unittest.TestCase):
         self.assertEqual(set(graph.subjects(RDF.type, OWL.Ontology)), {ontology})
         self.assertEqual(set(graph.triples((None, OWL.imports, None))), {(ontology, OWL.imports, core)})
         self.assertEqual(self.strict_result.logical_triple_count, 125)
-        self.assertEqual(len(graph), 127)
+        self.assertEqual(self.strict_result.ontology_declaration_triple_count, 1)
+        self.assertEqual(self.strict_result.import_triple_count, 1)
+        self.assertEqual(self.strict_result.metadata_annotation_count, 7)
+        self.assertEqual(len(graph), 134)
+        self.assertEqual(
+            set(ontology_metadata_rdf_triples(self.metadata, "strict_bfo_mapping")),
+            set(graph.triples((ontology, None, None)))
+            - {
+                (ontology, RDF.type, OWL.Ontology),
+                (ontology, OWL.imports, core),
+            },
+        )
+        self.assertEqual(
+            validate_emitted_ontology_metadata(
+                graph,
+                self.metadata,
+                "strict_bfo_mapping",
+                (str(core),),
+            ),
+            (),
+        )
+        self.assertEqual(
+            len(
+                strip_emitted_ontology_header(
+                    graph,
+                    self.metadata,
+                    "strict_bfo_mapping",
+                    (str(core),),
+                )
+            ),
+            125,
+        )
         self.assertEqual(len(set(graph.subjects(OWL.unionOf, None))), 6)
         self.assertEqual(len(set(graph.subjects(OWL.intersectionOf, None))), 6)
         self.assertEqual(len(set(graph.subjects(OWL.someValuesFrom, None))), 6)
@@ -334,7 +370,19 @@ class StrictBfoMappingTests(unittest.TestCase):
         self.assertFalse(self.strict_result.serialized_bytes.endswith(b"\n\n"))
         self.assertEqual(
             hashlib.sha256(self.core_result.serialized_bytes).hexdigest(),
-            "95f71184b90224906b0ba703d0ea60fd2f8b993b3853b803c66b88b91ba0b01c",
+            "17695ef17379924449153b2c92ffaed6b57d497a1b2d1e854f584614cebec770",
+        )
+
+    def test_reordered_canonical_header_is_rejected_by_product_validator(self) -> None:
+        lines = self.strict_result.serialized_bytes.splitlines()
+        label = next(i for i, line in enumerate(lines) if line.startswith(b"    rdfs:label "))
+        description = next(
+            i for i, line in enumerate(lines) if line.startswith(b"    dcterms:description ")
+        )
+        lines[label], lines[description] = lines[description], lines[label]
+        self.assertIn(
+            "NONCANONICAL_ONTOLOGY_HEADER",
+            self.validate_bytes(b"\n".join(lines) + b"\n"),
         )
 
     def test_processed_row_and_audit_order_do_not_affect_strict_bfo_output(self) -> None:
@@ -373,7 +421,7 @@ class StrictBfoMappingTests(unittest.TestCase):
         self.assertEqual(reordered_bytes, baseline_bytes)
         self.assertEqual(
             hashlib.sha256(reordered_bytes).hexdigest(),
-            "15f080145c6803d174a00cf9e13c971925b40485049744dba6e0847093016ea7",
+            "676b31620df10db5c26c46bcc44b2dfd5939d606b16e0fa8a910926e8497c3af",
         )
 
     def test_fresh_process_generation_is_byte_deterministic(self) -> None:
@@ -424,10 +472,10 @@ class StrictBfoMappingTests(unittest.TestCase):
         self.assertEqual(len(strict_ids | core_ids), 48)
         graph = Graph().parse(data=self.strict_result.serialized_bytes.decode(), format="turtle")
         graph.parse(data=self.core_result.serialized_bytes.decode(), format="turtle")
-        self.assertEqual(len(graph), 181)
+        self.assertEqual(len(graph), 195)
         for triple in list(graph.triples((None, OWL.imports, None))):
             graph.remove(triple)
-        self.assertEqual(len(graph), 180)
+        self.assertEqual(len(graph), 194)
 
     def test_fixed_pinned_merged_cco_bfo_closure(self) -> None:
         dependencies = (
@@ -443,7 +491,7 @@ class StrictBfoMappingTests(unittest.TestCase):
             dependencies,
             coms.CLEANUP_TRIPLES,
         )
-        self.assertEqual(len(closure), 14972)
+        self.assertEqual(len(closure), 14986)
         self.assertFalse(any(True for _ in closure.triples((None, OWL.imports, None))))
         bfo_iris = {
             iri
@@ -470,7 +518,7 @@ class StrictBfoMappingTests(unittest.TestCase):
         self.assertTrue(result.passed, result.robot_output)
         self.assertEqual(result.return_code, 0)
         self.assertTrue(result.reasoned_output_produced)
-        self.assertEqual(result.closure_triple_count, 14972)
+        self.assertEqual(result.closure_triple_count, 14986)
         self.assertEqual(result.unsat_classes, [])
 
 

--- a/tools/check_coms_mapping.py
+++ b/tools/check_coms_mapping.py
@@ -28,7 +28,28 @@ from product_dispositions import (
     load_disposition_document,
     serialize_disposition_document,
 )
-from publication_metadata import PublicationMetadataError, load_metadata
+from generate_mapping_from_coms import (
+    GENERATED_NOTICE as ROOT_GENERATED_NOTICE,
+    ROOT_IMPORT_TURTLE_TERMS,
+    ROOT_ORDERED_IMPORTS,
+    ROOT_PREFIXES,
+)
+from modular_products import (
+    ALIGNMENT_CORE_IMPORT_IRI,
+    BFO_PROJECTION_PREFIXES,
+    CCO_EXTENSION_PREFIXES,
+    GENERATED_NOTICE as MODULAR_GENERATED_NOTICE,
+    PREFIXES as ALIGNMENT_CORE_PREFIXES,
+    STRICT_BFO_IMPORT_IRI,
+    STRICT_BFO_PREFIXES,
+)
+from publication_metadata import (
+    PublicationMetadataError,
+    load_metadata,
+    strip_emitted_ontology_header,
+    validate_emitted_ontology_metadata,
+    validate_serialized_ontology_header,
+)
 
 try:
     import openpyxl
@@ -64,6 +85,49 @@ MAINTAINED_OUTPUTS = {
     "bfo_projection": REPO_ROOT / "releases/current-ssn-sosa/ssn-sosa-bfo-projection.ttl",
     "cco_extension": REPO_ROOT / "releases/current-ssn-sosa/ssn-sosa-cco-extension.ttl",
 }
+
+SERIALIZED_HEADER_PRODUCTS = (
+    (
+        "candidate",
+        "integrated",
+        ROOT_ORDERED_IMPORTS,
+        ROOT_GENERATED_NOTICE,
+        ROOT_PREFIXES,
+        ROOT_IMPORT_TURTLE_TERMS,
+    ),
+    (
+        "alignment_core",
+        "alignment_core",
+        (),
+        MODULAR_GENERATED_NOTICE,
+        ALIGNMENT_CORE_PREFIXES,
+        None,
+    ),
+    (
+        "strict_bfo_mapping",
+        "strict_bfo_mapping",
+        (ALIGNMENT_CORE_IMPORT_IRI,),
+        MODULAR_GENERATED_NOTICE,
+        STRICT_BFO_PREFIXES,
+        None,
+    ),
+    (
+        "bfo_projection",
+        "bfo_projection",
+        (STRICT_BFO_IMPORT_IRI,),
+        MODULAR_GENERATED_NOTICE,
+        BFO_PROJECTION_PREFIXES,
+        None,
+    ),
+    (
+        "cco_extension",
+        "cco_extension",
+        (STRICT_BFO_IMPORT_IRI,),
+        MODULAR_GENERATED_NOTICE,
+        CCO_EXTENSION_PREFIXES,
+        None,
+    ),
+)
 
 METADATA_LABELS = {
     "workbook SHA-256": "workbook_sha256",
@@ -113,6 +177,62 @@ def sha256_file(path: Path) -> str:
 def emit(message: str, log: list[str]) -> None:
     print(message, flush=True)
     log.append(message)
+
+
+def validate_product_metadata(
+    graph: Graph,
+    publication_metadata: object,
+    product_key: str,
+    expected_imports: tuple[str, ...],
+) -> None:
+    issues = validate_emitted_ontology_metadata(
+        graph,
+        publication_metadata,
+        product_key,
+        expected_imports,
+    )
+    if issues:
+        raise CheckFailure(
+            f"{product_key} publication metadata validation failed: "
+            + " | ".join(
+                f"ERROR [{issue.code}] {issue.field}: {issue.message}"
+                for issue in issues
+            )
+        )
+
+
+def validate_candidate_serialized_headers(
+    paths: dict[str, Path],
+    publication_metadata: object,
+) -> None:
+    issues = []
+    for (
+        output_name,
+        product_key,
+        expected_imports,
+        generated_notice,
+        prefixes,
+        import_turtle_terms,
+    ) in SERIALIZED_HEADER_PRODUCTS:
+        issues.extend(
+            validate_serialized_ontology_header(
+                paths[output_name].read_bytes(),
+                publication_metadata,
+                product_key,
+                expected_imports,
+                generated_notice=generated_notice,
+                prefixes=prefixes,
+                import_turtle_terms=import_turtle_terms,
+            )
+        )
+    if issues:
+        raise CheckFailure(
+            "serialized ontology header validation failed: "
+            + " | ".join(
+                f"ERROR [{issue.code}] {issue.field}: {issue.message}"
+                for issue in issues
+            )
+        )
 
 
 def verify_workbook(log: list[str]) -> str:
@@ -278,6 +398,7 @@ def validate_temporary_outputs(
         raise CheckFailure(f"product-disposition validation failed: {exc}") from exc
     if paths["disposition_report"].read_bytes() != serialize_disposition_document(disposition):
         raise CheckFailure("product-disposition JSON is not canonically serialized")
+    validate_candidate_serialized_headers(paths, publication_metadata)
     expected_disposition_hashes = {
         "workbook_sha256": workbook_hash,
         "generator_sha256": generator_hash,
@@ -322,8 +443,10 @@ def validate_temporary_outputs(
         "stable_ontology_iri": alignment_metadata.stable_ontology_iri,
         "governed_axiom_count": 29,
         "logical_triple_count": 53,
-        "ontology_header_triple_count": 1,
-        "total_triple_count": 54,
+        "ontology_declaration_triple_count": 1,
+        "import_triple_count": 0,
+        "metadata_annotation_count": 7,
+        "total_triple_count": 61,
         "domain_axiom_count": 15,
         "range_axiom_count": 14,
         "named_target_count": 26,
@@ -349,15 +472,18 @@ def validate_temporary_outputs(
         raise CheckFailure(
             f"alignment-core parse failed: {type(exc).__name__}: {exc}"
         ) from exc
-    ontology_iri = URIRef(alignment_metadata.stable_ontology_iri)
-    if set(alignment_graph.subjects(RDF.type, OWL.Ontology)) != {ontology_iri}:
-        raise CheckFailure("alignment core has an incorrect ontology declaration")
-    if any(True for _ in alignment_graph.triples((None, OWL.imports, None))):
-        raise CheckFailure("alignment core must not contain owl:imports")
-    if len(alignment_graph) != 54:
-        raise CheckFailure(f"alignment-core parsed triple count is {len(alignment_graph)}, expected 54")
+    validate_product_metadata(alignment_graph, publication_metadata, "alignment_core", ())
+    alignment_logical = strip_emitted_ontology_header(
+        alignment_graph, publication_metadata, "alignment_core", ()
+    )
+    if len(alignment_logical) != 53 or len(alignment_graph) != 61:
+        raise CheckFailure(
+            "alignment-core triple partition mismatch: expected 1 declaration, "
+            f"0 imports, 7 metadata, 53 logical, 61 total; got {len(alignment_graph)} total"
+        )
     emit(
-        "Alignment core: PASS (29 governed axioms; 53 logical triples; 54 total triples)",
+        "Alignment core: PASS (1 declaration; 0 imports; 7 metadata; "
+        "29 governed axioms; 53 logical triples; 61 total triples)",
         log,
     )
 
@@ -376,9 +502,10 @@ def validate_temporary_outputs(
         "stable_ontology_iri": strict_metadata.stable_ontology_iri,
         "governed_axiom_count": 19,
         "logical_triple_count": 125,
-        "ontology_header_triple_count": 2,
+        "ontology_declaration_triple_count": 1,
         "import_triple_count": 1,
-        "total_triple_count": 127,
+        "metadata_annotation_count": 7,
+        "total_triple_count": 134,
         "subclass_axiom_count": 3,
         "equivalent_class_axiom_count": 3,
         "direct_subproperty_axiom_count": 9,
@@ -390,11 +517,11 @@ def validate_temporary_outputs(
         "existential_restriction_count": 6,
         "rdf_list_count": 14,
         "project_closure_governed_axiom_count": 48,
-        "project_graph_triple_count": 181,
-        "local_project_graph_triple_count": 180,
+        "project_graph_triple_count": 195,
+        "local_project_graph_triple_count": 194,
         "hermit_return_code": 0,
         "hermit_result": "PASS",
-        "closure_triple_count": 14972,
+        "closure_triple_count": 14986,
         "named_unsat_count": 0,
     }
     for field, expected in expected_strict.items():
@@ -413,20 +540,28 @@ def validate_temporary_outputs(
             f"strict-BFO parse failed: {type(exc).__name__}: {exc}"
         ) from exc
     strict_ontology_iri = URIRef(strict_metadata.stable_ontology_iri)
-    if set(strict_graph.subjects(RDF.type, OWL.Ontology)) != {strict_ontology_iri}:
-        raise CheckFailure("strict BFO mapping has an incorrect ontology declaration")
     expected_import = URIRef(alignment_metadata.stable_ontology_iri)
-    if set(strict_graph.triples((None, OWL.imports, None))) != {
-        (strict_ontology_iri, OWL.imports, expected_import)
-    }:
-        raise CheckFailure("strict BFO mapping must import only the alignment core")
-    if len(strict_graph) != 127:
+    validate_product_metadata(
+        strict_graph,
+        publication_metadata,
+        "strict_bfo_mapping",
+        (str(expected_import),),
+    )
+    strict_logical = strip_emitted_ontology_header(
+        strict_graph,
+        publication_metadata,
+        "strict_bfo_mapping",
+        (str(expected_import),),
+    )
+    if len(strict_logical) != 125 or len(strict_graph) != 134:
         raise CheckFailure(
-            f"strict-BFO parsed triple count is {len(strict_graph)}, expected 127"
+            "strict-BFO triple partition mismatch: expected 1 declaration, 1 import, "
+            f"7 metadata, 125 logical, 134 total; got {len(strict_graph)} total"
         )
     emit(
         "Strict BFO mapping: PASS "
-        "(19 direct governed axioms; 125 logical triples; 127 total triples)",
+        "(1 declaration; 1 import; 7 metadata; 19 direct governed axioms; "
+        "125 logical triples; 134 total triples)",
         log,
     )
 
@@ -447,16 +582,17 @@ def validate_temporary_outputs(
         "logical_triple_count": 0,
         "ontology_declaration_triple_count": 1,
         "import_triple_count": 1,
-        "total_triple_count": 2,
+        "metadata_annotation_count": 7,
+        "total_triple_count": 9,
         "provided_transitively_count": 29,
         "provided_through_import_count": 19,
         "deferred_no_transformation_rule_count": 57,
         "project_closure_governed_axiom_count": 48,
-        "project_graph_triple_count": 183,
-        "local_project_graph_triple_count": 181,
+        "project_graph_triple_count": 204,
+        "local_project_graph_triple_count": 202,
         "reasoning_reused_from": "strict_bfo_mapping",
         "reasoning_source_sha256": strict_hash,
-        "reasoning_closure_triple_count": 14972,
+        "reasoning_closure_triple_count": 14986,
         "reasoning_return_code": 0,
         "reasoned_output_produced": True,
         "named_unsat_count": 0,
@@ -478,21 +614,27 @@ def validate_temporary_outputs(
             f"BFO-projection parse failed: {type(exc).__name__}: {exc}"
         ) from exc
     projection_ontology_iri = URIRef(projection_metadata.stable_ontology_iri)
-    if set(projection_graph.subjects(RDF.type, OWL.Ontology)) != {
-        projection_ontology_iri
-    }:
-        raise CheckFailure("BFO projection has an incorrect ontology declaration")
-    if set(projection_graph.triples((None, OWL.imports, None))) != {
-        (projection_ontology_iri, OWL.imports, strict_ontology_iri)
-    }:
-        raise CheckFailure("BFO projection must import only the strict BFO mapping")
-    if len(projection_graph) != 2:
+    validate_product_metadata(
+        projection_graph,
+        publication_metadata,
+        "bfo_projection",
+        (str(strict_ontology_iri),),
+    )
+    projection_logical = strip_emitted_ontology_header(
+        projection_graph,
+        publication_metadata,
+        "bfo_projection",
+        (str(strict_ontology_iri),),
+    )
+    if len(projection_logical) != 0 or len(projection_graph) != 9:
         raise CheckFailure(
-            f"BFO-projection parsed triple count is {len(projection_graph)}, expected 2"
+            "BFO-projection triple partition mismatch: expected 1 declaration, "
+            f"1 import, 7 metadata, 0 logical, 9 total; got {len(projection_graph)} total"
         )
     emit(
         "BFO projection: PASS "
-        "(0 direct governed axioms; 0 logical triples; 2 total triples; "
+        "(1 declaration; 1 import; 7 metadata; 0 direct governed axioms; "
+        "0 logical triples; 9 total triples; "
         "strict reasoning reused)",
         log,
     )
@@ -514,9 +656,10 @@ def validate_temporary_outputs(
         "cco_bearing_axiom_count": 25,
         "mixed_bfo_cco_axiom_count": 32,
         "logical_triple_count": 934,
-        "ontology_header_triple_count": 2,
+        "ontology_declaration_triple_count": 1,
         "import_triple_count": 1,
-        "total_triple_count": 936,
+        "metadata_annotation_count": 7,
+        "total_triple_count": 943,
         "subclass_axiom_count": 31,
         "equivalent_class_axiom_count": 7,
         "direct_subproperty_axiom_count": 16,
@@ -526,11 +669,11 @@ def validate_temporary_outputs(
         "existential_restriction_count": 95,
         "rdf_list_count": 96,
         "project_closure_governed_axiom_count": 105,
-        "project_graph_triple_count": 1117,
-        "local_project_graph_triple_count": 1115,
+        "project_graph_triple_count": 1138,
+        "local_project_graph_triple_count": 1136,
         "hermit_return_code": 0,
         "hermit_result": "PASS",
-        "closure_triple_count": 15907,
+        "closure_triple_count": 15928,
         "named_unsat_count": 0,
     }
     for field, expected in expected_cco.items():
@@ -549,20 +692,28 @@ def validate_temporary_outputs(
             f"CCO-extension parse failed: {type(exc).__name__}: {exc}"
         ) from exc
     cco_ontology_iri = URIRef(cco_metadata.stable_ontology_iri)
-    if set(cco_graph.subjects(RDF.type, OWL.Ontology)) != {cco_ontology_iri}:
-        raise CheckFailure("CCO extension has an incorrect ontology declaration")
     expected_cco_import = URIRef(strict_metadata.stable_ontology_iri)
-    if set(cco_graph.triples((None, OWL.imports, None))) != {
-        (cco_ontology_iri, OWL.imports, expected_cco_import)
-    }:
-        raise CheckFailure("CCO extension must import only the strict BFO mapping")
-    if len(cco_graph) != 936:
+    validate_product_metadata(
+        cco_graph,
+        publication_metadata,
+        "cco_extension",
+        (str(expected_cco_import),),
+    )
+    cco_logical = strip_emitted_ontology_header(
+        cco_graph,
+        publication_metadata,
+        "cco_extension",
+        (str(expected_cco_import),),
+    )
+    if len(cco_logical) != 934 or len(cco_graph) != 943:
         raise CheckFailure(
-            f"CCO-extension parsed triple count is {len(cco_graph)}, expected 936"
+            "CCO-extension triple partition mismatch: expected 1 declaration, "
+            f"1 import, 7 metadata, 934 logical, 943 total; got {len(cco_graph)} total"
         )
     emit(
         "CCO extension: PASS "
-        "(57 direct governed axioms; 934 logical triples; 936 total triples)",
+        "(1 declaration; 1 import; 7 metadata; 57 direct governed axioms; "
+        "934 logical triples; 943 total triples)",
         log,
     )
 
@@ -593,10 +744,43 @@ def validate_temporary_outputs(
         raise CheckFailure(
             f"generated triple-count mismatch: parsed {len(graph)}, summary recorded {expected_triples}"
         )
+    root_partition = {
+        "generated_candidate_ontology_declaration_triple_count": 1,
+        "generated_candidate_import_triple_count": 4,
+        "generated_candidate_metadata_annotation_count": 7,
+        "generated_candidate_logical_triple_count": 1112,
+    }
+    for field, expected in root_partition.items():
+        if summary.get(field) != expected:
+            raise CheckFailure(
+                f"integrated-root summary mismatch for {field}: expected {expected}, "
+                f"got {summary.get(field)!r}"
+            )
+    validate_product_metadata(
+        graph,
+        publication_metadata,
+        "integrated",
+        ROOT_ORDERED_IMPORTS,
+    )
+    root_logical = strip_emitted_ontology_header(
+        graph,
+        publication_metadata,
+        "integrated",
+        ROOT_ORDERED_IMPORTS,
+    )
+    if len(root_logical) != 1112 or len(graph) != 1124:
+        raise CheckFailure(
+            "integrated-root triple partition mismatch: expected 1 declaration, "
+            f"4 imports, 7 metadata, 1112 logical, 1124 total; got {len(graph)} total"
+        )
     candidate_hash = sha256_file(paths["candidate"])
     if summary.get("generated_candidate_sha256") != candidate_hash:
         raise CheckFailure("generated candidate hash does not match generator summary")
-    emit(f"Generated candidate parse: PASS ({len(graph)} triples)", log)
+    emit(
+        "Generated candidate parse: PASS "
+        f"(1 declaration; 4 imports; 7 metadata; 1112 logical; {len(graph)} total)",
+        log,
+    )
 
     emit("[7-9/11] Confirming candidate closure cleanup and HermiT result", log)
     if summary.get("hermit_return_code") != 0 or summary.get("hermit_result") != "PASS":
@@ -608,6 +792,11 @@ def validate_temporary_outputs(
         raise CheckFailure(f"candidate closure has owl:Nothing count {summary.get('owl_nothing_count')}")
     if summary.get("named_unsat_count") != 0 or summary.get("named_unsat_set"):
         raise CheckFailure(f"candidate closure has named unsatisfiable classes: {summary.get('named_unsat_set')}")
+    if summary.get("candidate_closure_triple_count") != 15912:
+        raise CheckFailure(
+            "candidate closure triple-count mismatch: expected 15912, got "
+            f"{summary.get('candidate_closure_triple_count')!r}"
+        )
     emit(
         "Candidate HermiT: PASS "
         f"({summary.get('candidate_closure_triple_count')} closure triples; no named unsats)",
@@ -868,6 +1057,18 @@ def record_success(summary: dict[str, object], workbook_hash: str, generator_has
         "cco_extension": summary.get("cco_extension"),
         "timestamp": utc_now(),
         "generated_ontology_triple_count": summary.get("generated_ontology_triple_count"),
+        "generated_candidate_ontology_declaration_triple_count": summary.get(
+            "generated_candidate_ontology_declaration_triple_count"
+        ),
+        "generated_candidate_import_triple_count": summary.get(
+            "generated_candidate_import_triple_count"
+        ),
+        "generated_candidate_metadata_annotation_count": summary.get(
+            "generated_candidate_metadata_annotation_count"
+        ),
+        "generated_candidate_logical_triple_count": summary.get(
+            "generated_candidate_logical_triple_count"
+        ),
         "candidate_closure_triple_count": summary.get("candidate_closure_triple_count"),
         "hermit_result": summary.get("hermit_result"),
         "source_term_counts": {

--- a/tools/generate_mapping_from_coms.py
+++ b/tools/generate_mapping_from_coms.py
@@ -54,6 +54,7 @@ from modular_products import (
     build_fixed_validation_closure,
     build_strict_bfo_mapping,
     reconcile_product_axioms,
+    render_authoritative_axiom_lines,
     select_product_axioms,
     serialize_modular_product,
     validate_alignment_core,
@@ -61,7 +62,15 @@ from modular_products import (
     validate_cco_extension,
     validate_strict_bfo_mapping,
 )
-from publication_metadata import PublicationMetadataError, load_metadata
+from publication_metadata import (
+    METADATA_PREFIXES,
+    PublicationMetadata,
+    PublicationMetadataError,
+    render_ontology_header_bytes,
+    strip_emitted_ontology_header,
+    load_metadata,
+    validate_serialized_ontology_header,
+)
 
 try:
     import openpyxl
@@ -71,6 +80,7 @@ except ModuleNotFoundError as exc:  # pragma: no cover - runtime dependency guar
 try:
     from rdflib import BNode, Graph, Literal, Namespace, RDF, RDFS, OWL, URIRef
     from rdflib.collection import Collection
+    from rdflib.compare import isomorphic
     from rdflib.namespace import XSD
 except ModuleNotFoundError as exc:  # pragma: no cover - runtime dependency guard
     raise SystemExit("Missing dependency: rdflib is required to generate and validate RDF.") from exc
@@ -123,6 +133,12 @@ PREFIXES = {
     "ssn": str(SSN),
     "ssn-system": str(SSN_SYSTEM),
 }
+ROOT_ONTOLOGY_DECLARATION_COUNT = 1
+ROOT_IMPORT_COUNT = 4
+ROOT_METADATA_ANNOTATION_COUNT = 7
+ROOT_LOGICAL_TRIPLE_COUNT = 1112
+ROOT_TOTAL_TRIPLE_COUNT = 1124
+ROOT_FIXED_CLOSURE_TRIPLE_COUNT = 15912
 
 PREFIX_FILES = {
     "bfo": Path("imports/cco.ttl"),
@@ -964,14 +980,23 @@ def build_and_write_disposition_report(
     processed_rows: list[ProcessedRow],
     path: Path,
     input_hashes: RequiredInputHashes,
+    publication_metadata: PublicationMetadata,
 ) -> tuple[DispositionDocument, list[DispositionRowInput]]:
     try:
-        metadata = load_metadata(PUBLICATION_METADATA)
         row_inputs = [disposition_input_for_processed_row(item) for item in processed_rows]
-        document = build_disposition_document(row_inputs, metadata, input_hashes)
+        document = build_disposition_document(
+            row_inputs,
+            publication_metadata,
+            input_hashes,
+        )
         path.parent.mkdir(parents=True, exist_ok=True)
         path.write_bytes(serialize_disposition_document(document))
-        loaded, issues = validate_disposition_file(path, row_inputs, metadata, input_hashes)
+        loaded, issues = validate_disposition_file(
+            path,
+            row_inputs,
+            publication_metadata,
+            input_hashes,
+        )
     except (ProductDispositionError, PublicationMetadataError) as exc:
         raise GenerationError(str(exc)) from exc
     if issues:
@@ -1171,7 +1196,86 @@ def expr_to_rdf(graph: Graph, expr: Expr) -> URIRef | BNode:
     raise GenerationError(f"unsupported expression node {expr.kind!r}")
 
 
-def generate_ontology(processed_rows: list[ProcessedRow], output_path: Path) -> Graph:
+ROOT_PREFIX_ORDER = (
+    "bfo",
+    "cco",
+    "owl",
+    "rdf",
+    "rdfs",
+    "sampling",
+    "sosa",
+    "ssn",
+    "ssn-system",
+)
+ROOT_PREFIXES = (
+    *METADATA_PREFIXES,
+    *((prefix, PREFIXES[prefix]) for prefix in ROOT_PREFIX_ORDER),
+)
+ROOT_ORDERED_IMPORTS = tuple(sorted((str(value) for value in DIRECT_IMPORTS)))
+ROOT_IMPORT_TURTLE_TERMS = (
+    "sampling:",
+    "ssn:",
+    "ssn-system:",
+    "<https://www.commoncoreontologies.org/2024-11-06/CommonCoreOntologiesMerged>",
+)
+
+
+def _root_turtle_bytes(
+    processed_rows: Iterable[ProcessedRow],
+    publication_metadata: PublicationMetadata,
+) -> bytes:
+    """Render maintained root bytes solely from governed structured inputs."""
+
+    rendered_axioms: list[tuple[tuple[str, str, str], tuple[str, ...]]] = []
+    for item in processed_rows:
+        if not item.predicate:
+            continue
+        audit = item.identity_audit
+        if audit is None or len(audit.authoritative_axioms) != 1:
+            raise GenerationError(
+                f"{item.row.diagnostic_id}: deterministic root rendering requires "
+                "exactly one audited authoritative axiom"
+            )
+        canonical_input = canonical_input_for_processed_row(item)
+        axiom_id = f"sha256:{audit.authoritative_axioms[0].sha256}"
+        try:
+            lines = render_authoritative_axiom_lines(canonical_input, axiom_id)
+        except ModularProductError as exc:
+            raise GenerationError(f"deterministic root rendering failed: {exc}") from exc
+        rendered_axioms.append(
+            (
+                (
+                    canonical_input.subject_iri,
+                    canonical_input.predicate_iri or "",
+                    axiom_id,
+                ),
+                lines,
+            )
+        )
+
+    header = render_ontology_header_bytes(
+        publication_metadata,
+        "integrated",
+        ROOT_ORDERED_IMPORTS,
+        generated_notice=GENERATED_NOTICE,
+        prefixes=ROOT_PREFIXES,
+        import_turtle_terms=ROOT_IMPORT_TURTLE_TERMS,
+    )
+    output = bytearray(header.rstrip(b"\n"))
+    for _, lines in sorted(rendered_axioms, key=lambda value: value[0]):
+        output.extend(b"\n\n")
+        output.extend("\n".join(lines).encode("utf-8"))
+    output.extend(b"\n")
+    return bytes(output)
+
+
+def generate_ontology(
+    processed_rows: list[ProcessedRow],
+    output_path: Path,
+    publication_metadata: PublicationMetadata,
+    *,
+    require_current_counts: bool = False,
+) -> Graph:
     graph = Graph()
     bind_prefixes(graph)
     graph.add((ONTOLOGY_IRI, RDF.type, OWL.Ontology))
@@ -1193,10 +1297,57 @@ def generate_ontology(processed_rows: list[ProcessedRow], output_path: Path) -> 
         else:
             raise GenerationError(f"{item.row.diagnostic_id}: processed row has no target")
 
+    logical_before_metadata = Graph()
+    header_triples = {
+        (ONTOLOGY_IRI, RDF.type, OWL.Ontology),
+        *((ONTOLOGY_IRI, OWL.imports, value) for value in DIRECT_IMPORTS),
+    }
+    for triple in graph:
+        if triple not in header_triples:
+            logical_before_metadata.add(triple)
+
+    serialized = _root_turtle_bytes(processed_rows, publication_metadata)
+    parsed = Graph().parse(data=serialized.decode("utf-8"), format="turtle")
+    expected_imports = ROOT_ORDERED_IMPORTS
+    metadata_issues = validate_serialized_ontology_header(
+        serialized,
+        publication_metadata,
+        "integrated",
+        expected_imports,
+        generated_notice=GENERATED_NOTICE,
+        prefixes=ROOT_PREFIXES,
+        import_turtle_terms=ROOT_IMPORT_TURTLE_TERMS,
+    )
+    if metadata_issues:
+        raise GenerationError(
+            "integrated-root metadata validation failed: "
+            + " | ".join(
+                f"ERROR [{value.code}] {value.field}: {value.message}"
+                for value in metadata_issues
+            )
+        )
+    logical_after_metadata = strip_emitted_ontology_header(
+        parsed,
+        publication_metadata,
+        "integrated",
+        expected_imports,
+    )
+    if require_current_counts and len(logical_after_metadata) != ROOT_LOGICAL_TRIPLE_COUNT:
+        raise GenerationError(
+            "integrated-root logical triple count mismatch: "
+            f"expected {ROOT_LOGICAL_TRIPLE_COUNT}, got {len(logical_after_metadata)}"
+        )
+    if not isomorphic(logical_before_metadata, logical_after_metadata):
+        raise GenerationError("integrated-root logical graph changed during metadata emission")
+    if require_current_counts and len(parsed) != ROOT_TOTAL_TRIPLE_COUNT:
+        raise GenerationError(
+            f"integrated-root total triple count mismatch: expected {ROOT_TOTAL_TRIPLE_COUNT}, "
+            f"got {len(parsed)}"
+        )
+
     output_path.parent.mkdir(parents=True, exist_ok=True)
-    turtle = graph.serialize(format="turtle").rstrip() + "\n"
-    output_path.write_text(f"{GENERATED_NOTICE}\n\n{turtle}", encoding="utf-8")
-    return graph
+    output_path.write_bytes(serialized)
+    return parsed
 
 
 def normalized_axiom_rows(processed_rows: list[ProcessedRow], graph: Graph) -> list[NormalizedRow]:
@@ -1575,6 +1726,7 @@ def build_and_write_alignment_core(
     processed_rows: list[ProcessedRow],
     identity_audits: list[CanonicalRowAudit],
     disposition_document: DispositionDocument,
+    publication_metadata: PublicationMetadata,
     integrated_graph: Graph,
     output_path: Path,
     tmp_dir: Path,
@@ -1582,7 +1734,6 @@ def build_and_write_alignment_core(
     """Build and fully validate the candidate alignment-core development artifact."""
 
     try:
-        metadata = load_metadata(PUBLICATION_METADATA)
         canonical_rows = [canonical_input_for_processed_row(item) for item in processed_rows]
         selected = select_product_axioms(
             "alignment_core",
@@ -1590,7 +1741,7 @@ def build_and_write_alignment_core(
             identity_audits,
             disposition_document,
         )
-        result = build_alignment_core(selected, metadata)
+        result = build_alignment_core(selected, publication_metadata)
         closure = build_fixed_source_closure(
             result.serialized_bytes,
             (REPO_ROOT / path for path in SOURCE_IMPORTS),
@@ -1598,7 +1749,7 @@ def build_and_write_alignment_core(
         structural_issues = validate_alignment_core(
             result.serialized_bytes,
             selected,
-            metadata,
+            publication_metadata,
             fixed_source_closure=closure,
             integrated_graph=integrated_graph,
         )
@@ -1620,6 +1771,7 @@ def build_and_write_strict_bfo_mapping(
     processed_rows: list[ProcessedRow],
     identity_audits: list[CanonicalRowAudit],
     disposition_document: DispositionDocument,
+    publication_metadata: PublicationMetadata,
     integrated_graph: Graph,
     alignment_core_result: ModularProductResult,
     alignment_core_path: Path,
@@ -1629,7 +1781,6 @@ def build_and_write_strict_bfo_mapping(
     """Build and validate the strict BFO development artifact and fixed closure."""
 
     try:
-        metadata = load_metadata(PUBLICATION_METADATA)
         canonical_rows = [canonical_input_for_processed_row(item) for item in processed_rows]
         selected = select_product_axioms(
             "strict_bfo_mapping",
@@ -1642,7 +1793,7 @@ def build_and_write_strict_bfo_mapping(
             for row in alignment_core_result.selected_rows
             for axiom in row.axioms
         )
-        result = build_strict_bfo_mapping(selected, metadata)
+        result = build_strict_bfo_mapping(selected, publication_metadata)
         fixed_closure = build_fixed_validation_closure(
             (result.serialized_bytes, alignment_core_result.serialized_bytes),
             (
@@ -1656,7 +1807,7 @@ def build_and_write_strict_bfo_mapping(
             selected,
             alignment_core_result.serialized_bytes,
             alignment_selected,
-            metadata,
+            publication_metadata,
             integrated_graph=integrated_graph,
             fixed_semantic_closure=fixed_closure,
         )
@@ -1680,6 +1831,7 @@ def build_and_write_bfo_projection(
     processed_rows: list[ProcessedRow],
     identity_audits: list[CanonicalRowAudit],
     disposition_document: DispositionDocument,
+    publication_metadata: PublicationMetadata,
     integrated_graph: Graph,
     alignment_core_result: ModularProductResult,
     strict_bfo_result: ModularProductResult,
@@ -1693,7 +1845,6 @@ def build_and_write_bfo_projection(
     """Build the import-only projection after exact disposition reconciliation."""
 
     try:
-        metadata = load_metadata(PUBLICATION_METADATA)
         canonical_rows = [canonical_input_for_processed_row(item) for item in processed_rows]
         reconciliation = reconcile_product_axioms(
             BFO_PROJECTION_KEY,
@@ -1720,7 +1871,10 @@ def build_and_write_bfo_projection(
             owl_nothing_count=strict_bfo_hermit.owl_nothing_count,
             named_unsatisfiable_count=len(strict_bfo_hermit.unsat_classes),
         )
-        result = build_bfo_projection(reconciliation.selected_axioms, metadata)
+        result = build_bfo_projection(
+            reconciliation.selected_axioms,
+            publication_metadata,
+        )
         structural_issues = validate_bfo_projection(
             result.serialized_bytes,
             reconciliation,
@@ -1728,7 +1882,7 @@ def build_and_write_bfo_projection(
             strict_selected,
             alignment_core_result.serialized_bytes,
             alignment_selected,
-            metadata,
+            publication_metadata,
             integrated_graph=integrated_graph,
             strict_reasoning_result=reasoning_result,
         )
@@ -1746,6 +1900,7 @@ def build_and_write_cco_extension(
     processed_rows: list[ProcessedRow],
     identity_audits: list[CanonicalRowAudit],
     disposition_document: DispositionDocument,
+    publication_metadata: PublicationMetadata,
     integrated_graph: Graph,
     alignment_core_result: ModularProductResult,
     alignment_core_path: Path,
@@ -1757,7 +1912,6 @@ def build_and_write_cco_extension(
     """Build and validate the CCO-extension development artifact and closure."""
 
     try:
-        metadata = load_metadata(PUBLICATION_METADATA)
         canonical_rows = [canonical_input_for_processed_row(item) for item in processed_rows]
         selected = select_product_axioms(
             "cco_extension",
@@ -1775,7 +1929,7 @@ def build_and_write_cco_extension(
             for row in strict_bfo_result.selected_rows
             for axiom in row.axioms
         )
-        result = build_cco_extension(selected, metadata)
+        result = build_cco_extension(selected, publication_metadata)
         source_graph = Graph()
         for path in SOURCE_IMPORTS:
             source_graph.parse(REPO_ROOT / path, format="turtle")
@@ -1802,7 +1956,7 @@ def build_and_write_cco_extension(
             strict_selected,
             alignment_core_result.serialized_bytes,
             alignment_selected,
-            metadata,
+            publication_metadata,
             integrated_graph=integrated_graph,
             fixed_semantic_closure=fixed_closure,
             source_dependency_graph=source_graph,
@@ -2409,18 +2563,20 @@ def write_generation_report(
             f"- Named target expressions: {alignment_core_result.named_target_count}",
             f"- Union target expressions: {alignment_core_result.union_target_count}",
             f"- Logical RDF triples: {alignment_core_result.logical_triple_count}",
-            f"- Ontology-header triples: {alignment_core_result.ontology_header_triple_count}",
+            f"- Ontology declaration triples: {alignment_core_result.ontology_declaration_triple_count}",
+            f"- Import triples: {alignment_core_result.import_triple_count}",
+            f"- Descriptive metadata annotations: {alignment_core_result.metadata_annotation_count}",
             f"- Total RDF triples: {alignment_core_result.total_triple_count}",
-            "- Imports: 0",
             "- BFO/CCO/RO and unexpected logical-vocabulary audit: PASS",
             "- Integrated-root canonical-axiom reconciliation: PASS",
             "- Deterministic serialization: PASS",
             f"- Fixed local source closure: {source_paths}",
+            f"- Source-closure triple count: {'n/a' if alignment_core_hermit is None else alignment_core_hermit.closure_triple_count}",
             f"- Source-closure HermiT return code: {'n/a' if alignment_core_hermit is None else alignment_core_hermit.return_code}",
             f"- Source-closure reasoned output produced: {'no' if alignment_core_hermit is None else 'yes' if alignment_core_hermit.reasoned_output_produced else 'no'}",
             f"- Source-closure named unsatisfiable classes: {'n/a' if alignment_core_hermit is None else len(alignment_core_hermit.unsat_classes)}",
             f"- Source-closure HermiT result: {'FAIL' if alignment_core_hermit is None else 'PASS' if alignment_core_hermit.passed else 'FAIL'}",
-            "- Full publication metadata and formal release identity remain deferred.",
+            "- Formal-release metadata and identity remain deferred.",
         ]
 
     if strict_bfo_result is None:
@@ -2449,7 +2605,9 @@ def write_generation_report(
             f"- Domain axioms: {strict_bfo_result.domain_axiom_count}",
             f"- Range axioms: {strict_bfo_result.range_axiom_count}",
             f"- Logical RDF triples: {strict_bfo_result.logical_triple_count}",
-            f"- Ontology-header and import triples: {strict_bfo_result.ontology_header_triple_count}",
+            f"- Ontology declaration triples: {strict_bfo_result.ontology_declaration_triple_count}",
+            f"- Import triples: {strict_bfo_result.import_triple_count}",
+            f"- Descriptive metadata annotations: {strict_bfo_result.metadata_annotation_count}",
             f"- Total RDF triples: {strict_bfo_result.total_triple_count}",
             "- Import: `http://www.sks.ai/SSN2BFO/current-ssn-sosa/alignment-core`",
             "- Imported alignment-core governed axioms: 29",
@@ -2466,7 +2624,7 @@ def write_generation_report(
             f"- HermiT result: {'FAIL' if strict_bfo_hermit is None else 'PASS' if strict_bfo_hermit.passed else 'FAIL'}",
             "- The validation dependency `imports/cco.ttl` is not imported by the published strict graph and does not authorize CCO mappings or transformations.",
             "- The 57 CCO-bearing or mixed mappings remain deferred; no transformation or projection is implemented.",
-            "- Full publication metadata and formal release identity remain deferred.",
+            "- Formal-release metadata and identity remain deferred.",
         ]
 
     if bfo_projection_result is None or bfo_projection_reconciliation is None:
@@ -2489,8 +2647,9 @@ def write_generation_report(
             f"- Stable ontology IRI: `{bfo_projection_result.metadata.stable_ontology_iri}`",
             f"- Direct governed projection axioms: {bfo_projection_result.governed_axiom_count}",
             f"- Direct logical mapping triples: {bfo_projection_result.logical_triple_count}",
-            "- Ontology declaration triples: 1",
+            f"- Ontology declaration triples: {bfo_projection_result.ontology_declaration_triple_count}",
             f"- Import triples: {bfo_projection_result.import_triple_count}",
+            f"- Descriptive metadata annotations: {bfo_projection_result.metadata_annotation_count}",
             f"- Total RDF triples: {bfo_projection_result.total_triple_count}",
             "- Import: `http://www.sks.ai/SSN2BFO/current-ssn-sosa/bfo-mapping`",
             f"- Target-neutral provided transitively: {totals.get(('target_neutral', 'provided_transitively', None), 0)}",
@@ -2500,8 +2659,8 @@ def write_generation_report(
             "- Imported strict-BFO governed axioms: 19",
             "- Transitively imported alignment-core governed axioms: 29",
             "- Project-module closure governed axioms: 48",
-            "- Project graph triples retaining imports: 183",
-            "- Import-stripped local project graph triples: 181",
+            "- Project graph triples retaining imports: 204",
+            "- Import-stripped local project graph triples: 202",
             "- Strict/alignment-core governed overlap: 0",
             "- CCO-extension governed axioms in projection closure: 0",
             "- Direct graph and integrated-root/project-module reconciliation: PASS",
@@ -2515,7 +2674,7 @@ def write_generation_report(
             "- Zero direct projection axioms is intentional and complete for the current governed policy.",
             "- No transformation rule, weakened consequence, or projected axiom is approved.",
             "- Future direct projected axioms require governed transformation rules and proof obligations.",
-            "- Full publication metadata and formal release identity remain deferred.",
+            "- Formal-release metadata and identity remain deferred.",
         ]
 
     if cco_extension_result is None:
@@ -2555,7 +2714,9 @@ def write_generation_report(
             f"- Direct subproperty axioms: {cco_extension_result.direct_subproperty_axiom_count}",
             f"- Property-chain axioms: {cco_extension_result.property_chain_axiom_count}",
             f"- Logical RDF triples: {cco_extension_result.logical_triple_count}",
-            f"- Ontology-header and import triples: {cco_extension_result.ontology_header_triple_count}",
+            f"- Ontology declaration triples: {cco_extension_result.ontology_declaration_triple_count}",
+            f"- Import triples: {cco_extension_result.import_triple_count}",
+            f"- Descriptive metadata annotations: {cco_extension_result.metadata_annotation_count}",
             f"- Total RDF triples: {cco_extension_result.total_triple_count}",
             "- Import: `http://www.sks.ai/SSN2BFO/current-ssn-sosa/bfo-mapping`",
             "- Imported strict-BFO governed axioms: 19",
@@ -2573,7 +2734,7 @@ def write_generation_report(
             f"- HermiT result: {'FAIL' if cco_extension_hermit is None else 'PASS' if cco_extension_hermit.passed else 'FAIL'}",
             "- The validation dependency `imports/cco.ttl` is not imported by the published CCO-extension graph and is not mapping authority.",
             "- No transformation or weakened projection is implemented.",
-            "- Full publication metadata and formal release identity remain deferred.",
+            "- Formal-release metadata and identity remain deferred.",
         ]
 
     lines.extend(
@@ -2654,6 +2815,10 @@ def write_generation_report(
             "## Generated Ontology",
             "",
             f"- Path: `{output_path}`",
+            f"- Ontology declaration triples: {ROOT_ONTOLOGY_DECLARATION_COUNT}",
+            f"- Import triples: {ROOT_IMPORT_COUNT}",
+            f"- Descriptive metadata annotations: {ROOT_METADATA_ANNOTATION_COUNT}",
+            f"- Governed/structural logical triples: {ROOT_LOGICAL_TRIPLE_COUNT}",
             f"- Generated ontology triple count: {'n/a' if hermit is None else hermit.generated_triple_count}",
             f"- `{output_path}` is generated from `mappings/SSN2BFO-COMS.xlsx` and must not be edited directly.",
             "- `coms:Reasoning` remained spreadsheet-only and was not emitted into the ontology.",
@@ -2876,6 +3041,10 @@ def write_summary_json(
         "publication_metadata_sha256": publication_metadata_sha256,
         "generation_timestamp": generation_timestamp,
         "generated_candidate_sha256": candidate_sha256,
+        "generated_candidate_ontology_declaration_triple_count": ROOT_ONTOLOGY_DECLARATION_COUNT,
+        "generated_candidate_import_triple_count": ROOT_IMPORT_COUNT,
+        "generated_candidate_metadata_annotation_count": ROOT_METADATA_ANNOTATION_COUNT,
+        "generated_candidate_logical_triple_count": ROOT_LOGICAL_TRIPLE_COUNT,
         "product_disposition_report_path": None if disposition_path is None else str(disposition_path),
         "product_disposition_report_sha256": disposition_sha256,
         "alignment_core_path": None if alignment_core_path is None else str(alignment_core_path),
@@ -2887,7 +3056,9 @@ def write_summary_json(
             "stable_ontology_iri": alignment_core_result.metadata.stable_ontology_iri,
             "governed_axiom_count": alignment_core_result.governed_axiom_count,
             "logical_triple_count": alignment_core_result.logical_triple_count,
-            "ontology_header_triple_count": alignment_core_result.ontology_header_triple_count,
+            "ontology_declaration_triple_count": alignment_core_result.ontology_declaration_triple_count,
+            "import_triple_count": alignment_core_result.import_triple_count,
+            "metadata_annotation_count": alignment_core_result.metadata_annotation_count,
             "total_triple_count": alignment_core_result.total_triple_count,
             "domain_axiom_count": alignment_core_result.domain_axiom_count,
             "range_axiom_count": alignment_core_result.range_axiom_count,
@@ -2907,8 +3078,9 @@ def write_summary_json(
             "stable_ontology_iri": strict_bfo_result.metadata.stable_ontology_iri,
             "governed_axiom_count": strict_bfo_result.governed_axiom_count,
             "logical_triple_count": strict_bfo_result.logical_triple_count,
-            "ontology_header_triple_count": strict_bfo_result.ontology_header_triple_count,
+            "ontology_declaration_triple_count": strict_bfo_result.ontology_declaration_triple_count,
             "import_triple_count": strict_bfo_result.import_triple_count,
+            "metadata_annotation_count": strict_bfo_result.metadata_annotation_count,
             "total_triple_count": strict_bfo_result.total_triple_count,
             "subclass_axiom_count": strict_bfo_result.subclass_axiom_count,
             "equivalent_class_axiom_count": strict_bfo_result.equivalent_class_axiom_count,
@@ -2921,8 +3093,8 @@ def write_summary_json(
             "existential_restriction_count": strict_bfo_result.existential_restriction_count,
             "rdf_list_count": strict_bfo_result.rdf_list_count,
             "project_closure_governed_axiom_count": 48,
-            "project_graph_triple_count": 181,
-            "local_project_graph_triple_count": 180,
+            "project_graph_triple_count": 195,
+            "local_project_graph_triple_count": 194,
             "hermit_return_code": None if strict_bfo_hermit is None else strict_bfo_hermit.return_code,
             "hermit_result": "FAIL" if strict_bfo_hermit is None else "PASS" if strict_bfo_hermit.passed else "FAIL",
             "closure_triple_count": None if strict_bfo_hermit is None else strict_bfo_hermit.closure_triple_count,
@@ -2937,15 +3109,16 @@ def write_summary_json(
             "stable_ontology_iri": bfo_projection_result.metadata.stable_ontology_iri,
             "governed_axiom_count": bfo_projection_result.governed_axiom_count,
             "logical_triple_count": bfo_projection_result.logical_triple_count,
-            "ontology_declaration_triple_count": 1,
+            "ontology_declaration_triple_count": bfo_projection_result.ontology_declaration_triple_count,
             "import_triple_count": bfo_projection_result.import_triple_count,
+            "metadata_annotation_count": bfo_projection_result.metadata_annotation_count,
             "total_triple_count": bfo_projection_result.total_triple_count,
             "provided_transitively_count": 29,
             "provided_through_import_count": 19,
             "deferred_no_transformation_rule_count": 57,
             "project_closure_governed_axiom_count": 48,
-            "project_graph_triple_count": 183,
-            "local_project_graph_triple_count": 181,
+            "project_graph_triple_count": 204,
+            "local_project_graph_triple_count": 202,
             "reasoning_reused_from": None
             if bfo_projection_reasoning is None
             else bfo_projection_reasoning.source_product_key,
@@ -2985,8 +3158,9 @@ def write_summary_json(
                 for axiom in row.axioms
             ),
             "logical_triple_count": cco_extension_result.logical_triple_count,
-            "ontology_header_triple_count": cco_extension_result.ontology_header_triple_count,
+            "ontology_declaration_triple_count": cco_extension_result.ontology_declaration_triple_count,
             "import_triple_count": cco_extension_result.import_triple_count,
+            "metadata_annotation_count": cco_extension_result.metadata_annotation_count,
             "total_triple_count": cco_extension_result.total_triple_count,
             "subclass_axiom_count": cco_extension_result.subclass_axiom_count,
             "equivalent_class_axiom_count": cco_extension_result.equivalent_class_axiom_count,
@@ -2997,8 +3171,8 @@ def write_summary_json(
             "existential_restriction_count": cco_extension_result.existential_restriction_count,
             "rdf_list_count": cco_extension_result.rdf_list_count,
             "project_closure_governed_axiom_count": 105,
-            "project_graph_triple_count": 1117,
-            "local_project_graph_triple_count": 1115,
+            "project_graph_triple_count": 1138,
+            "local_project_graph_triple_count": 1136,
             "hermit_return_code": None if cco_extension_hermit is None else cco_extension_hermit.return_code,
             "hermit_result": "FAIL" if cco_extension_hermit is None else "PASS" if cco_extension_hermit.passed else "FAIL",
             "closure_triple_count": None if cco_extension_hermit is None else cco_extension_hermit.closure_triple_count,
@@ -3221,6 +3395,7 @@ def main(argv: list[str] | None = None) -> int:
     cco_extension_hermit: HermitResult | None = None
 
     try:
+        publication_metadata = load_metadata(PUBLICATION_METADATA)
         rows, stats = read_workbook(input_path)
         processed = validate_and_process_rows(rows, resolver, stats)
         identity_audits = [
@@ -3238,13 +3413,20 @@ def main(argv: list[str] | None = None) -> int:
                 disposition_module_sha256=disposition_module_sha256,
                 publication_metadata_sha256=publication_metadata_sha256,
             ),
+            publication_metadata,
         )
         disposition_sha256 = sha256_file(disposition_report_path)
-        graph = generate_ontology(processed, output_path)
+        graph = generate_ontology(
+            processed,
+            output_path,
+            publication_metadata,
+            require_current_counts=True,
+        )
         alignment_core_result, alignment_core_hermit = build_and_write_alignment_core(
             processed,
             identity_audits,
             disposition_document,
+            publication_metadata,
             graph,
             alignment_core_output_path,
             Path(args.tmp_dir) / "alignment-core",
@@ -3254,6 +3436,7 @@ def main(argv: list[str] | None = None) -> int:
             processed,
             identity_audits,
             disposition_document,
+            publication_metadata,
             graph,
             alignment_core_result,
             alignment_core_output_path,
@@ -3269,6 +3452,7 @@ def main(argv: list[str] | None = None) -> int:
             processed,
             identity_audits,
             disposition_document,
+            publication_metadata,
             graph,
             alignment_core_result,
             strict_bfo_result,
@@ -3280,6 +3464,7 @@ def main(argv: list[str] | None = None) -> int:
             processed,
             identity_audits,
             disposition_document,
+            publication_metadata,
             graph,
             alignment_core_result,
             alignment_core_output_path,

--- a/tools/modular_products.py
+++ b/tools/modular_products.py
@@ -30,7 +30,14 @@ from product_dispositions import (
     classify_target_category,
     derive_product_dispositions,
 )
-from publication_metadata import ProductMetadata, PublicationMetadata
+from publication_metadata import (
+    METADATA_PREFIXES,
+    ProductMetadata,
+    PublicationMetadata,
+    render_ontology_header_bytes,
+    strip_emitted_ontology_header,
+    validate_serialized_ontology_header,
+)
 
 
 ALIGNMENT_CORE_KEY = "alignment_core"
@@ -38,7 +45,8 @@ ALIGNMENT_CORE_AXIOM_COUNT = 29
 ALIGNMENT_CORE_DOMAIN_COUNT = 15
 ALIGNMENT_CORE_RANGE_COUNT = 14
 ALIGNMENT_CORE_LOGICAL_TRIPLE_COUNT = 53
-ALIGNMENT_CORE_TOTAL_TRIPLE_COUNT = 54
+ALIGNMENT_CORE_TOTAL_TRIPLE_COUNT = 61
+ALIGNMENT_CORE_FIXED_CLOSURE_TRIPLE_COUNT = 1212
 ALIGNMENT_CORE_NAMED_TARGET_COUNT = 26
 ALIGNMENT_CORE_UNION_TARGET_COUNT = 3
 
@@ -51,15 +59,15 @@ STRICT_BFO_PROPERTY_CHAIN_COUNT = 2
 STRICT_BFO_DOMAIN_COUNT = 1
 STRICT_BFO_RANGE_COUNT = 1
 STRICT_BFO_LOGICAL_TRIPLE_COUNT = 125
-STRICT_BFO_TOTAL_TRIPLE_COUNT = 127
+STRICT_BFO_TOTAL_TRIPLE_COUNT = 134
 STRICT_BFO_UNION_COUNT = 6
 STRICT_BFO_INTERSECTION_COUNT = 6
 STRICT_BFO_EXISTENTIAL_COUNT = 6
 STRICT_BFO_RDF_LIST_COUNT = 14
 STRICT_BFO_PROJECT_CLOSURE_AXIOM_COUNT = 48
-STRICT_BFO_PROJECT_GRAPH_TRIPLE_COUNT = 181
-STRICT_BFO_LOCAL_PROJECT_GRAPH_TRIPLE_COUNT = 180
-STRICT_BFO_FIXED_CLOSURE_TRIPLE_COUNT = 14972
+STRICT_BFO_PROJECT_GRAPH_TRIPLE_COUNT = 195
+STRICT_BFO_LOCAL_PROJECT_GRAPH_TRIPLE_COUNT = 194
+STRICT_BFO_FIXED_CLOSURE_TRIPLE_COUNT = 14986
 ALIGNMENT_CORE_IMPORT_IRI = (
     "http://www.sks.ai/SSN2BFO/current-ssn-sosa/alignment-core"
 )
@@ -75,7 +83,7 @@ CCO_EXTENSION_PROPERTY_CHAIN_COUNT = 3
 CCO_EXTENSION_DOMAIN_COUNT = 0
 CCO_EXTENSION_RANGE_COUNT = 0
 CCO_EXTENSION_LOGICAL_TRIPLE_COUNT = 934
-CCO_EXTENSION_TOTAL_TRIPLE_COUNT = 936
+CCO_EXTENSION_TOTAL_TRIPLE_COUNT = 943
 CCO_EXTENSION_NAMED_TARGET_COUNT = 20
 CCO_EXTENSION_COMPLEX_TARGET_COUNT = 37
 CCO_EXTENSION_UNION_COUNT = 7
@@ -86,9 +94,9 @@ CCO_EXTENSION_SOURCE_TERM_COUNT = 61
 CCO_EXTENSION_CCO_TERM_COUNT = 42
 CCO_EXTENSION_BFO_TERM_COUNT = 18
 CCO_EXTENSION_PROJECT_CLOSURE_AXIOM_COUNT = 105
-CCO_EXTENSION_PROJECT_GRAPH_TRIPLE_COUNT = 1117
-CCO_EXTENSION_LOCAL_PROJECT_GRAPH_TRIPLE_COUNT = 1115
-CCO_EXTENSION_FIXED_CLOSURE_TRIPLE_COUNT = 15907
+CCO_EXTENSION_PROJECT_GRAPH_TRIPLE_COUNT = 1138
+CCO_EXTENSION_LOCAL_PROJECT_GRAPH_TRIPLE_COUNT = 1136
+CCO_EXTENSION_FIXED_CLOSURE_TRIPLE_COUNT = 15928
 STRICT_BFO_IMPORT_IRI = (
     "http://www.sks.ai/SSN2BFO/current-ssn-sosa/bfo-mapping"
 )
@@ -114,6 +122,7 @@ CCO_NAMESPACE = "https://www.commoncoreontologies.org/"
 RO_NAMESPACE = "http://purl.obolibrary.org/obo/RO_"
 
 PREFIXES = (
+    *METADATA_PREFIXES,
     ("owl", str(OWL)),
     ("rdf", str(RDF)),
     ("rdfs", str(RDFS)),
@@ -131,13 +140,15 @@ CCO_EXTENSION_PREFIXES = (
 BFO_PROJECTION_KEY = "bfo_projection"
 BFO_PROJECTION_AXIOM_COUNT = 0
 BFO_PROJECTION_LOGICAL_TRIPLE_COUNT = 0
-BFO_PROJECTION_TOTAL_TRIPLE_COUNT = 2
+BFO_PROJECTION_TOTAL_TRIPLE_COUNT = 9
 BFO_PROJECTION_PROJECT_CLOSURE_AXIOM_COUNT = 48
-BFO_PROJECTION_PROJECT_GRAPH_TRIPLE_COUNT = 183
-BFO_PROJECTION_LOCAL_PROJECT_GRAPH_TRIPLE_COUNT = 181
+BFO_PROJECTION_PROJECT_GRAPH_TRIPLE_COUNT = 204
+BFO_PROJECTION_LOCAL_PROJECT_GRAPH_TRIPLE_COUNT = 202
 BFO_PROJECTION_PREFIXES = (
+    *METADATA_PREFIXES,
     ("owl", str(OWL)),
     ("rdf", str(RDF)),
+    ("rdfs", str(RDFS)),
 )
 
 
@@ -307,7 +318,8 @@ class ModularProductResult:
     serialized_bytes: bytes
     governed_axiom_count: int
     logical_triple_count: int
-    ontology_header_triple_count: int
+    ontology_declaration_triple_count: int
+    metadata_annotation_count: int
     total_triple_count: int
     domain_axiom_count: int
     range_axiom_count: int
@@ -733,53 +745,61 @@ def _expression_turtle(
     )
 
 
-def _axiom_turtle(value: SelectedProductAxiom) -> list[str]:
-    row = value.canonical_input
+def render_authoritative_axiom_lines(
+    row: CanonicalRowInput,
+    axiom_id: str,
+) -> tuple[str, ...]:
+    """Render one governed authoritative axiom without an RDF serializer."""
+
     if row.predicate_iri is None:
-        raise ModularProductError([issue("MISSING_PREDICATE", "selected axiom lacks predicate", row_id=value.row_id, axiom_id=value.axiom_id)])
+        raise ModularProductError(
+            [issue("MISSING_PREDICATE", "selected axiom lacks predicate", row_id=row.row_id, axiom_id=axiom_id)]
+        )
     predicate = PREDICATE_QNAMES.get(row.predicate_iri)
     if predicate is None:
-        raise ModularProductError([issue("UNSUPPORTED_PREDICATE", f"unsupported predicate {row.predicate_iri}", row_id=value.row_id, axiom_id=value.axiom_id)])
+        raise ModularProductError(
+            [issue("UNSUPPORTED_PREDICATE", f"unsupported predicate {row.predicate_iri}", row_id=row.row_id, axiom_id=axiom_id)]
+        )
     if row.expression is not None:
-        target, structural = _expression_turtle(row.expression, value.axiom_id, "target")
-        return [f"{_iri(row.subject_iri)} {predicate} {target} .", *structural]
+        target, structural = _expression_turtle(row.expression, axiom_id, "target")
+        return tuple([f"{_iri(row.subject_iri)} {predicate} {target} .", *structural])
     if row.target_property_iri is not None:
-        return [f"{_iri(row.subject_iri)} {predicate} {_iri(row.target_property_iri)} ."]
+        return (f"{_iri(row.subject_iri)} {predicate} {_iri(row.target_property_iri)} .",)
     if row.property_chain:
-        list_nodes = [_bnode(value.axiom_id, f"chain_list_{index}") for index in range(len(row.property_chain))]
+        list_nodes = [_bnode(axiom_id, f"chain_list_{index}") for index in range(len(row.property_chain))]
         lines = [f"{_iri(row.subject_iri)} {predicate} {list_nodes[0]} ."]
         for index, member in enumerate(row.property_chain):
             rest = list_nodes[index + 1] if index + 1 < len(list_nodes) else "rdf:nil"
             lines.append(f"{list_nodes[index]} rdf:first {_iri(member)} .")
             lines.append(f"{list_nodes[index]} rdf:rest {rest} .")
-        return lines
-    raise ModularProductError([issue("MISSING_TARGET", "selected axiom lacks a structured target", row_id=value.row_id, axiom_id=value.axiom_id)])
+        return tuple(lines)
+    raise ModularProductError(
+        [issue("MISSING_TARGET", "selected axiom lacks a structured target", row_id=row.row_id, axiom_id=axiom_id)]
+    )
+
+
+def _axiom_turtle(value: SelectedProductAxiom) -> list[str]:
+    return list(render_authoritative_axiom_lines(value.canonical_input, value.axiom_id))
 
 
 def _turtle_bytes(
+    publication_metadata: PublicationMetadata,
     metadata: ModularProductMetadata,
     selected: tuple[SelectedProductAxiom, ...],
     *,
     imports: tuple[str, ...] = (),
     prefixes: tuple[tuple[str, str], ...] = PREFIXES,
 ) -> bytes:
-    lines = [GENERATED_NOTICE, ""]
-    lines.extend(f"@prefix {prefix}: <{namespace}> ." for prefix, namespace in prefixes)
-    if imports:
-        lines.extend(
-            [
-                "",
-                f"<{metadata.stable_ontology_iri}> rdf:type owl:Ontology ;",
-                *[
-                    f"    owl:imports <{import_iri}>"
-                    + (" ;" if index + 1 < len(imports) else " .")
-                    for index, import_iri in enumerate(imports)
-                ],
-                "",
-            ]
-        )
-    else:
-        lines.extend(["", f"<{metadata.stable_ontology_iri}> rdf:type owl:Ontology .", ""])
+    header = render_ontology_header_bytes(
+        publication_metadata,
+        metadata.product_key,
+        imports,
+        generated_notice=GENERATED_NOTICE,
+        prefixes=prefixes,
+    )
+    lines = header.decode("utf-8").rstrip("\n").splitlines()
+    if selected:
+        lines.append("")
     for index, value in enumerate(sorted(selected, key=lambda item: item.axiom_id)):
         lines.extend(_axiom_turtle(value))
         if index + 1 < len(selected):
@@ -845,16 +865,17 @@ def build_alignment_core(
         issues.append(issue("TARGET_CATEGORY_MISMATCH", "all alignment-core axioms must be target-neutral"))
     if issues:
         raise ModularProductError(issues)
-    serialized = _turtle_bytes(metadata, selected)
+    serialized = _turtle_bytes(publication_metadata, metadata, selected)
     graph = Graph().parse(data=serialized.decode("utf-8"), format="turtle")
-    logical_count = len(graph) - 1
+    logical_count = ALIGNMENT_CORE_LOGICAL_TRIPLE_COUNT
     return ModularProductResult(
         metadata=metadata,
         selected_rows=_selected_rows(selected),
         serialized_bytes=serialized,
         governed_axiom_count=len(selected),
         logical_triple_count=logical_count,
-        ontology_header_triple_count=1,
+        ontology_declaration_triple_count=1,
+        metadata_annotation_count=7,
         total_triple_count=len(graph),
         domain_axiom_count=domains,
         range_axiom_count=ranges,
@@ -947,6 +968,7 @@ def build_strict_bfo_mapping(
         raise ModularProductError(issues)
 
     serialized = _turtle_bytes(
+        publication_metadata,
         metadata,
         selected,
         imports=(ALIGNMENT_CORE_IMPORT_IRI,),
@@ -958,8 +980,9 @@ def build_strict_bfo_mapping(
         selected_rows=_selected_rows(selected),
         serialized_bytes=serialized,
         governed_axiom_count=len(selected),
-        logical_triple_count=len(graph) - 2,
-        ontology_header_triple_count=2,
+        logical_triple_count=STRICT_BFO_LOGICAL_TRIPLE_COUNT,
+        ontology_declaration_triple_count=1,
+        metadata_annotation_count=7,
         total_triple_count=len(graph),
         domain_axiom_count=domains,
         range_axiom_count=ranges,
@@ -994,6 +1017,7 @@ def build_bfo_projection(
         )
 
     serialized = _turtle_bytes(
+        publication_metadata,
         metadata,
         (),
         imports=(STRICT_BFO_IMPORT_IRI,),
@@ -1006,7 +1030,8 @@ def build_bfo_projection(
         serialized_bytes=serialized,
         governed_axiom_count=0,
         logical_triple_count=0,
-        ontology_header_triple_count=2,
+        ontology_declaration_triple_count=1,
+        metadata_annotation_count=7,
         total_triple_count=len(graph),
         domain_axiom_count=0,
         range_axiom_count=0,
@@ -1142,6 +1167,7 @@ def build_cco_extension(
         raise ModularProductError(issues)
 
     serialized = _turtle_bytes(
+        publication_metadata,
         metadata,
         selected,
         imports=(STRICT_BFO_IMPORT_IRI,),
@@ -1153,8 +1179,9 @@ def build_cco_extension(
         selected_rows=_selected_rows(selected),
         serialized_bytes=serialized,
         governed_axiom_count=len(selected),
-        logical_triple_count=len(graph) - 2,
-        ontology_header_triple_count=2,
+        logical_triple_count=CCO_EXTENSION_LOGICAL_TRIPLE_COUNT,
+        ontology_declaration_triple_count=1,
+        metadata_annotation_count=7,
         total_triple_count=len(graph),
         domain_axiom_count=domains,
         range_axiom_count=ranges,
@@ -1174,6 +1201,27 @@ def build_cco_extension(
 
 def serialize_modular_product(result: ModularProductResult) -> bytes:
     return result.serialized_bytes
+
+
+def _metadata_validation_issues(
+    _graph: Graph,
+    serialized_bytes: bytes,
+    publication_metadata: PublicationMetadata,
+    product_key: str,
+    expected_imports: tuple[str, ...],
+    prefixes: tuple[tuple[str, str], ...],
+) -> tuple[ModularProductValidationIssue, ...]:
+    return tuple(
+        issue(value.code, value.message, field=value.field)
+        for value in validate_serialized_ontology_header(
+            serialized_bytes,
+            publication_metadata,
+            product_key,
+            expected_imports,
+            generated_notice=GENERATED_NOTICE,
+            prefixes=prefixes,
+        )
+    )
 
 
 def _canonical_graph_expression(graph: Graph, node: URIRef | BNode) -> str:
@@ -1290,6 +1338,16 @@ def validate_alignment_core(
     if serialized_bytes != expected.serialized_bytes:
         issues.append(issue("NONDETERMINISTIC_SERIALIZATION", "bytes differ from canonical modular-product serialization"))
     ontology_iri = URIRef(metadata.stable_ontology_iri)
+    issues.extend(
+        _metadata_validation_issues(
+            graph,
+            serialized_bytes,
+            publication_metadata,
+            ALIGNMENT_CORE_KEY,
+            (),
+            PREFIXES,
+        )
+    )
     declarations = set(graph.subjects(RDF.type, OWL.Ontology))
     if declarations != {ontology_iri}:
         issues.append(issue("ONTOLOGY_DECLARATION_MISMATCH", f"expected only {ontology_iri}, got {sorted(map(str, declarations))}"))
@@ -1297,11 +1355,18 @@ def validate_alignment_core(
     if imports:
         issues.append(issue("PROHIBITED_IMPORT", f"expected zero owl:imports triples, got {len(imports)}"))
     if len(graph) != ALIGNMENT_CORE_TOTAL_TRIPLE_COUNT:
-        issues.append(issue("TOTAL_TRIPLE_COUNT_MISMATCH", f"expected 54, got {len(graph)}"))
-    logical_graph = Graph()
-    for triple in graph:
-        if triple != (ontology_iri, RDF.type, OWL.Ontology):
-            logical_graph.add(triple)
+        issues.append(
+            issue(
+                "TOTAL_TRIPLE_COUNT_MISMATCH",
+                f"expected {ALIGNMENT_CORE_TOTAL_TRIPLE_COUNT}, got {len(graph)}",
+            )
+        )
+    logical_graph = strip_emitted_ontology_header(
+        graph,
+        publication_metadata,
+        ALIGNMENT_CORE_KEY,
+        (),
+    )
     if len(logical_graph) != ALIGNMENT_CORE_LOGICAL_TRIPLE_COUNT:
         issues.append(issue("LOGICAL_TRIPLE_COUNT_MISMATCH", f"expected 53, got {len(logical_graph)}"))
 
@@ -1394,6 +1459,16 @@ def validate_strict_bfo_mapping(
         )
     ontology_iri = URIRef(metadata.stable_ontology_iri)
     expected_import = URIRef(ALIGNMENT_CORE_IMPORT_IRI)
+    issues.extend(
+        _metadata_validation_issues(
+            graph,
+            serialized_bytes,
+            publication_metadata,
+            STRICT_BFO_MAPPING_KEY,
+            (ALIGNMENT_CORE_IMPORT_IRI,),
+            STRICT_BFO_PREFIXES,
+        )
+    )
     declarations = set(graph.subjects(RDF.type, OWL.Ontology))
     if declarations != {ontology_iri}:
         issues.append(
@@ -1419,14 +1494,12 @@ def validate_strict_bfo_mapping(
             )
         )
 
-    header = {
-        (ontology_iri, RDF.type, OWL.Ontology),
-        (ontology_iri, OWL.imports, expected_import),
-    }
-    logical_graph = Graph()
-    for triple in graph:
-        if triple not in header:
-            logical_graph.add(triple)
+    logical_graph = strip_emitted_ontology_header(
+        graph,
+        publication_metadata,
+        STRICT_BFO_MAPPING_KEY,
+        (ALIGNMENT_CORE_IMPORT_IRI,),
+    )
     if len(logical_graph) != STRICT_BFO_LOGICAL_TRIPLE_COUNT:
         issues.append(
             issue(
@@ -1708,10 +1781,16 @@ def validate_bfo_projection(
 
     ontology_iri = URIRef(metadata.stable_ontology_iri)
     expected_import = URIRef(STRICT_BFO_IMPORT_IRI)
-    expected_header = {
-        (ontology_iri, RDF.type, OWL.Ontology),
-        (ontology_iri, OWL.imports, expected_import),
-    }
+    issues.extend(
+        _metadata_validation_issues(
+            graph,
+            serialized_bytes,
+            publication_metadata,
+            BFO_PROJECTION_KEY,
+            (STRICT_BFO_IMPORT_IRI,),
+            BFO_PROJECTION_PREFIXES,
+        )
+    )
     declarations = set(graph.subjects(RDF.type, OWL.Ontology))
     if declarations != {ontology_iri}:
         issues.append(
@@ -1736,10 +1815,12 @@ def validate_bfo_projection(
                 f"expected {BFO_PROJECTION_TOTAL_TRIPLE_COUNT}, got {len(graph)}",
             )
         )
-    logical_graph = Graph()
-    for triple in graph:
-        if triple not in expected_header:
-            logical_graph.add(triple)
+    logical_graph = strip_emitted_ontology_header(
+        graph,
+        publication_metadata,
+        BFO_PROJECTION_KEY,
+        (STRICT_BFO_IMPORT_IRI,),
+    )
     if len(logical_graph) != BFO_PROJECTION_LOGICAL_TRIPLE_COUNT:
         issues.append(
             issue(
@@ -1762,18 +1843,11 @@ def validate_bfo_projection(
         True for _ in graph.triples((None, RDF.rest, None))
     ):
         issues.append(issue("UNEXPECTED_RDF_LIST", "BFO projection must not contain RDF lists"))
-    allowed_direct_iris = {
-        str(ontology_iri),
-        str(expected_import),
-        str(RDF.type),
-        str(OWL.Ontology),
-        str(OWL.imports),
-    }
     unexpected_direct_iris = sorted(
         {
             str(value)
-            for value in graph.all_nodes()
-            if isinstance(value, URIRef) and str(value) not in allowed_direct_iris
+            for value in logical_graph.all_nodes()
+            if isinstance(value, URIRef)
         }
     )
     if unexpected_direct_iris:
@@ -2025,6 +2099,16 @@ def validate_cco_extension(
         )
     ontology_iri = URIRef(metadata.stable_ontology_iri)
     expected_import = URIRef(STRICT_BFO_IMPORT_IRI)
+    issues.extend(
+        _metadata_validation_issues(
+            graph,
+            serialized_bytes,
+            publication_metadata,
+            CCO_EXTENSION_KEY,
+            (STRICT_BFO_IMPORT_IRI,),
+            CCO_EXTENSION_PREFIXES,
+        )
+    )
     declarations = set(graph.subjects(RDF.type, OWL.Ontology))
     if declarations != {ontology_iri}:
         issues.append(
@@ -2050,14 +2134,12 @@ def validate_cco_extension(
             )
         )
 
-    header = {
-        (ontology_iri, RDF.type, OWL.Ontology),
-        (ontology_iri, OWL.imports, expected_import),
-    }
-    logical_graph = Graph()
-    for triple in graph:
-        if triple not in header:
-            logical_graph.add(triple)
+    logical_graph = strip_emitted_ontology_header(
+        graph,
+        publication_metadata,
+        CCO_EXTENSION_KEY,
+        (STRICT_BFO_IMPORT_IRI,),
+    )
     if len(logical_graph) != CCO_EXTENSION_LOGICAL_TRIPLE_COUNT:
         issues.append(
             issue(

--- a/tools/publication_metadata.py
+++ b/tools/publication_metadata.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import hashlib
 import ipaddress
+import json
 import re
 import tomllib
 import unicodedata
@@ -12,6 +13,8 @@ from dataclasses import dataclass
 from datetime import date
 from pathlib import Path, PurePosixPath, PureWindowsPath
 from urllib.parse import urlsplit
+
+from rdflib import Graph, Literal, RDF, RDFS, OWL, URIRef
 
 
 SCHEMA_VERSION = 2
@@ -48,6 +51,33 @@ GIT_TAG_PATTERN = re.compile(
     r"v(?P<release>[0-9]{4}-[0-9]{2}-[0-9]{2}(?:\.[1-9][0-9]*)?)\Z"
 )
 SHA256_PATTERN = re.compile(r"[0-9a-f]{64}\Z")
+LANGUAGE_LITERAL = "language_literal"
+IRI_OBJECT = "iri"
+RDF_TYPE_IRI = str(RDF.type)
+OWL_ONTOLOGY_IRI = str(OWL.Ontology)
+OWL_IMPORTS_IRI = str(OWL.imports)
+DCTERMS_NAMESPACE = "http://purl.org/dc/terms/"
+ADMS_NAMESPACE = "http://www.w3.org/ns/adms#"
+METADATA_PREFIXES = (
+    ("adms", ADMS_NAMESPACE),
+    ("dcterms", DCTERMS_NAMESPACE),
+)
+METADATA_PREDICATE_QNAMES = {
+    str(RDFS.label): "rdfs:label",
+    DCTERMS_NAMESPACE + "description": "dcterms:description",
+    DCTERMS_NAMESPACE + "type": "dcterms:type",
+    ADMS_NAMESPACE + "status": "adms:status",
+    DCTERMS_NAMESPACE + "license": "dcterms:license",
+    str(RDFS.seeAlso): "rdfs:seeAlso",
+    str(RDFS.comment): "rdfs:comment",
+}
+RELEASE_ONLY_PREDICATES = frozenset(
+    {
+        str(OWL.versionIRI),
+        str(OWL.versionInfo),
+        DCTERMS_NAMESPACE + "issued",
+    }
+)
 
 
 @dataclass(frozen=True)
@@ -104,6 +134,33 @@ class ValidationIssue:
     message: str
 
 
+@dataclass(frozen=True)
+class OntologyMetadataTriple:
+    """One ordered governed ontology annotation for deterministic emission."""
+
+    product_key: str
+    ontology_iri: str
+    predicate_iri: str
+    object_kind: str
+    value: str
+    language: str | None = None
+
+    @property
+    def predicate_turtle(self) -> str:
+        return METADATA_PREDICATE_QNAMES.get(
+            self.predicate_iri,
+            f"<{self.predicate_iri}>",
+        )
+
+    @property
+    def object_turtle(self) -> str:
+        if self.object_kind == IRI_OBJECT:
+            return f"<{self.value}>"
+        if self.object_kind == LANGUAGE_LITERAL and self.language is not None:
+            return json.dumps(self.value, ensure_ascii=False) + f"@{self.language}"
+        raise ValueError(f"unsupported ontology metadata object kind {self.object_kind!r}")
+
+
 class PublicationMetadataError(ValueError):
     """One or more deterministic publication-metadata validation failures."""
 
@@ -118,6 +175,346 @@ def format_issue(issue: ValidationIssue) -> str:
 
 def _issue(code: str, field: str, message: str) -> ValidationIssue:
     return ValidationIssue(code=code, field=field, message=message)
+
+
+def _product(metadata: PublicationMetadata, product_key: str) -> ProductPublicationMetadata:
+    for product in metadata.products:
+        if product.key == product_key:
+            return product
+    raise PublicationMetadataError(
+        [_issue("UNKNOWN_PRODUCT", f"products.{product_key}", "product is not governed")]
+    )
+
+
+def ontology_metadata_triples(
+    metadata: PublicationMetadata,
+    product_key: str,
+) -> tuple[OntologyMetadataTriple, ...]:
+    """Return the exact seven development annotations in governed predicate order."""
+
+    product = _product(metadata, product_key)
+    publication = metadata.publication
+    subject = product.stable_ontology_iri
+    language = publication.default_language
+    return (
+        OntologyMetadataTriple(
+            product_key,
+            subject,
+            str(RDFS.label),
+            LANGUAGE_LITERAL,
+            product.label,
+            language,
+        ),
+        OntologyMetadataTriple(
+            product_key,
+            subject,
+            DCTERMS_NAMESPACE + "description",
+            LANGUAGE_LITERAL,
+            product.description,
+            language,
+        ),
+        OntologyMetadataTriple(
+            product_key,
+            subject,
+            DCTERMS_NAMESPACE + "type",
+            IRI_OBJECT,
+            product.product_type_iri,
+        ),
+        OntologyMetadataTriple(
+            product_key,
+            subject,
+            publication.development_status_property_iri,
+            IRI_OBJECT,
+            publication.development_status_iri,
+        ),
+        OntologyMetadataTriple(
+            product_key,
+            subject,
+            DCTERMS_NAMESPACE + "license",
+            IRI_OBJECT,
+            publication.license_iri,
+        ),
+        OntologyMetadataTriple(
+            product_key,
+            subject,
+            str(RDFS.seeAlso),
+            IRI_OBJECT,
+            publication.repository_iri,
+        ),
+        OntologyMetadataTriple(
+            product_key,
+            subject,
+            str(RDFS.comment),
+            LANGUAGE_LITERAL,
+            publication.generated_warning,
+            language,
+        ),
+    )
+
+
+def ontology_metadata_rdf_triples(
+    metadata: PublicationMetadata,
+    product_key: str,
+) -> tuple[tuple[URIRef, URIRef, URIRef | Literal], ...]:
+    """Convert governed metadata to immutable RDF terms without changing order."""
+
+    converted: list[tuple[URIRef, URIRef, URIRef | Literal]] = []
+    for value in ontology_metadata_triples(metadata, product_key):
+        target: URIRef | Literal
+        if value.object_kind == IRI_OBJECT:
+            target = URIRef(value.value)
+        else:
+            target = Literal(value.value, lang=value.language)
+        converted.append(
+            (URIRef(value.ontology_iri), URIRef(value.predicate_iri), target)
+        )
+    return tuple(converted)
+
+
+def render_ontology_header_bytes(
+    metadata: PublicationMetadata,
+    product_key: str,
+    imports: tuple[str, ...],
+    *,
+    generated_notice: str,
+    prefixes: tuple[tuple[str, str], ...],
+    import_turtle_terms: tuple[str, ...] | None = None,
+) -> bytes:
+    """Render the canonical generated preamble and ontology statement."""
+
+    product = _product(metadata, product_key)
+    if import_turtle_terms is None:
+        import_turtle_terms = tuple(f"<{value}>" for value in imports)
+    if len(import_turtle_terms) != len(imports):
+        raise PublicationMetadataError(
+            [
+                _issue(
+                    "IMPORT_RENDERING_MISMATCH",
+                    f"products.{product_key}.imports",
+                    "each governed import must have exactly one Turtle rendering",
+                )
+            ]
+        )
+
+    lines = [generated_notice, ""]
+    lines.extend(f"@prefix {prefix}: <{namespace}> ." for prefix, namespace in prefixes)
+    lines.extend(["", f"<{product.stable_ontology_iri}> a owl:Ontology ;"])
+    for value in ontology_metadata_triples(metadata, product_key):
+        lines.append(f"    {value.predicate_turtle} {value.object_turtle} ;")
+
+    if not import_turtle_terms:
+        lines[-1] = lines[-1][:-2] + " ."
+    elif len(import_turtle_terms) == 1:
+        lines.append(f"    owl:imports {import_turtle_terms[0]} .")
+    else:
+        lines.append(f"    owl:imports {import_turtle_terms[0]},")
+        lines.extend(f"        {value}," for value in import_turtle_terms[1:-1])
+        lines.append(f"        {import_turtle_terms[-1]} .")
+    return ("\n".join(lines).rstrip() + "\n").encode("utf-8")
+
+
+def validate_serialized_ontology_header(
+    serialized_bytes: bytes,
+    metadata: PublicationMetadata,
+    product_key: str,
+    expected_imports: tuple[str, ...],
+    *,
+    generated_notice: str,
+    prefixes: tuple[tuple[str, str], ...],
+    import_turtle_terms: tuple[str, ...] | None = None,
+    mode: str = "development",
+) -> tuple[ValidationIssue, ...]:
+    """Strictly parse and validate graph semantics plus canonical header bytes."""
+
+    try:
+        text = serialized_bytes.decode("utf-8")
+        graph = Graph().parse(data=text, format="turtle")
+    except Exception as exc:
+        return (
+            _issue(
+                "TURTLE_PARSE",
+                f"products.{product_key}.serialized_ontology",
+                f"cannot strictly parse UTF-8 Turtle: {type(exc).__name__}: {exc}",
+            ),
+        )
+
+    issues = list(
+        validate_emitted_ontology_metadata(
+            graph,
+            metadata,
+            product_key,
+            expected_imports,
+            mode=mode,
+        )
+    )
+    expected_header = render_ontology_header_bytes(
+        metadata,
+        product_key,
+        expected_imports,
+        generated_notice=generated_notice,
+        prefixes=prefixes,
+        import_turtle_terms=import_turtle_terms,
+    )
+    remainder = serialized_bytes[len(expected_header) :] if serialized_bytes.startswith(expected_header) else None
+    canonical_boundary = remainder == b"" or (
+        remainder is not None
+        and remainder.startswith(b"\n")
+        and not remainder.startswith(b"\n\n")
+    )
+    canonical_final_newline = serialized_bytes.endswith(b"\n") and not serialized_bytes.endswith(b"\n\n")
+    if remainder is None or not canonical_boundary or not canonical_final_newline:
+        issues.append(
+            _issue(
+                "NONCANONICAL_ONTOLOGY_HEADER",
+                f"products.{product_key}.serialized_ontology_header",
+                "generated preamble and ontology header differ from canonical byte rendering",
+            )
+        )
+    return tuple(sorted(set(issues), key=lambda value: (value.code, value.field, value.message)))
+
+
+def strip_emitted_ontology_header(
+    graph: Graph,
+    metadata: PublicationMetadata,
+    product_key: str,
+    expected_imports: tuple[str, ...],
+) -> Graph:
+    """Return a copy containing only governed/structural logical content."""
+
+    product = _product(metadata, product_key)
+    ontology = URIRef(product.stable_ontology_iri)
+    removed = {
+        (ontology, RDF.type, OWL.Ontology),
+        *((ontology, OWL.imports, URIRef(value)) for value in expected_imports),
+        *ontology_metadata_rdf_triples(metadata, product_key),
+    }
+    result = Graph()
+    for triple in graph:
+        if triple not in removed:
+            result.add(triple)
+    return result
+
+
+def validate_emitted_ontology_metadata(
+    graph: Graph,
+    metadata: PublicationMetadata,
+    product_key: str,
+    expected_imports: tuple[str, ...],
+    mode: str = "development",
+) -> tuple[ValidationIssue, ...]:
+    """Validate exact ontology identity, imports, and governed development metadata."""
+
+    issues: list[ValidationIssue] = []
+    if mode != "development":
+        return (
+            _issue(
+                "UNSUPPORTED_METADATA_MODE",
+                "ontology_metadata.mode",
+                "only development metadata emission is implemented",
+            ),
+        )
+
+    product = _product(metadata, product_key)
+    ontology = URIRef(product.stable_ontology_iri)
+    declarations = set(graph.triples((None, RDF.type, OWL.Ontology)))
+    expected_declaration = {(ontology, RDF.type, OWL.Ontology)}
+    if declarations != expected_declaration:
+        issues.append(
+            _issue(
+                "ONTOLOGY_DECLARATION_MISMATCH",
+                f"products.{product_key}.stable_ontology_iri",
+                f"expected {sorted(map(str, expected_declaration))}, got "
+                f"{sorted(map(str, declarations))}",
+            )
+        )
+
+    imports = set(graph.triples((None, OWL.imports, None)))
+    expected_import_triples = {
+        (ontology, OWL.imports, URIRef(value)) for value in expected_imports
+    }
+    if imports != expected_import_triples:
+        issues.append(
+            _issue(
+                "IMPORT_POLICY_MISMATCH",
+                f"products.{product_key}.imports",
+                f"expected {sorted(map(str, expected_import_triples))}, got "
+                f"{sorted(map(str, imports))}",
+            )
+        )
+
+    expected_metadata = ontology_metadata_rdf_triples(metadata, product_key)
+    expected_by_predicate = {
+        predicate: triple for triple in expected_metadata for predicate in (triple[1],)
+    }
+    governed_predicates = set(expected_by_predicate)
+    for predicate, expected in expected_by_predicate.items():
+        observed = set(graph.triples((None, predicate, None)))
+        if observed != {expected}:
+            issues.append(
+                _issue(
+                    "ONTOLOGY_METADATA_MISMATCH",
+                    f"products.{product_key}.{predicate}",
+                    f"expected {expected!r}, got {sorted(map(repr, observed))}",
+                )
+            )
+
+    allowed_subject_triples = {
+        *expected_declaration,
+        *expected_import_triples,
+        *expected_metadata,
+    }
+    extra_subject_triples = set(graph.triples((ontology, None, None))) - allowed_subject_triples
+    if extra_subject_triples:
+        issues.append(
+            _issue(
+                "UNAPPROVED_ONTOLOGY_METADATA",
+                f"products.{product_key}.ontology_subject",
+                "ontology subject contains unapproved triples: "
+                + ", ".join(sorted(map(repr, extra_subject_triples))),
+            )
+        )
+
+    for predicate in governed_predicates:
+        misplaced = {
+            triple
+            for triple in graph.triples((None, predicate, None))
+            if triple[0] != ontology
+        }
+        if misplaced:
+            issues.append(
+                _issue(
+                    "MISPLACED_ONTOLOGY_METADATA",
+                    f"products.{product_key}.{predicate}",
+                    "metadata occurs on a non-ontology subject",
+                )
+            )
+
+    for predicate_iri in RELEASE_ONLY_PREDICATES:
+        triples = set(graph.triples((None, URIRef(predicate_iri), None)))
+        if triples:
+            issues.append(
+                _issue(
+                    "RELEASE_METADATA_IN_DEVELOPMENT",
+                    f"products.{product_key}.{predicate_iri}",
+                    "formal-release metadata is prohibited in development output",
+                )
+            )
+
+    controlled_iris = (
+        URIRef(product.product_type_iri),
+        URIRef(metadata.publication.development_status_iri),
+    )
+    for controlled in controlled_iris:
+        if any(True for _ in graph.triples((controlled, RDF.type, None))):
+            issues.append(
+                _issue(
+                    "CONTROLLED_IRI_DECLARATION",
+                    f"products.{product_key}.controlled_iri",
+                    f"declaration triples for {controlled} are prohibited",
+                )
+            )
+
+    return tuple(sorted(set(issues), key=lambda value: (value.code, value.field, value.message)))
 
 
 def _table(

--- a/tools/watch_coms_mapping.py
+++ b/tools/watch_coms_mapping.py
@@ -81,6 +81,35 @@ def last_success_coverage_status() -> str | None:
     )
 
 
+def last_success_metadata_status() -> str | None:
+    try:
+        payload = json.loads(LAST_SUCCESS.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    counts = [payload.get("generated_candidate_metadata_annotation_count")]
+    for product_key in (
+        "alignment_core",
+        "strict_bfo_mapping",
+        "bfo_projection",
+        "cco_extension",
+    ):
+        product = payload.get(product_key)
+        counts.append(
+            product.get("metadata_annotation_count")
+            if isinstance(product, dict)
+            else None
+        )
+    if any(value is None for value in counts):
+        return None
+    return "Development metadata annotations: " + ", ".join(
+        f"{key} {count}"
+        for key, count in zip(
+            ("integrated", "alignment core", "strict BFO", "BFO projection", "CCO extension"),
+            counts,
+        )
+    )
+
+
 def run_check(trigger: str, workbook_hash: str | None) -> bool:
     started = time.perf_counter()
     print(f"Detection time: {now_text()}", flush=True)
@@ -96,6 +125,9 @@ def run_check(trigger: str, workbook_hash: str | None) -> bool:
         coverage_status = last_success_coverage_status()
         if coverage_status is not None:
             print(coverage_status, flush=True)
+        metadata_status = last_success_metadata_status()
+        if metadata_status is not None:
+            print(metadata_status, flush=True)
     return passed
 
 


### PR DESCRIPTION
# Emit deterministic publication metadata

## Changed files

- README.md
- SSN2BFO.ttl
- releases/current-ssn-sosa/ssn-sosa-alignment-core.ttl
- releases/current-ssn-sosa/ssn-sosa-bfo-mapping.ttl
- releases/current-ssn-sosa/ssn-sosa-bfo-projection.ttl
- releases/current-ssn-sosa/ssn-sosa-cco-extension.ttl
- reports/coms-automatic-validation-setup.md
- reports/coms-generation-validation.md
- reports/coms-product-dispositions.json
- reports/publication-product-and-import-policy.md
- tests/test_bfo_projection.py
- tests/test_cco_extension.py
- tests/test_generate_mapping_from_coms.py
- tests/test_modular_products.py
- tests/test_publication_metadata.py
- tests/test_strict_bfo_mapping.py
- tools/check_coms_mapping.py
- tools/generate_mapping_from_coms.py
- tools/modular_products.py
- tools/publication_metadata.py
- tools/watch_coms_mapping.py

## Validation

- Human gate required: confirm validation output before merge.
