### PR TITLE
Consolidate ROBOT reconstruction validation

### DIFF
--- a/reports/robot-substitution-audit.md
+++ b/reports/robot-substitution-audit.md
@@ -219,7 +219,20 @@ reconstructs all 105 governed COMS axioms exactly:
 
 - 100 non-chain axioms through normalized ROBOT Template input;
 - 5 property-chain axioms through normalized OWL Functional Syntax;
+- 0 overlapping backend axioms;
 - 0 missing, extra, or mismatched canonical axioms.
+
+The permanent combined gate is implemented by:
+
+- `tools/robot_reconstruction_validation.py`, which provides shared workbook
+  loading, canonical extraction, ROBOT resolution, and comparison helpers;
+- `tools/validate_robot_reconstruction.py`, which runs both reconstruction
+  backends and requires exact 105-of-105 canonical equality;
+- `tests/test_robot_reconstruction_validation.py`, which locks the combined
+  result, deterministic normalized inputs, and non-modification of maintained
+  ontology products;
+- `tools/run_validation_suite.py`, which runs the focused tests and complete
+  reconstruction check as authoritative validation steps.
 
 The current Python generator remains authoritative, and all five maintained
 ontology products remain unchanged.
@@ -443,48 +456,54 @@ A reasonable code-reduction target is approximately 3,000–5,000 lines, subject
 to proof through narrow pilots. The greater benefit may be consistency and
 reduced maintenance rather than raw line-count reduction.
 
-## Recommended implementation sequence
+## Implementation status and next steps
 
-### Phase 1: report-only validation
+### Phase 1: report-only validation — complete
 
-1. Commit this audit without changing production behavior.
-2. Record the 70-of-100 unchanged Template baseline.
-3. Add an exact Python-normalized class-expression pilot.
-4. Compare ROBOT output with canonical COMS axiom identities.
+- recorded the 70-of-100 unchanged Template baseline;
+- implemented normalized ROBOT Template reconstruction;
+- proved exact canonical equality for all 100 non-chain axioms;
+- preserved the authoritative Python generation path.
 
-### Phase 2: consolidate reasoning
+### Phase 2: consolidate reasoning — complete
 
-1. Create one generic ROBOT reasoning adapter.
-2. Express product-specific reasoning as configuration.
-3. Migrate the five generator HermiT wrappers.
-4. Preserve report text and expected result semantics.
-5. Run the full current validation suite.
+- introduced one configured ROBOT/HermiT execution adapter;
+- migrated the five generator reasoning wrappers;
+- preserved public wrapper signatures, report semantics, and temporary
+  filenames;
+- passed direct old-versus-new equivalence and the full validation suite.
 
-### Phase 3: add independent ROBOT generation
+### Phase 3: independent ROBOT reconstruction — complete
 
-1. Emit normalized ROBOT inputs from governed COMS rows.
-2. Generate a comparison ontology.
-3. Canonicalize ROBOT output.
-4. Require exact canonical-axiom equality with the current generator.
-5. Keep the current generator authoritative during this phase.
+- implemented normalized Template reconstruction for 100 non-chain axioms;
+- implemented normalized Functional Syntax reconstruction for 5 property-chain
+  axioms;
+- introduced a permanent combined 105-of-105 validation gate;
+- required zero overlap, missing, extra, or mismatched canonical axioms;
+- kept the current Python generator authoritative;
+- left all five maintained ontology products unchanged.
 
-### Phase 4: evaluate production generation
+### Phase 4: production-generation evaluation — intentionally deferred
 
-Only after exact equivalence is stable:
+ROBOT will remain an independent validation oracle unless a future controlled
+experiment proves that production use would:
 
-1. decide whether ROBOT should become the primary OWL axiom constructor;
-2. retain Python governance and product selection;
-3. preserve deterministic published bytes or explicitly govern a new rendering
-   version;
-4. avoid changing release artifacts merely to reduce implementation size.
+1. remove a meaningful amount of custom Python;
+2. preserve COMS RowID-level diagnostics;
+3. preserve atomic failure and rollback behavior;
+4. preserve deterministic maintained and release artifact bytes;
+5. simplify the total architecture rather than add another production-critical
+   intermediate layer.
 
