### PR TITLE
Add ROBOT property-chain generation pilot

### DIFF
--- a/reports/robot-substitution-audit.md
+++ b/reports/robot-substitution-audit.md
@@ -180,20 +180,49 @@ across separate runs and different Python hash seeds. The five maintained
 ontology products remain unchanged because the current Python generator remains
 authoritative during this phase.
 
-### Property chains
+### Property-chain generation pilot
 
-The five property chains are not covered by the documented Template pilot.
+The five governed property-chain rows are now covered by a separate read-only
+pilot in `tools/robot_property_chain_generation_pilot.py`.
 
-Options include:
+The pilot:
 
-1. retain current Python chain emission initially;
-2. produce them as canonical OWL Functional Syntax and let ROBOT parse and
-   serialize them;
-3. generate controlled RDF list structures and merge them through ROBOT;
-4. use a narrowly governed SPARQL construction step.
+1. selects the five canonical `property_chain` rows produced from the unchanged
+   COMS workbook;
+2. emits deterministic OWL Functional Syntax using the already-resolved member
+   and super-property IRIs;
+3. invokes `robot convert --strict` to parse and serialize the temporary
+   ontology;
+4. canonicalizes ROBOT's RDF property-chain structures through the existing
+   graph-to-axiom comparison machinery;
+5. compares the result with the authoritative COMS axiom identities.
 
-The safest initial architecture is to retain the five current chain mappings
-until exact cross-tool equivalence is demonstrated.
+Results:
+
+| Measure | Result |
+| --- | ---: |
+| Governed COMS rows | 105 |
+| Attempted property-chain rows | 5 |
+| Expected canonical axioms | 5 |
+| ROBOT canonical axioms | 5 |
+| Missing axioms | 0 |
+| Extra axioms | 0 |
+| Mismatched axioms | 0 |
+| Declared object properties | 17 |
+| Pilot summary | PASS |
+
+The generated Functional Syntax is byte-deterministic across separate runs and
+different Python hash seeds. ROBOT outputs are graph-isomorphic across runs.
+
+Combined with the normalized Template pilot, ROBOT now independently
+reconstructs all 105 governed COMS axioms exactly:
+
+- 100 non-chain axioms through normalized ROBOT Template input;
+- 5 property-chain axioms through normalized OWL Functional Syntax;
+- 0 missing, extra, or mismatched canonical axioms.
+
+The current Python generator remains authoritative, and all five maintained
+ontology products remain unchanged.
 
 ## Recommended generation architecture
 

