### PR TITLE
Add normalized ROBOT Template generation pilot

### DIFF
--- a/reports/robot-substitution-audit.md
+++ b/reports/robot-substitution-audit.md
@@ -139,24 +139,46 @@ because the COMS lexical expressions use project-specific CURIE-like names for
 properties inside Manchester expressions. ROBOT Template requires those
 properties to be resolvable by its Manchester parser.
 
-### Python normalization
+### Normalized ROBOT Template pilot
 
-The existing COMS generator already resolves lexical expressions into
-structured expression nodes and canonical full IRIs.
+The normalized pilot is now implemented as a read-only comparison path in
+`tools/robot_template_generation_pilot.py`.
 
-A small deterministic Python renderer can convert those structures into
-ROBOT-compatible Manchester expressions:
+The existing COMS generator continues to resolve workbook expressions into
+structured expression nodes and canonical full IRIs. The pilot then produces:
 
-- named class → `<full-IRI>`;
-- intersection → `(A and B)`;
-- union → `(A or B)`;
-- existential restriction → `(<property-IRI> some Filler)`.
+- deterministic temporary labels for every class and object property used in
+  a class expression;
+- a generated resolver ontology containing those labels;
+- a generated ROBOT Template TSV using the temporary labels;
+- a ROBOT-generated comparison ontology;
+- an exact canonical-axiom comparison against the authoritative COMS
+  identities.
 
-This should allow ROBOT Template to generate all 44 class mappings without
-depending on labels or project-specific CURIE resolution.
+Temporary labels are required because ROBOT 1.9.7 does not accept full class or
+property IRIs inside Manchester restriction expressions. These labels are
+generated implementation details and do not appear in the COMS workbook or any
+maintained ontology product.
 
-That normalized pilot has not yet been completed and must be treated as a
-proposed next validation step, not a proven result.
+Results:
+
+| Measure | Result |
+| --- | ---: |
+| Governed COMS rows | 105 |
+| Attempted non-chain rows | 100 |
+| Excluded property-chain rows | 5 |
+| Expected canonical axioms | 100 |
+| ROBOT canonical axioms | 100 |
+| Missing axioms | 0 |
+| Extra axioms | 0 |
+| Mismatched axioms | 0 |
+| Resolver entities | 82 |
+| Pilot summary | PASS |
+
+The generated resolver ontology and normalized template are byte-deterministic
+across separate runs and different Python hash seeds. The five maintained
+ontology products remain unchanged because the current Python generator remains
+authoritative during this phase.
 
 ### Property chains
 

