### PR TITLE
Use governed ROBOT for retained example validation

### DIFF
--- a/reports/robot-substitution-audit.md
+++ b/reports/robot-substitution-audit.md
@@ -80,13 +80,12 @@ The repository already uses ROBOT for:
 - controlled release reasoning;
 - some ontology conversion.
 
-However, ROBOT is invoked through several separate Python wrappers and an older
-retained Makefile.
+ROBOT is still invoked through several separate Python wrappers.
 
-The repository-governed toolchain pins ROBOT 1.9.7, while
-`src/current-ssn-sosa/Makefile` still downloads ROBOT 1.9.5 directly. That
-second installation path should eventually be retired or redirected to the
-governed launcher.
+The older retained example-validation Makefile previously downloaded ROBOT
+1.9.5 independently. It now delegates to
+`tools/install_validation_robot.sh`, so example validation uses the governed
+ROBOT 1.9.7 version, checksum, and Java heap configuration.
 
 ## Mapping-axiom generation
 
@@ -436,14 +435,17 @@ Only after exact equivalence is stable:
 - import extraction;
 - the retained example-validation Makefile.
 
-## Immediate cleanup recommendation
+## Completed immediate cleanup
 
-Update or retire `src/current-ssn-sosa/Makefile` so it no longer downloads
-ROBOT 1.9.5 independently.
+`src/current-ssn-sosa/Makefile` now uses the repository-governed ROBOT installer
+instead of downloading ROBOT 1.9.5 independently.
 
-It should use the repository-governed ROBOT 1.9.7 launcher and checksum policy.
+Both supported invocation paths were verified successfully:
 
-This is a low-risk improvement even if no broader substitution is performed.
+- `make -C src/current-ssn-sosa validate-examples`;
+- `make -C src validate-examples`.
+
+All 11 retained Turtle examples parsed successfully using governed ROBOT 1.9.7.
 
 ## Final assessment
 

--- a/src/current-ssn-sosa/Makefile
+++ b/src/current-ssn-sosa/Makefile
@@ -1,37 +1,37 @@
 #### Parse validation for retained current SSN/SOSA examples
 
 config.TEMP_DIR      := build/artifacts
-config.LIBRARY_DIR   := ../../build/lib
 config.EXAMPLES_DIR  := examples
 
+REPOSITORY_ROOT := $(abspath ../..)
+ROBOT_INSTALLER := $(REPOSITORY_ROOT)/tools/install_validation_robot.sh
 EXAMPLE_VALIDATION_DIR := $(config.TEMP_DIR)/example-validation
-ROBOT_FILE := $(config.LIBRARY_DIR)/robot.jar
-ROBOT := java -jar $(ROBOT_FILE)
 
 .PHONY: all validate-examples clean
 all: validate-examples
 
-validate-examples: | $(EXAMPLE_VALIDATION_DIR) $(ROBOT_FILE)
-	@files="$$(find $(config.EXAMPLES_DIR) -type f -name '*.ttl' | sort)"; \
+validate-examples: | $(EXAMPLE_VALIDATION_DIR)
+	@robot_bin="$$( "$(ROBOT_INSTALLER)" )"; \
+	robot="$$robot_bin/robot"; \
+	files="$$(find $(config.EXAMPLES_DIR) -type f -name '*.ttl' | sort)"; \
 	if [ -z "$$files" ]; then \
 		echo "No Turtle example files found under $(config.EXAMPLES_DIR)."; \
 	else \
 		for file in $$files; do \
 			out="$(EXAMPLE_VALIDATION_DIR)/$$(printf '%s' "$$file" | sed 's#[/.]#_#g').ttl"; \
 			echo "Parse-checking $$file"; \
-			$(ROBOT) convert --input "$$file" --format ttl --output "$$out"; \
+			"$$robot" convert --input "$$file" --format ttl --output "$$out"; \
 		done; \
 	fi
 
-$(EXAMPLE_VALIDATION_DIR) $(config.LIBRARY_DIR):
+$(EXAMPLE_VALIDATION_DIR):
 	mkdir -p $@
-
-$(ROBOT_FILE): | $(config.LIBRARY_DIR)
-	curl -L -o $@ https://github.com/ontodev/robot/releases/download/v1.9.5/robot.jar
 
 clean:
 	@[ "$(config.TEMP_DIR)" ] || ( echo ">> config.TEMP_DIR is not set"; exit 1 )
 	rm -rf $(config.TEMP_DIR)
+	mkdir -p $(config.TEMP_DIR)
+	touch $(config.TEMP_DIR)/.gitkeep
 
 MAKEFLAGS += --warn-undefined-variables
 SHELL := bash


### PR DESCRIPTION
## Summary

Updates retained SSN/SOSA example validation to use the repository-governed ROBOT installer.

## Changes

- removes the independent ROBOT 1.9.5 download path;
- delegates to `tools/install_validation_robot.sh`;
- uses governed ROBOT 1.9.7, checksum verification, and Java heap configuration;
- preserves the tracked build placeholder during `make clean`;
- updates the ROBOT substitution audit to mark this cleanup complete.

## Validation

Both supported invocation paths passed:

- `make -C src/current-ssn-sosa validate-examples`
- `make -C src validate-examples`

All 11 retained Turtle examples parsed successfully.