--- a/tests/test_robot_property_chain_generation_pilot.py
+++ b/tests/test_robot_property_chain_generation_pilot.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+"""Focused tests for ROBOT property-chain generation from governed COMS rows."""
+
+from __future__ import annotations
+
+import hashlib
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+from rdflib import Graph
+from rdflib.compare import isomorphic
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT / "tools"))
+
+import robot_property_chain_generation_pilot as pilot  # noqa: E402
+
+
+WORKBOOK = REPO_ROOT / "mappings/SSN2BFO-COMS.xlsx"
+
+MAINTAINED_PRODUCTS = (
+    REPO_ROOT / "SSN2BFO.ttl",
+    REPO_ROOT / "releases/current-ssn-sosa/ssn-sosa-alignment-core.ttl",
+    REPO_ROOT / "releases/current-ssn-sosa/ssn-sosa-bfo-mapping.ttl",
+    REPO_ROOT / "releases/current-ssn-sosa/ssn-sosa-bfo-projection.ttl",
+    REPO_ROOT / "releases/current-ssn-sosa/ssn-sosa-cco-extension.ttl",
+)
+
+
+def sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+class RobotPropertyChainGenerationPilotTests(unittest.TestCase):
+    def test_functional_iri_validation(self) -> None:
+        value = "http://example.org/property"
+        self.assertEqual(
+            pilot.functional_iri(value),
+            "<http://example.org/property>",
+        )
+
+        for invalid in (
+            "",
+            "http://example.org/has space",
+            "http://example.org/<invalid>",
+        ):
+            with self.subTest(invalid=invalid):
+                with self.assertRaises(ValueError):
+                    pilot.functional_iri(invalid)
+
+    def test_governed_workbook_reconstructs_all_property_chains(self) -> None:
+        before = {
+            path.relative_to(REPO_ROOT).as_posix(): sha256(path)
+            for path in MAINTAINED_PRODUCTS
+        }
+
+        with tempfile.TemporaryDirectory(
+            prefix="robot-property-chain-a-"
+        ) as first_dir, tempfile.TemporaryDirectory(
+            prefix="robot-property-chain-b-"
+        ) as second_dir:
+            first_root = Path(first_dir)
+            second_root = Path(second_dir)
+
+            first = pilot.run_pilot(WORKBOOK, first_root)
+            second = pilot.run_pilot(WORKBOOK, second_root)
+
+            self.assertTrue(first["passed"], first)
+            self.assertTrue(second["passed"], second)
+
+            for summary in (first, second):
+                self.assertEqual(summary["governed_row_count"], 105)
+                self.assertEqual(
+                    summary["attempted_property_chain_rows"],
+                    5,
+                )
+                self.assertEqual(summary["expected_axiom_count"], 5)
+                self.assertEqual(summary["actual_axiom_count"], 5)
+                self.assertEqual(summary["robot_return_code"], 0)
+                self.assertEqual(summary["missing_axiom_ids"], [])
+                self.assertEqual(summary["extra_axiom_ids"], [])
+                self.assertEqual(summary["mismatched_axiom_ids"], [])
+                self.assertEqual(summary["declared_property_count"], 17)
+
+            first_artifacts = pilot.artifact_paths(first_root)
+            second_artifacts = pilot.artifact_paths(second_root)
+
+            self.assertEqual(
+                first_artifacts.functional_syntax_path.read_bytes(),
+                second_artifacts.functional_syntax_path.read_bytes(),
+            )
+
+            first_graph = Graph().parse(
+                first_artifacts.output_path,
+                format="turtle",
+            )
+            second_graph = Graph().parse(
+                second_artifacts.output_path,
+                format="turtle",
+            )
+            self.assertTrue(isomorphic(first_graph, second_graph))
+
+        after = {
+            path.relative_to(REPO_ROOT).as_posix(): sha256(path)
+            for path in MAINTAINED_PRODUCTS
+        }
+        self.assertEqual(before, after)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/robot_property_chain_generation_pilot.py
+++ b/tools/robot_property_chain_generation_pilot.py
@@ -1,0 +1,334 @@
+#!/usr/bin/env python3
+"""Validate governed COMS property chains through ROBOT and OWL Functional Syntax."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import shutil
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable
+
+from rdflib import Graph
+
+import generate_mapping_from_coms as coms
+import modular_products as modular
+from coms_row_identity import CanonicalRowInput
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+PILOT_ONTOLOGY_IRI = (
+    "http://www.sks.ai/SSN2BFO/pilots/robot-property-chain-normalized"
+)
+
+
+@dataclass(frozen=True)
+class PilotArtifacts:
+    functional_syntax_path: Path
+    output_path: Path
+    summary_path: Path
+
+
+def functional_iri(value: str) -> str:
+    """Render one already-resolved IRI for OWL Functional Syntax."""
+
+    if (
+        not value
+        or any(character.isspace() for character in value)
+        or any(character in value for character in '<>"{}|^`\\')
+    ):
+        raise ValueError(f"cannot render Functional Syntax IRI {value!r}")
+    return f"<{value}>"
+
+
+def select_property_chain_rows(
+    rows: Iterable[CanonicalRowInput],
+) -> tuple[CanonicalRowInput, ...]:
+    selected = tuple(
+        sorted(
+            (
+                row
+                for row in rows
+                if row.mapping_type == "property_chain"
+            ),
+            key=lambda row: row.row_id,
+        )
+    )
+
+    for row in selected:
+        if not row.property_chain:
+            raise ValueError(
+                f"{row.row_id}: property-chain row has no members"
+            )
+        if len(row.property_chain) < 2:
+            raise ValueError(
+                f"{row.row_id}: property chain must contain at least two members"
+            )
+
+    return selected
+
+
+def write_functional_syntax(
+    rows: Iterable[CanonicalRowInput],
+    path: Path,
+) -> tuple[CanonicalRowInput, ...]:
+    selected = select_property_chain_rows(rows)
+
+    declared_properties = sorted(
+        {
+            row.subject_iri
+            for row in selected
+        }
+        | {
+            member
+            for row in selected
+            for member in row.property_chain
+        }
+    )
+
+    lines = [
+        f"Ontology({functional_iri(PILOT_ONTOLOGY_IRI)}",
+    ]
+
+    for property_iri in declared_properties:
+        lines.append(
+            "  Declaration("
+            f"ObjectProperty({functional_iri(property_iri)})"
+            ")"
+        )
+
+    if declared_properties and selected:
+        lines.append("")
+
+    for index, row in enumerate(selected):
+        members = " ".join(
+            functional_iri(member)
+            for member in row.property_chain
+        )
+        lines.extend(
+            [
+                "  SubObjectPropertyOf(",
+                f"    ObjectPropertyChain({members})",
+                f"    {functional_iri(row.subject_iri)}",
+                "  )",
+            ]
+        )
+        if index + 1 < len(selected):
+            lines.append("")
+
+    lines.append(")")
+    path.write_text(
+        "\n".join(lines) + "\n",
+        encoding="utf-8",
+    )
+    return selected
+
+
+def canonical_expected_axioms(
+    processed_rows: Iterable[coms.ProcessedRow],
+) -> dict[str, str]:
+    expected: dict[str, str] = {}
+
+    for processed in processed_rows:
+        row = coms.canonical_input_for_processed_row(processed)
+        if row.mapping_type != "property_chain":
+            continue
+        if processed.identity_audit is None:
+            raise ValueError(
+                f"{row.row_id}: canonical identity audit is missing"
+            )
+
+        for identity in processed.identity_audit.authoritative_axioms:
+            axiom_id = (
+                "sha256:"
+                + hashlib.sha256(
+                    identity.canonical_axiom.encode("utf-8")
+                ).hexdigest()
+            )
+            expected[axiom_id] = identity.canonical_axiom
+
+    return expected
+
+
+def artifact_paths(output_dir: Path) -> PilotArtifacts:
+    return PilotArtifacts(
+        functional_syntax_path=output_dir / "normalized-property-chains.ofn",
+        output_path=output_dir / "robot-property-chains.ttl",
+        summary_path=output_dir / "summary.json",
+    )
+
+
+def run_pilot(
+    workbook_path: Path,
+    output_dir: Path,
+    robot_path: str | None = None,
+) -> dict[str, object]:
+    workbook_path = workbook_path.resolve()
+    output_dir.mkdir(parents=True, exist_ok=True)
+    artifacts = artifact_paths(output_dir)
+
+    workbook_rows, stats = coms.read_workbook(workbook_path)
+    processed = coms.validate_and_process_rows(
+        workbook_rows,
+        coms.Resolver(),
+        stats,
+    )
+    canonical_rows = tuple(
+        coms.canonical_input_for_processed_row(row)
+        for row in processed
+    )
+
+    selected = write_functional_syntax(
+        canonical_rows,
+        artifacts.functional_syntax_path,
+    )
+
+    artifacts.output_path.unlink(missing_ok=True)
+
+    robot = robot_path or shutil.which("robot")
+    if robot is None:
+        raise RuntimeError("ROBOT executable not found on PATH")
+
+    completed = subprocess.run(
+        [
+            robot,
+            "convert",
+            "--strict",
+            "--input",
+            str(artifacts.functional_syntax_path),
+            "--format",
+            "ttl",
+            "--output",
+            str(artifacts.output_path),
+        ],
+        cwd=REPO_ROOT,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+    expected = canonical_expected_axioms(processed)
+    actual: dict[str, str] = {}
+
+    if artifacts.output_path.exists():
+        graph = Graph().parse(
+            artifacts.output_path,
+            format="turtle",
+        )
+        actual = {
+            axiom_id: value[0]
+            for axiom_id, value in modular._canonical_graph_axioms(
+                graph,
+                ignore_unsupported=True,
+            ).items()
+        }
+
+    missing = sorted(set(expected) - set(actual))
+    extra = sorted(set(actual) - set(expected))
+    mismatched = sorted(
+        axiom_id
+        for axiom_id in set(expected) & set(actual)
+        if expected[axiom_id] != actual[axiom_id]
+    )
+
+    passed = (
+        completed.returncode == 0
+        and len(selected) == 5
+        and len(expected) == 5
+        and len(actual) == 5
+        and not missing
+        and not extra
+        and not mismatched
+    )
+
+    summary: dict[str, object] = {
+        "passed": passed,
+        "robot_path": robot,
+        "robot_return_code": completed.returncode,
+        "robot_output": "\n".join(
+            part
+            for part in (
+                completed.stdout.strip(),
+                completed.stderr.strip(),
+            )
+            if part
+        ),
+        "workbook": str(workbook_path),
+        "governed_row_count": len(processed),
+        "attempted_property_chain_rows": len(selected),
+        "expected_axiom_count": len(expected),
+        "actual_axiom_count": len(actual),
+        "missing_axiom_ids": missing,
+        "extra_axiom_ids": extra,
+        "mismatched_axiom_ids": mismatched,
+        "declared_property_count": len(
+            {
+                row.subject_iri
+                for row in selected
+            }
+            | {
+                member
+                for row in selected
+                for member in row.property_chain
+            }
+        ),
+        "functional_syntax_sha256": hashlib.sha256(
+            artifacts.functional_syntax_path.read_bytes()
+        ).hexdigest(),
+    }
+
+    artifacts.summary_path.write_text(
+        json.dumps(summary, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    return summary
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--input",
+        default=str(REPO_ROOT / "mappings/SSN2BFO-COMS.xlsx"),
+        help="Governed COMS workbook.",
+    )
+    parser.add_argument(
+        "--output-dir",
+        required=True,
+        help="Directory for temporary pilot artifacts.",
+    )
+    parser.add_argument(
+        "--robot",
+        help="Optional explicit ROBOT executable path.",
+    )
+    args = parser.parse_args(argv)
+
+    summary = run_pilot(
+        Path(args.input),
+        Path(args.output_dir),
+        args.robot,
+    )
+
+    print(f"Governed rows: {summary['governed_row_count']}")
+    print(
+        "Attempted property-chain rows: "
+        f"{summary['attempted_property_chain_rows']}"
+    )
+    print(f"Expected canonical axioms: {summary['expected_axiom_count']}")
+    print(f"ROBOT canonical axioms: {summary['actual_axiom_count']}")
+    print(f"ROBOT return code: {summary['robot_return_code']}")
+    print(f"Missing axioms: {len(summary['missing_axiom_ids'])}")
+    print(f"Extra axioms: {len(summary['extra_axiom_ids'])}")
+    print(f"Mismatched axioms: {len(summary['mismatched_axiom_ids'])}")
+    print("Summary: PASS" if summary["passed"] else "Summary: FAIL")
+
+    if summary["robot_output"]:
+        print(summary["robot_output"])
+
+    return 0 if summary["passed"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/run_validation_suite.py
+++ b/tools/run_validation_suite.py
@@ -397,6 +397,7 @@ def compile_check() -> StepResult:
             "tools/modular_products.py",
             "tools/generate_mapping_from_coms.py",
             "tools/robot_template_generation_pilot.py",
+            "tools/robot_property_chain_generation_pilot.py",
             "tools/check_coms_mapping.py",
             "tools/watch_coms_mapping.py",
             "tools/publication_metadata.py",
@@ -409,6 +410,7 @@ def compile_check() -> StepResult:
             "tools/rehearse_release.py",
             "tests/test_generate_mapping_from_coms.py",
             "tests/test_robot_template_generation_pilot.py",
+            "tests/test_robot_property_chain_generation_pilot.py",
             "tests/test_coms_row_identity.py",
             "tests/test_product_dispositions.py",
             "tests/test_modular_products.py",
@@ -731,6 +733,22 @@ def run_validation_suite(args: argparse.Namespace) -> int:
                     "tests",
                     "-p",
                     "test_robot_template_generation_pilot.py",
+                ],
+            )
+        )
+    if results[-1].passed:
+        results.append(
+            run_command(
+                "ROBOT property-chain generation focused tests",
+                [
+                    sys.executable,
+                    "-m",
+                    "unittest",
+                    "discover",
+                    "-s",
+                    "tests",
+                    "-p",
+                    "test_robot_property_chain_generation_pilot.py",
                 ],
             )
         )


### PR DESCRIPTION
## Summary

- add a read-only ROBOT property-chain generation pilot
- preserve the existing COMS workbook format and authoritative Python generation path
- select the five governed property-chain rows from canonical COMS inputs
- emit deterministic OWL Functional Syntax using resolved full IRIs
- parse and serialize the temporary ontology through `robot convert --strict`
- compare ROBOT output against authoritative canonical COMS axiom identities
- add focused deterministic and semantic-equivalence tests
- add the pilot to the authoritative validation suite
- update the ROBOT substitution audit with the completed 105/105 result

## Results

- governed COMS rows: 105
- property-chain rows attempted: 5
- expected canonical property-chain axioms: 5
- ROBOT canonical property-chain axioms: 5
- missing axioms: 0
- extra axioms: 0
- mismatched axioms: 0
- generated Functional Syntax is byte-deterministic
- ROBOT outputs are graph-isomorphic across runs
- combined ROBOT reconstruction: 105/105 governed axioms
- maintained ontology products remain unchanged
- `make check` passes