--- a/tests/test_robot_template_generation_pilot.py
+++ b/tests/test_robot_template_generation_pilot.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+"""Focused tests for normalized ROBOT Template generation from governed COMS rows."""
+
+from __future__ import annotations
+
+import hashlib
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT / "tools"))
+
+import robot_template_generation_pilot as pilot  # noqa: E402
+from coms_row_identity import ExpressionNode  # noqa: E402
+
+
+WORKBOOK = REPO_ROOT / "mappings/SSN2BFO-COMS.xlsx"
+
+MAINTAINED_PRODUCTS = (
+    REPO_ROOT / "SSN2BFO.ttl",
+    REPO_ROOT / "releases/current-ssn-sosa/ssn-sosa-alignment-core.ttl",
+    REPO_ROOT / "releases/current-ssn-sosa/ssn-sosa-bfo-mapping.ttl",
+    REPO_ROOT / "releases/current-ssn-sosa/ssn-sosa-bfo-projection.ttl",
+    REPO_ROOT / "releases/current-ssn-sosa/ssn-sosa-cco-extension.ttl",
+)
+
+
+def sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+class RobotTemplateGenerationPilotTests(unittest.TestCase):
+    def test_normalized_expression_uses_generated_labels(self) -> None:
+        class_a = "http://example.org/ClassA"
+        class_b = "http://example.org/ClassB"
+        property_a = "http://example.org/propertyA"
+
+        expression = ExpressionNode(
+            kind="intersection",
+            children=(
+                ExpressionNode(kind="named", iri=class_a),
+                ExpressionNode(
+                    kind="some",
+                    property_iri=property_a,
+                    filler=ExpressionNode(kind="named", iri=class_b),
+                ),
+            ),
+        )
+
+        labels = {
+            ("class", class_a): pilot.deterministic_label("class", class_a),
+            ("class", class_b): pilot.deterministic_label("class", class_b),
+            ("property", property_a): pilot.deterministic_label(
+                "property",
+                property_a,
+            ),
+        }
+
+        rendered = pilot.render_manchester_expression(expression, labels)
+
+        self.assertNotIn(class_a, rendered)
+        self.assertNotIn(class_b, rendered)
+        self.assertNotIn(property_a, rendered)
+        self.assertIn(labels[("class", class_a)], rendered)
+        self.assertIn(labels[("class", class_b)], rendered)
+        self.assertIn(labels[("property", property_a)], rendered)
+        self.assertIn(" and ", rendered)
+        self.assertIn(" some ", rendered)
+
+    def test_governed_workbook_reconstructs_all_non_chain_axioms(self) -> None:
+        before = {
+            path.relative_to(REPO_ROOT).as_posix(): sha256(path)
+            for path in MAINTAINED_PRODUCTS
+        }
+
+        with tempfile.TemporaryDirectory(
+            prefix="robot-template-pilot-a-"
+        ) as first_dir, tempfile.TemporaryDirectory(
+            prefix="robot-template-pilot-b-"
+        ) as second_dir:
+            first_root = Path(first_dir)
+            second_root = Path(second_dir)
+
+            first = pilot.run_pilot(WORKBOOK, first_root)
+            second = pilot.run_pilot(WORKBOOK, second_root)
+
+            self.assertTrue(first["passed"], first)
+            self.assertTrue(second["passed"], second)
+
+            for summary in (first, second):
+                self.assertEqual(summary["governed_row_count"], 105)
+                self.assertEqual(summary["attempted_non_chain_rows"], 100)
+                self.assertEqual(summary["excluded_property_chain_rows"], 5)
+                self.assertEqual(summary["expected_axiom_count"], 100)
+                self.assertEqual(summary["actual_axiom_count"], 100)
+                self.assertEqual(summary["robot_return_code"], 0)
+                self.assertEqual(summary["missing_axiom_ids"], [])
+                self.assertEqual(summary["extra_axiom_ids"], [])
+                self.assertEqual(summary["mismatched_axiom_ids"], [])
+
+            first_artifacts = pilot.artifact_paths(first_root)
+            second_artifacts = pilot.artifact_paths(second_root)
+
+            self.assertEqual(
+                first_artifacts.resolver_path.read_bytes(),
+                second_artifacts.resolver_path.read_bytes(),
+            )
+            self.assertEqual(
+                first_artifacts.template_path.read_bytes(),
+                second_artifacts.template_path.read_bytes(),
+            )
+
+        after = {
+            path.relative_to(REPO_ROOT).as_posix(): sha256(path)
+            for path in MAINTAINED_PRODUCTS
+        }
+        self.assertEqual(before, after)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/robot_template_generation_pilot.py
+++ b/tools/robot_template_generation_pilot.py
@@ -1,0 +1,508 @@
+#!/usr/bin/env python3
+"""Generate and validate a normalized ROBOT Template view of governed COMS rows."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import hashlib
+import json
+import shutil
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable
+
+from rdflib import Graph, Literal, URIRef
+
+import generate_mapping_from_coms as coms
+import modular_products as modular
+from coms_row_identity import (
+    CanonicalRowInput,
+    ExpressionNode,
+    OWL_EQUIVALENT_CLASS,
+    OWL_EQUIVALENT_PROPERTY,
+    RDFS_DOMAIN,
+    RDFS_RANGE,
+    RDFS_SUBCLASS_OF,
+    RDFS_SUBPROPERTY_OF,
+)
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+PILOT_ONTOLOGY_IRI = "http://www.sks.ai/SSN2BFO/pilots/robot-template-normalized"
+
+TEMPLATE_HEADER = (
+    "ID",
+    "Type",
+    "SubClassOf",
+    "EquivalentClass",
+    "SubPropertyOf",
+    "EquivalentProperty",
+    "Domain",
+    "Range",
+)
+
+TEMPLATE_DIRECTIVES = (
+    "ID",
+    "TYPE",
+    "SC %",
+    "EC %",
+    "SP %",
+    "EP %",
+    "DOMAIN",
+    "RANGE",
+)
+
+SUPPORTED_MAPPING_TYPES = frozenset(
+    {
+        "class_mapping",
+        "object_property_mapping",
+        "domain",
+        "range",
+    }
+)
+
+
+@dataclass(frozen=True)
+class PilotArtifacts:
+    resolver_path: Path
+    template_path: Path
+    output_path: Path
+    errors_path: Path
+    summary_path: Path
+
+
+def deterministic_label(kind: str, iri: str) -> str:
+    if kind not in {"class", "property"}:
+        raise ValueError(f"unsupported ROBOT label kind: {kind}")
+    digest = hashlib.sha256(iri.encode("utf-8")).hexdigest()
+    return f"__robot_{kind}_{digest}"
+
+
+def _flatten_expression(
+    expression: ExpressionNode,
+    kind: str,
+) -> tuple[ExpressionNode, ...]:
+    flattened: list[ExpressionNode] = []
+    for child in expression.children:
+        if child.kind == kind:
+            flattened.extend(_flatten_expression(child, kind))
+        else:
+            flattened.append(child)
+    return tuple(flattened)
+
+
+def collect_expression_entities(
+    expression: ExpressionNode,
+    classes: set[str],
+    properties: set[str],
+) -> None:
+    if expression.kind == "named":
+        if expression.iri is None:
+            raise ValueError("named expression lacks an IRI")
+        classes.add(expression.iri)
+        return
+
+    if expression.kind in {"intersection", "union"}:
+        if not expression.children:
+            raise ValueError(f"{expression.kind} expression has no operands")
+        for child in expression.children:
+            collect_expression_entities(child, classes, properties)
+        return
+
+    if expression.kind == "some":
+        if expression.property_iri is None or expression.filler is None:
+            raise ValueError("existential restriction is incomplete")
+        properties.add(expression.property_iri)
+        collect_expression_entities(expression.filler, classes, properties)
+        return
+
+    raise ValueError(f"unsupported expression kind: {expression.kind}")
+
+
+def build_entity_labels(
+    rows: Iterable[CanonicalRowInput],
+) -> dict[tuple[str, str], str]:
+    classes: set[str] = set()
+    properties: set[str] = set()
+
+    for row in rows:
+        if row.expression is not None:
+            collect_expression_entities(row.expression, classes, properties)
+        if row.target_property_iri is not None:
+            properties.add(row.target_property_iri)
+
+    labels: dict[tuple[str, str], str] = {}
+    for iri in sorted(classes):
+        labels[("class", iri)] = deterministic_label("class", iri)
+    for iri in sorted(properties):
+        labels[("property", iri)] = deterministic_label("property", iri)
+    return labels
+
+
+def _quoted_label(kind: str, iri: str, labels: dict[tuple[str, str], str]) -> str:
+    try:
+        label = labels[(kind, iri)]
+    except KeyError as exc:
+        raise ValueError(f"missing generated {kind} label for {iri}") from exc
+    return f"'{label}'"
+
+
+def render_manchester_expression(
+    expression: ExpressionNode,
+    labels: dict[tuple[str, str], str],
+) -> str:
+    if expression.kind == "named":
+        if expression.iri is None:
+            raise ValueError("named expression lacks an IRI")
+        return _quoted_label("class", expression.iri, labels)
+
+    if expression.kind in {"intersection", "union"}:
+        flattened = _flatten_expression(expression, expression.kind)
+        rendered = sorted(
+            {
+                render_manchester_expression(child, labels)
+                for child in flattened
+            }
+        )
+        if not rendered:
+            raise ValueError(f"{expression.kind} expression has no operands")
+        if len(rendered) == 1:
+            return rendered[0]
+        operator = " and " if expression.kind == "intersection" else " or "
+        return f"({operator.join(rendered)})"
+
+    if expression.kind == "some":
+        if expression.property_iri is None or expression.filler is None:
+            raise ValueError("existential restriction is incomplete")
+        property_label = _quoted_label(
+            "property",
+            expression.property_iri,
+            labels,
+        )
+        filler = render_manchester_expression(expression.filler, labels)
+        return f"({property_label} some {filler})"
+
+    raise ValueError(f"unsupported expression kind: {expression.kind}")
+
+
+def _template_row(
+    row: CanonicalRowInput,
+    labels: dict[tuple[str, str], str],
+) -> tuple[str, ...]:
+    values = [""] * len(TEMPLATE_HEADER)
+    values[0] = row.subject_iri
+
+    if row.mapping_type == "class_mapping":
+        values[1] = "owl:Class"
+        if row.expression is None:
+            raise ValueError(f"{row.row_id}: class mapping lacks expression")
+        target = render_manchester_expression(row.expression, labels)
+        if row.predicate_iri == RDFS_SUBCLASS_OF:
+            values[2] = target
+        elif row.predicate_iri == OWL_EQUIVALENT_CLASS:
+            values[3] = target
+        else:
+            raise ValueError(
+                f"{row.row_id}: unsupported class predicate {row.predicate_iri}"
+            )
+
+    elif row.mapping_type == "object_property_mapping":
+        values[1] = "owl:ObjectProperty"
+        if row.target_property_iri is None:
+            raise ValueError(
+                f"{row.row_id}: object-property mapping lacks target property"
+            )
+        target = _quoted_label(
+            "property",
+            row.target_property_iri,
+            labels,
+        )
+        if row.predicate_iri == RDFS_SUBPROPERTY_OF:
+            values[4] = target
+        elif row.predicate_iri == OWL_EQUIVALENT_PROPERTY:
+            values[5] = target
+        else:
+            raise ValueError(
+                f"{row.row_id}: unsupported property predicate {row.predicate_iri}"
+            )
+
+    elif row.mapping_type in {"domain", "range"}:
+        values[1] = "owl:ObjectProperty"
+        if row.expression is None:
+            raise ValueError(f"{row.row_id}: {row.mapping_type} lacks expression")
+        target = render_manchester_expression(row.expression, labels)
+        expected_predicate = RDFS_DOMAIN if row.mapping_type == "domain" else RDFS_RANGE
+        if row.predicate_iri != expected_predicate:
+            raise ValueError(
+                f"{row.row_id}: {row.mapping_type} predicate mismatch"
+            )
+        values[6 if row.mapping_type == "domain" else 7] = target
+
+    else:
+        raise ValueError(
+            f"{row.row_id}: unsupported pilot mapping type {row.mapping_type}"
+        )
+
+    return tuple(values)
+
+
+def write_resolver_ontology(
+    labels: dict[tuple[str, str], str],
+    path: Path,
+) -> None:
+    lines = [
+        "@prefix owl: <http://www.w3.org/2002/07/owl#> .",
+        "@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .",
+        "",
+        f"<{PILOT_ONTOLOGY_IRI}/resolver> a owl:Ontology .",
+    ]
+
+    for (kind, iri), label in sorted(labels.items()):
+        owl_type = "owl:Class" if kind == "class" else "owl:ObjectProperty"
+        lines.extend(
+            [
+                "",
+                f"{URIRef(iri).n3()} a {owl_type} ;",
+                f"    rdfs:label {Literal(label).n3()} .",
+            ]
+        )
+
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def write_template(
+    rows: Iterable[CanonicalRowInput],
+    labels: dict[tuple[str, str], str],
+    path: Path,
+) -> tuple[CanonicalRowInput, ...]:
+    selected = tuple(
+        sorted(
+            (
+                row
+                for row in rows
+                if row.mapping_type in SUPPORTED_MAPPING_TYPES
+            ),
+            key=lambda row: row.row_id,
+        )
+    )
+
+    with path.open("w", encoding="utf-8", newline="") as handle:
+        writer = csv.writer(
+            handle,
+            delimiter="\t",
+            lineterminator="\n",
+        )
+        writer.writerow(TEMPLATE_HEADER)
+        writer.writerow(TEMPLATE_DIRECTIVES)
+        for row in selected:
+            writer.writerow(_template_row(row, labels))
+
+    return selected
+
+
+def canonical_expected_axioms(
+    processed_rows: Iterable[coms.ProcessedRow],
+) -> dict[str, str]:
+    expected: dict[str, str] = {}
+
+    for processed in processed_rows:
+        row = coms.canonical_input_for_processed_row(processed)
+        if row.mapping_type not in SUPPORTED_MAPPING_TYPES:
+            continue
+        if processed.identity_audit is None:
+            raise ValueError(f"{row.row_id}: canonical identity audit is missing")
+
+        for identity in processed.identity_audit.authoritative_axioms:
+            axiom_id = (
+                "sha256:"
+                + hashlib.sha256(
+                    identity.canonical_axiom.encode("utf-8")
+                ).hexdigest()
+            )
+            expected[axiom_id] = identity.canonical_axiom
+
+    return expected
+
+
+def artifact_paths(output_dir: Path) -> PilotArtifacts:
+    return PilotArtifacts(
+        resolver_path=output_dir / "resolver.ttl",
+        template_path=output_dir / "normalized-template.tsv",
+        output_path=output_dir / "robot-output.ttl",
+        errors_path=output_dir / "robot-errors.tsv",
+        summary_path=output_dir / "summary.json",
+    )
+
+
+def run_pilot(
+    workbook_path: Path,
+    output_dir: Path,
+    robot_path: str | None = None,
+) -> dict[str, object]:
+    workbook_path = workbook_path.resolve()
+    output_dir.mkdir(parents=True, exist_ok=True)
+    artifacts = artifact_paths(output_dir)
+
+    rows, stats = coms.read_workbook(workbook_path)
+    processed = coms.validate_and_process_rows(
+        rows,
+        coms.Resolver(),
+        stats,
+    )
+    canonical_rows = tuple(
+        coms.canonical_input_for_processed_row(row)
+        for row in processed
+    )
+
+    labels = build_entity_labels(canonical_rows)
+    selected = write_template(
+        canonical_rows,
+        labels,
+        artifacts.template_path,
+    )
+    write_resolver_ontology(labels, artifacts.resolver_path)
+
+    artifacts.output_path.unlink(missing_ok=True)
+    artifacts.errors_path.unlink(missing_ok=True)
+
+    robot = robot_path or shutil.which("robot")
+    if robot is None:
+        raise RuntimeError("ROBOT executable not found on PATH")
+
+    completed = subprocess.run(
+        [
+            robot,
+            "template",
+            "--input",
+            str(artifacts.resolver_path),
+            "--template",
+            str(artifacts.template_path),
+            "--ontology-iri",
+            PILOT_ONTOLOGY_IRI,
+            "--errors",
+            str(artifacts.errors_path),
+            "--output",
+            str(artifacts.output_path),
+        ],
+        cwd=REPO_ROOT,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+    expected = canonical_expected_axioms(processed)
+    actual: dict[str, str] = {}
+
+    if artifacts.output_path.exists():
+        graph = Graph().parse(artifacts.output_path, format="turtle")
+        actual = {
+            axiom_id: value[0]
+            for axiom_id, value in modular._canonical_graph_axioms(
+                graph,
+                ignore_unsupported=True,
+            ).items()
+        }
+
+    missing = sorted(set(expected) - set(actual))
+    extra = sorted(set(actual) - set(expected))
+    mismatched = sorted(
+        axiom_id
+        for axiom_id in set(expected) & set(actual)
+        if expected[axiom_id] != actual[axiom_id]
+    )
+
+    passed = (
+        completed.returncode == 0
+        and len(selected) == 100
+        and len(expected) == 100
+        and len(actual) == 100
+        and not missing
+        and not extra
+        and not mismatched
+    )
+
+    summary: dict[str, object] = {
+        "passed": passed,
+        "robot_path": robot,
+        "robot_return_code": completed.returncode,
+        "robot_output": "\n".join(
+            part
+            for part in (
+                completed.stdout.strip(),
+                completed.stderr.strip(),
+            )
+            if part
+        ),
+        "workbook": str(workbook_path),
+        "governed_row_count": len(processed),
+        "attempted_non_chain_rows": len(selected),
+        "excluded_property_chain_rows": sum(
+            row.mapping_type == "property_chain"
+            for row in canonical_rows
+        ),
+        "expected_axiom_count": len(expected),
+        "actual_axiom_count": len(actual),
+        "missing_axiom_ids": missing,
+        "extra_axiom_ids": extra,
+        "mismatched_axiom_ids": mismatched,
+        "resolver_entity_count": len(labels),
+        "resolver_sha256": hashlib.sha256(
+            artifacts.resolver_path.read_bytes()
+        ).hexdigest(),
+        "template_sha256": hashlib.sha256(
+            artifacts.template_path.read_bytes()
+        ).hexdigest(),
+    }
+
+    artifacts.summary_path.write_text(
+        json.dumps(summary, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    return summary
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--input",
+        default=str(REPO_ROOT / "mappings/SSN2BFO-COMS.xlsx"),
+        help="Governed COMS workbook.",
+    )
+    parser.add_argument(
+        "--output-dir",
+        required=True,
+        help="Directory for temporary pilot artifacts.",
+    )
+    parser.add_argument(
+        "--robot",
+        help="Optional explicit ROBOT executable path.",
+    )
+    args = parser.parse_args(argv)
+
+    summary = run_pilot(
+        Path(args.input),
+        Path(args.output_dir),
+        args.robot,
+    )
+
+    print(f"Governed rows: {summary['governed_row_count']}")
+    print(f"Attempted non-chain rows: {summary['attempted_non_chain_rows']}")
+    print(f"Excluded property-chain rows: {summary['excluded_property_chain_rows']}")
+    print(f"Expected canonical axioms: {summary['expected_axiom_count']}")
+    print(f"ROBOT canonical axioms: {summary['actual_axiom_count']}")
+    print(f"ROBOT return code: {summary['robot_return_code']}")
+    print(f"Missing axioms: {len(summary['missing_axiom_ids'])}")
+    print(f"Extra axioms: {len(summary['extra_axiom_ids'])}")
+    print(f"Mismatched axioms: {len(summary['mismatched_axiom_ids'])}")
+    print("Summary: PASS" if summary["passed"] else "Summary: FAIL")
+
+    if summary["robot_output"]:
+        print(summary["robot_output"])
+
+    return 0 if summary["passed"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/run_validation_suite.py
+++ b/tools/run_validation_suite.py
@@ -396,6 +396,7 @@ def compile_check() -> StepResult:
             "tools/product_dispositions.py",
             "tools/modular_products.py",
             "tools/generate_mapping_from_coms.py",
+            "tools/robot_template_generation_pilot.py",
             "tools/check_coms_mapping.py",
             "tools/watch_coms_mapping.py",
             "tools/publication_metadata.py",
@@ -407,6 +408,7 @@ def compile_check() -> StepResult:
             "tools/release_archive.py",
             "tools/rehearse_release.py",
             "tests/test_generate_mapping_from_coms.py",
+            "tests/test_robot_template_generation_pilot.py",
             "tests/test_coms_row_identity.py",
             "tests/test_product_dispositions.py",
             "tests/test_modular_products.py",
@@ -713,6 +715,22 @@ def run_validation_suite(args: argparse.Namespace) -> int:
                     "tests",
                     "-p",
                     "test_generate_mapping_from_coms.py",
+                ],
+            )
+        )
+    if results[-1].passed:
+        results.append(
+            run_command(
+                "Normalized ROBOT Template generation focused tests",
+                [
+                    sys.executable,
+                    "-m",
+                    "unittest",
+                    "discover",
+                    "-s",
+                    "tests",
+                    "-p",
+                    "test_robot_template_generation_pilot.py",
                 ],
             )
         )


### PR DESCRIPTION
## Summary

- add a read-only normalized ROBOT Template generation pilot
- preserve the existing COMS workbook format and authoritative Python generation path
- generate deterministic temporary labels and a resolver ontology for Manchester parsing
- reconstruct the 100 governed non-property-chain axioms through ROBOT Template
- compare ROBOT output against canonical COMS axiom identities
- leave the five property-chain mappings on the existing Python path
- add the pilot to the authoritative validation suite
- update the ROBOT substitution audit with completed results

## Results

- governed COMS rows: 105
- non-chain rows attempted: 100
- property-chain rows excluded: 5
- expected canonical axioms: 100
- ROBOT canonical axioms: 100
- missing axioms: 0
- extra axioms: 0
- mismatched axioms: 0
- normalized template and resolver ontology are byte-deterministic
- maintained ontology products remain unchanged
- `make check` passes