-### Phase 5: standardize other ROBOT operations
+### Phase 5: standardize other ROBOT operations — future work
+
+Potential candidates remain:
 
 - merge and closure assembly;
 - query and verify;
 - semantic diff;
 - import extraction;
-- the retained example-validation Makefile.
+- retained example validation.
 
 ## Completed immediate cleanup
 

--- a/tests/test_robot_reconstruction_validation.py
+++ b/tests/test_robot_reconstruction_validation.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+"""Focused tests for complete independent ROBOT reconstruction validation."""
+
+from __future__ import annotations
+
+import hashlib
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT / "tools"))
+
+import robot_reconstruction_validation as reconstruction  # noqa: E402
+import validate_robot_reconstruction as combined  # noqa: E402
+
+
+WORKBOOK = REPO_ROOT / "mappings/SSN2BFO-COMS.xlsx"
+
+MAINTAINED_PRODUCTS = (
+    REPO_ROOT / "SSN2BFO.ttl",
+    REPO_ROOT / "releases/current-ssn-sosa/ssn-sosa-alignment-core.ttl",
+    REPO_ROOT / "releases/current-ssn-sosa/ssn-sosa-bfo-mapping.ttl",
+    REPO_ROOT / "releases/current-ssn-sosa/ssn-sosa-bfo-projection.ttl",
+    REPO_ROOT / "releases/current-ssn-sosa/ssn-sosa-cco-extension.ttl",
+)
+
+
+def sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+class RobotReconstructionValidationTests(unittest.TestCase):
+    def test_canonical_comparison_reports_each_difference_category(self) -> None:
+        comparison = reconstruction.compare_canonical_axioms(
+            {
+                "sha256:missing": "ExpectedMissing",
+                "sha256:mismatch": "ExpectedMismatch",
+                "sha256:shared": "Shared",
+            },
+            {
+                "sha256:extra": "ActualExtra",
+                "sha256:mismatch": "ActualMismatch",
+                "sha256:shared": "Shared",
+            },
+        )
+
+        self.assertFalse(comparison.passed)
+        self.assertEqual(
+            comparison.missing_axiom_ids,
+            ("sha256:missing",),
+        )
+        self.assertEqual(
+            comparison.extra_axiom_ids,
+            ("sha256:extra",),
+        )
+        self.assertEqual(
+            comparison.mismatched_axiom_ids,
+            ("sha256:mismatch",),
+        )
+
+    def test_governed_workbook_reconstructs_all_105_axioms(self) -> None:
+        before = {
+            path.relative_to(REPO_ROOT).as_posix(): sha256(path)
+            for path in MAINTAINED_PRODUCTS
+        }
+
+        with tempfile.TemporaryDirectory(
+            prefix="robot-reconstruction-a-"
+        ) as first_dir, tempfile.TemporaryDirectory(
+            prefix="robot-reconstruction-b-"
+        ) as second_dir:
+            first_root = Path(first_dir)
+            second_root = Path(second_dir)
+
+            first = combined.run_validation(
+                WORKBOOK,
+                first_root,
+            )
+            second = combined.run_validation(
+                WORKBOOK,
+                second_root,
+            )
+
+            self.assertTrue(first["passed"], first)
+            self.assertTrue(second["passed"], second)
+
+            for summary in (first, second):
+                self.assertEqual(summary["governed_row_count"], 105)
+                self.assertTrue(
+                    summary["non_chain_reconstruction_passed"]
+                )
+                self.assertTrue(
+                    summary["property_chain_reconstruction_passed"]
+                )
+                self.assertEqual(summary["non_chain_axiom_count"], 100)
+                self.assertEqual(summary["property_chain_axiom_count"], 5)
+                self.assertEqual(summary["expected_axiom_count"], 105)
+                self.assertEqual(summary["actual_axiom_count"], 105)
+                self.assertEqual(summary["overlapping_axiom_ids"], [])
+                self.assertEqual(summary["missing_axiom_ids"], [])
+                self.assertEqual(summary["extra_axiom_ids"], [])
+                self.assertEqual(summary["mismatched_axiom_ids"], [])
+                self.assertEqual(
+                    summary["non_chain_robot_return_code"],
+                    0,
+                )
+                self.assertEqual(
+                    summary["property_chain_robot_return_code"],
+                    0,
+                )
+
+            self.assertEqual(
+                (
+                    first_root
+                    / "non-chain"
+                    / "normalized-template.tsv"
+                ).read_bytes(),
+                (
+                    second_root
+                    / "non-chain"
+                    / "normalized-template.tsv"
+                ).read_bytes(),
+            )
+            self.assertEqual(
+                (
+                    first_root
+                    / "non-chain"
+                    / "resolver.ttl"
+                ).read_bytes(),
+                (
+                    second_root
+                    / "non-chain"
+                    / "resolver.ttl"
+                ).read_bytes(),
+            )
+            self.assertEqual(
+                (
+                    first_root
+                    / "property-chains"
+                    / "normalized-property-chains.ofn"
+                ).read_bytes(),
+                (
+                    second_root
+                    / "property-chains"
+                    / "normalized-property-chains.ofn"
+                ).read_bytes(),
+            )
+
+        after = {
+            path.relative_to(REPO_ROOT).as_posix(): sha256(path)
+            for path in MAINTAINED_PRODUCTS
+        }
+        self.assertEqual(before, after)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/robot_property_chain_generation_pilot.py
+++ b/tools/robot_property_chain_generation_pilot.py
@@ -6,16 +6,12 @@ from __future__ import annotations
 import argparse
 import hashlib
 import json
-import shutil
 import subprocess
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Iterable
 
-from rdflib import Graph
-
-import generate_mapping_from_coms as coms
-import modular_products as modular
+import robot_reconstruction_validation as reconstruction
 from coms_row_identity import CanonicalRowInput
 
 
@@ -127,32 +123,6 @@ def write_functional_syntax(
     return selected
 
 
-def canonical_expected_axioms(
-    processed_rows: Iterable[coms.ProcessedRow],
-) -> dict[str, str]:
-    expected: dict[str, str] = {}
-
-    for processed in processed_rows:
-        row = coms.canonical_input_for_processed_row(processed)
-        if row.mapping_type != "property_chain":
-            continue
-        if processed.identity_audit is None:
-            raise ValueError(
-                f"{row.row_id}: canonical identity audit is missing"
-            )
-
-        for identity in processed.identity_audit.authoritative_axioms:
-            axiom_id = (
-                "sha256:"
-                + hashlib.sha256(
-                    identity.canonical_axiom.encode("utf-8")
-                ).hexdigest()
-            )
-            expected[axiom_id] = identity.canonical_axiom
-
-    return expected
-
-
 def artifact_paths(output_dir: Path) -> PilotArtifacts:
     return PilotArtifacts(
         functional_syntax_path=output_dir / "normalized-property-chains.ofn",
@@ -170,16 +140,11 @@ def run_pilot(
     output_dir.mkdir(parents=True, exist_ok=True)
     artifacts = artifact_paths(output_dir)
 
-    workbook_rows, stats = coms.read_workbook(workbook_path)
-    processed = coms.validate_and_process_rows(
-        workbook_rows,
-        coms.Resolver(),
-        stats,
+    governed = reconstruction.load_governed_coms_rows(
+        workbook_path,
     )
-    canonical_rows = tuple(
-        coms.canonical_input_for_processed_row(row)
-        for row in processed
-    )
+    processed = governed.processed_rows
+    canonical_rows = governed.canonical_rows
 
     selected = write_functional_syntax(
         canonical_rows,
@@ -188,9 +153,7 @@ def run_pilot(
 
     artifacts.output_path.unlink(missing_ok=True)
 
-    robot = robot_path or shutil.which("robot")
-    if robot is None:
-        raise RuntimeError("ROBOT executable not found on PATH")
+    robot = reconstruction.resolve_robot_path(robot_path)
 
     completed = subprocess.run(
         [
@@ -210,51 +173,40 @@ def run_pilot(
         stderr=subprocess.PIPE,
     )
 
-    expected = canonical_expected_axioms(processed)
+    expected = reconstruction.canonical_expected_axioms(
+        processed,
+        {"property_chain"},
+    )
     actual: dict[str, str] = {}
 
     if artifacts.output_path.exists():
-        graph = Graph().parse(
+        actual = reconstruction.canonical_axioms_from_turtle(
             artifacts.output_path,
-            format="turtle",
         )
-        actual = {
-            axiom_id: value[0]
-            for axiom_id, value in modular._canonical_graph_axioms(
-                graph,
-                ignore_unsupported=True,
-            ).items()
-        }
 
-    missing = sorted(set(expected) - set(actual))
-    extra = sorted(set(actual) - set(expected))
-    mismatched = sorted(
-        axiom_id
-        for axiom_id in set(expected) & set(actual)
-        if expected[axiom_id] != actual[axiom_id]
+    comparison = reconstruction.compare_canonical_axioms(
+        expected,
+        actual,
     )
+    missing = list(comparison.missing_axiom_ids)
+    extra = list(comparison.extra_axiom_ids)
+    mismatched = list(comparison.mismatched_axiom_ids)
 
     passed = (
         completed.returncode == 0
         and len(selected) == 5
         and len(expected) == 5
         and len(actual) == 5
-        and not missing
-        and not extra
-        and not mismatched
+        and comparison.passed
     )
 
     summary: dict[str, object] = {
         "passed": passed,
         "robot_path": robot,
         "robot_return_code": completed.returncode,
-        "robot_output": "\n".join(
-            part
-            for part in (
-                completed.stdout.strip(),
-                completed.stderr.strip(),
-            )
-            if part
+        "robot_output": reconstruction.combined_process_output(
+            completed.stdout,
+            completed.stderr,
         ),
         "workbook": str(workbook_path),
         "governed_row_count": len(processed),

--- a/tools/robot_reconstruction_validation.py
+++ b/tools/robot_reconstruction_validation.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python3
+"""Shared helpers for independent ROBOT reconstruction of governed COMS axioms."""
+
+from __future__ import annotations
+
+import hashlib
+import shutil
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable
+
+from rdflib import Graph
+
+import generate_mapping_from_coms as coms
+import modular_products as modular
+from coms_row_identity import CanonicalRowInput
+
+
+@dataclass(frozen=True)
+class GovernedComsRows:
+    processed_rows: tuple[coms.ProcessedRow, ...]
+    canonical_rows: tuple[CanonicalRowInput, ...]
+
+
+@dataclass(frozen=True)
+class CanonicalAxiomComparison:
+    expected: dict[str, str]
+    actual: dict[str, str]
+    missing_axiom_ids: tuple[str, ...]
+    extra_axiom_ids: tuple[str, ...]
+    mismatched_axiom_ids: tuple[str, ...]
+
+    @property
+    def passed(self) -> bool:
+        return (
+            not self.missing_axiom_ids
+            and not self.extra_axiom_ids
+            and not self.mismatched_axiom_ids
+        )
+
+
+def load_governed_coms_rows(workbook_path: Path) -> GovernedComsRows:
+    """Load and fully validate the governed COMS workbook once."""
+
+    workbook_rows, stats = coms.read_workbook(workbook_path.resolve())
+    processed_rows = tuple(
+        coms.validate_and_process_rows(
+            workbook_rows,
+            coms.Resolver(),
+            stats,
+        )
+    )
+    canonical_rows = tuple(
+        coms.canonical_input_for_processed_row(row)
+        for row in processed_rows
+    )
+    return GovernedComsRows(
+        processed_rows=processed_rows,
+        canonical_rows=canonical_rows,
+    )
+
+
+def canonical_expected_axioms(
+    processed_rows: Iterable[coms.ProcessedRow],
+    mapping_types: Iterable[str],
+) -> dict[str, str]:
+    """Return authoritative canonical axioms for the selected mapping types."""
+
+    selected_types = frozenset(mapping_types)
+    expected: dict[str, str] = {}
+
+    for processed in processed_rows:
+        row = coms.canonical_input_for_processed_row(processed)
+        if row.mapping_type not in selected_types:
+            continue
+        if processed.identity_audit is None:
+            raise ValueError(
+                f"{row.row_id}: canonical identity audit is missing"
+            )
+
+        for identity in processed.identity_audit.authoritative_axioms:
+            axiom_id = (
+                "sha256:"
+                + hashlib.sha256(
+                    identity.canonical_axiom.encode("utf-8")
+                ).hexdigest()
+            )
+            previous = expected.get(axiom_id)
+            if previous is not None and previous != identity.canonical_axiom:
+                raise ValueError(
+                    f"{row.row_id}: canonical axiom hash collision"
+                )
+            expected[axiom_id] = identity.canonical_axiom
+
+    return expected
+
+
+def canonical_axioms_from_turtle(path: Path) -> dict[str, str]:
+    """Canonicalize supported OWL axioms from a ROBOT-produced Turtle graph."""
+
+    graph = Graph().parse(path, format="turtle")
+    return {
+        axiom_id: value[0]
+        for axiom_id, value in modular._canonical_graph_axioms(
+            graph,
+            ignore_unsupported=True,
+        ).items()
+    }
+
+
+def compare_canonical_axioms(
+    expected: dict[str, str],
+    actual: dict[str, str],
+) -> CanonicalAxiomComparison:
+    """Compare exact canonical axiom identities and expressions."""
+
+    shared = set(expected) & set(actual)
+    return CanonicalAxiomComparison(
+        expected=expected,
+        actual=actual,
+        missing_axiom_ids=tuple(sorted(set(expected) - set(actual))),
+        extra_axiom_ids=tuple(sorted(set(actual) - set(expected))),
+        mismatched_axiom_ids=tuple(
+            sorted(
+                axiom_id
+                for axiom_id in shared
+                if expected[axiom_id] != actual[axiom_id]
+            )
+        ),
+    )
+
+
+def resolve_robot_path(robot_path: str | None = None) -> str:
+    """Return the explicit or PATH-resolved ROBOT executable."""
+
+    resolved = robot_path or shutil.which("robot")
+    if resolved is None:
+        raise RuntimeError("ROBOT executable not found on PATH")
+    return resolved
+
+
+def combined_process_output(stdout: str, stderr: str) -> str:
+    """Combine subprocess output using the repository's existing convention."""
+
+    return "\n".join(
+        part
+        for part in (
+            stdout.strip(),
+            stderr.strip(),
+        )
+        if part
+    )

--- a/tools/robot_template_generation_pilot.py
+++ b/tools/robot_template_generation_pilot.py
@@ -7,16 +7,14 @@ import argparse
 import csv
 import hashlib
 import json
-import shutil
 import subprocess
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Iterable
 
-from rdflib import Graph, Literal, URIRef
+from rdflib import Literal, URIRef
 
-import generate_mapping_from_coms as coms
-import modular_products as modular
+import robot_reconstruction_validation as reconstruction
 from coms_row_identity import (
     CanonicalRowInput,
     ExpressionNode,
@@ -302,30 +300,6 @@ def write_template(
     return selected
 
 
-def canonical_expected_axioms(
-    processed_rows: Iterable[coms.ProcessedRow],
-) -> dict[str, str]:
-    expected: dict[str, str] = {}
-
-    for processed in processed_rows:
-        row = coms.canonical_input_for_processed_row(processed)
-        if row.mapping_type not in SUPPORTED_MAPPING_TYPES:
-            continue
-        if processed.identity_audit is None:
-            raise ValueError(f"{row.row_id}: canonical identity audit is missing")
-
-        for identity in processed.identity_audit.authoritative_axioms:
-            axiom_id = (
-                "sha256:"
-                + hashlib.sha256(
-                    identity.canonical_axiom.encode("utf-8")
-                ).hexdigest()
-            )
-            expected[axiom_id] = identity.canonical_axiom
-
-    return expected
-
-
 def artifact_paths(output_dir: Path) -> PilotArtifacts:
     return PilotArtifacts(
         resolver_path=output_dir / "resolver.ttl",
@@ -345,16 +319,11 @@ def run_pilot(
     output_dir.mkdir(parents=True, exist_ok=True)
     artifacts = artifact_paths(output_dir)
 
-    rows, stats = coms.read_workbook(workbook_path)
-    processed = coms.validate_and_process_rows(
-        rows,
-        coms.Resolver(),
-        stats,
+    governed = reconstruction.load_governed_coms_rows(
+        workbook_path,
     )
-    canonical_rows = tuple(
-        coms.canonical_input_for_processed_row(row)
-        for row in processed
-    )
+    processed = governed.processed_rows
+    canonical_rows = governed.canonical_rows
 
     labels = build_entity_labels(canonical_rows)
     selected = write_template(
@@ -367,9 +336,7 @@ def run_pilot(
     artifacts.output_path.unlink(missing_ok=True)
     artifacts.errors_path.unlink(missing_ok=True)
 
-    robot = robot_path or shutil.which("robot")
-    if robot is None:
-        raise RuntimeError("ROBOT executable not found on PATH")
+    robot = reconstruction.resolve_robot_path(robot_path)
 
     completed = subprocess.run(
         [
@@ -392,48 +359,40 @@ def run_pilot(
         stderr=subprocess.PIPE,
     )
 
-    expected = canonical_expected_axioms(processed)
+    expected = reconstruction.canonical_expected_axioms(
+        processed,
+        SUPPORTED_MAPPING_TYPES,
+    )
     actual: dict[str, str] = {}
 
     if artifacts.output_path.exists():
-        graph = Graph().parse(artifacts.output_path, format="turtle")
-        actual = {
-            axiom_id: value[0]
-            for axiom_id, value in modular._canonical_graph_axioms(
-                graph,
-                ignore_unsupported=True,
-            ).items()
-        }
+        actual = reconstruction.canonical_axioms_from_turtle(
+            artifacts.output_path,
+        )
 
-    missing = sorted(set(expected) - set(actual))
-    extra = sorted(set(actual) - set(expected))
-    mismatched = sorted(
-        axiom_id
-        for axiom_id in set(expected) & set(actual)
-        if expected[axiom_id] != actual[axiom_id]
+    comparison = reconstruction.compare_canonical_axioms(
+        expected,
+        actual,
     )
+    missing = list(comparison.missing_axiom_ids)
+    extra = list(comparison.extra_axiom_ids)
+    mismatched = list(comparison.mismatched_axiom_ids)
 
     passed = (
         completed.returncode == 0
         and len(selected) == 100
         and len(expected) == 100
         and len(actual) == 100
-        and not missing
-        and not extra
-        and not mismatched
+        and comparison.passed
     )
 
     summary: dict[str, object] = {
         "passed": passed,
         "robot_path": robot,
         "robot_return_code": completed.returncode,
-        "robot_output": "\n".join(
-            part
-            for part in (
-                completed.stdout.strip(),
-                completed.stderr.strip(),
-            )
-            if part
+        "robot_output": reconstruction.combined_process_output(
+            completed.stdout,
+            completed.stderr,
         ),
         "workbook": str(workbook_path),
         "governed_row_count": len(processed),

--- a/tools/run_validation_suite.py
+++ b/tools/run_validation_suite.py
@@ -398,6 +398,8 @@ def compile_check() -> StepResult:
             "tools/generate_mapping_from_coms.py",
             "tools/robot_template_generation_pilot.py",
             "tools/robot_property_chain_generation_pilot.py",
+            "tools/robot_reconstruction_validation.py",
+            "tools/validate_robot_reconstruction.py",
             "tools/check_coms_mapping.py",
             "tools/watch_coms_mapping.py",
             "tools/publication_metadata.py",
@@ -411,6 +413,7 @@ def compile_check() -> StepResult:
             "tests/test_generate_mapping_from_coms.py",
             "tests/test_robot_template_generation_pilot.py",
             "tests/test_robot_property_chain_generation_pilot.py",
+            "tests/test_robot_reconstruction_validation.py",
             "tests/test_coms_row_identity.py",
             "tests/test_product_dispositions.py",
             "tests/test_modular_products.py",
@@ -723,32 +726,26 @@ def run_validation_suite(args: argparse.Namespace) -> int:
     if results[-1].passed:
         results.append(
             run_command(
-                "Normalized ROBOT Template generation focused tests",
+                "ROBOT reconstruction focused tests",
                 [
                     sys.executable,
                     "-m",
                     "unittest",
-                    "discover",
-                    "-s",
-                    "tests",
-                    "-p",
-                    "test_robot_template_generation_pilot.py",
+                    "tests.test_robot_template_generation_pilot",
+                    "tests.test_robot_property_chain_generation_pilot",
+                    "tests.test_robot_reconstruction_validation",
                 ],
             )
         )
     if results[-1].passed:
         results.append(
             run_command(
-                "ROBOT property-chain generation focused tests",
+                "Complete ROBOT reconstruction check",
                 [
                     sys.executable,
-                    "-m",
-                    "unittest",
-                    "discover",
-                    "-s",
-                    "tests",
-                    "-p",
-                    "test_robot_property_chain_generation_pilot.py",
+                    "tools/validate_robot_reconstruction.py",
+                    "--output-dir",
+                    str(tmp_dir / "robot-reconstruction"),
                 ],
             )
         )

--- a/tools/validate_robot_reconstruction.py
+++ b/tools/validate_robot_reconstruction.py
@@ -1,0 +1,205 @@
+#!/usr/bin/env python3
+"""Validate exact ROBOT reconstruction of all governed COMS axioms."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+import robot_property_chain_generation_pilot as property_chains
+import robot_reconstruction_validation as reconstruction
+import robot_template_generation_pilot as template
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+GOVERNED_AXIOM_MAPPING_TYPES = frozenset(
+    {
+        "class_mapping",
+        "object_property_mapping",
+        "domain",
+        "range",
+        "property_chain",
+    }
+)
+
+
+def run_validation(
+    workbook_path: Path,
+    output_dir: Path,
+    robot_path: str | None = None,
+) -> dict[str, object]:
+    workbook_path = workbook_path.resolve()
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    template_dir = output_dir / "non-chain"
+    property_chain_dir = output_dir / "property-chains"
+
+    template_summary = template.run_pilot(
+        workbook_path,
+        template_dir,
+        robot_path,
+    )
+    property_chain_summary = property_chains.run_pilot(
+        workbook_path,
+        property_chain_dir,
+        robot_path,
+    )
+
+    governed = reconstruction.load_governed_coms_rows(
+        workbook_path,
+    )
+    expected = reconstruction.canonical_expected_axioms(
+        governed.processed_rows,
+        GOVERNED_AXIOM_MAPPING_TYPES,
+    )
+
+    template_actual = reconstruction.canonical_axioms_from_turtle(
+        template.artifact_paths(template_dir).output_path,
+    )
+    property_chain_actual = reconstruction.canonical_axioms_from_turtle(
+        property_chains.artifact_paths(property_chain_dir).output_path,
+    )
+
+    overlap = tuple(
+        sorted(
+            set(template_actual)
+            & set(property_chain_actual)
+        )
+    )
+
+    actual = dict(template_actual)
+    for axiom_id, canonical in property_chain_actual.items():
+        previous = actual.get(axiom_id)
+        if previous is not None and previous != canonical:
+            raise ValueError(
+                f"ROBOT reconstruction axiom collision for {axiom_id}"
+            )
+        actual[axiom_id] = canonical
+
+    comparison = reconstruction.compare_canonical_axioms(
+        expected,
+        actual,
+    )
+
+    passed = (
+        bool(template_summary["passed"])
+        and bool(property_chain_summary["passed"])
+        and len(governed.processed_rows) == 105
+        and len(template_actual) == 100
+        and len(property_chain_actual) == 5
+        and len(expected) == 105
+        and len(actual) == 105
+        and not overlap
+        and comparison.passed
+    )
+
+    summary: dict[str, object] = {
+        "passed": passed,
+        "workbook": str(workbook_path),
+        "governed_row_count": len(governed.processed_rows),
+        "non_chain_reconstruction_passed": bool(
+            template_summary["passed"]
+        ),
+        "property_chain_reconstruction_passed": bool(
+            property_chain_summary["passed"]
+        ),
+        "non_chain_axiom_count": len(template_actual),
+        "property_chain_axiom_count": len(property_chain_actual),
+        "expected_axiom_count": len(expected),
+        "actual_axiom_count": len(actual),
+        "overlapping_axiom_ids": list(overlap),
+        "missing_axiom_ids": list(
+            comparison.missing_axiom_ids
+        ),
+        "extra_axiom_ids": list(
+            comparison.extra_axiom_ids
+        ),
+        "mismatched_axiom_ids": list(
+            comparison.mismatched_axiom_ids
+        ),
+        "robot_path": template_summary["robot_path"],
+        "non_chain_robot_return_code": template_summary[
+            "robot_return_code"
+        ],
+        "property_chain_robot_return_code": property_chain_summary[
+            "robot_return_code"
+        ],
+    }
+
+    (output_dir / "summary.json").write_text(
+        json.dumps(summary, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    return summary
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--input",
+        default=str(
+            REPO_ROOT / "mappings/SSN2BFO-COMS.xlsx"
+        ),
+        help="Governed COMS workbook.",
+    )
+    parser.add_argument(
+        "--output-dir",
+        required=True,
+        help="Directory for temporary validation artifacts.",
+    )
+    parser.add_argument(
+        "--robot",
+        help="Optional explicit ROBOT executable path.",
+    )
+    args = parser.parse_args(argv)
+
+    summary = run_validation(
+        Path(args.input),
+        Path(args.output_dir),
+        args.robot,
+    )
+
+    print(f"Governed rows: {summary['governed_row_count']}")
+    print(
+        "Non-chain ROBOT axioms: "
+        f"{summary['non_chain_axiom_count']}"
+    )
+    print(
+        "Property-chain ROBOT axioms: "
+        f"{summary['property_chain_axiom_count']}"
+    )
+    print(
+        "Expected canonical axioms: "
+        f"{summary['expected_axiom_count']}"
+    )
+    print(
+        "Combined ROBOT canonical axioms: "
+        f"{summary['actual_axiom_count']}"
+    )
+    print(
+        "Overlapping backend axioms: "
+        f"{len(summary['overlapping_axiom_ids'])}"
+    )
+    print(
+        f"Missing axioms: {len(summary['missing_axiom_ids'])}"
+    )
+    print(
+        f"Extra axioms: {len(summary['extra_axiom_ids'])}"
+    )
+    print(
+        "Mismatched axioms: "
+        f"{len(summary['mismatched_axiom_ids'])}"
+    )
+    print(
+        "Summary: PASS"
+        if summary["passed"]
+        else "Summary: FAIL"
+    )
+
+    return 0 if summary["passed"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- extract shared ROBOT reconstruction helpers for governed COMS loading, canonical axiom extraction, ROBOT resolution, and exact comparison
- migrate the normalized Template and property-chain validators to the shared layer
- add one permanent combined validator for all 105 governed COMS axioms
- replace the two separate validation-suite entries with:
  - one combined focused-test step
  - one complete 105/105 reconstruction check
- update the ROBOT substitution audit to record Phases 1–3 as complete and production generation as intentionally deferred

## Results

- non-chain ROBOT reconstruction: 100/100
- property-chain ROBOT reconstruction: 5/5
- combined reconstruction: 105/105
- overlapping backend axioms: 0
- missing axioms: 0
- extra axioms: 0
- mismatched axioms: 0
- maintained ontology products remain unchanged
- `make check` passes
