### PR TITLE
Add ROBOT query equivalence gate

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,7 @@ compile:
 		tools/product_dispositions.py \
 		tools/modular_products.py \
 		tools/generate_mapping_from_coms.py \
+		tools/robot_query_equivalence_pilot.py \
 		tools/check_coms_mapping.py \
 		tools/watch_coms_mapping.py \
 		tools/publication_metadata.py \
@@ -39,6 +40,7 @@ compile:
 		tools/release_archive.py \
 		tools/rehearse_release.py \
 		tests/test_generate_mapping_from_coms.py \
+		tests/test_robot_query_equivalence_pilot.py \
 		tests/test_coms_row_identity.py \
 		tests/test_product_dispositions.py \
 		tests/test_modular_products.py \

--- a/reports/robot-substitution-audit.md
+++ b/reports/robot-substitution-audit.md
@@ -381,10 +381,35 @@ semantics rather than a declarative selection.
 
 ### Query and verify
 
-Good ROBOT candidates include:
+A read-only `robot query` equivalence pilot has now been completed for the two
+SPARQL `SELECT` queries used by the governed COMS source-term coverage path.
+Production query execution remains unchanged.
 
-- source-term coverage queries;
-- unmapped-term queries;
+The pilot serialized only temporary Python-built graphs and compared ROBOT
+1.9.7 results against the existing RDFLib results:
+
+- the exact Python source union contained 1,157 triples, including four retained
+  `owl:imports` statements, and survived the temporary Turtle round trip
+  isomorphically;
+- `queries/source-classes-and-object-properties.rq` returned the same 91 rows
+  from RDFLib and ROBOT, in the same order, with zero engine-only rows;
+- the Python-built coverage graph contained 182 triples and also survived its
+  temporary Turtle round trip isomorphically;
+- `queries/unmapped-source-terms.rq` returned zero rows from both engines;
+- both ROBOT invocations returned code 0 without warnings or errors;
+- ROBOT represented the empty result as an existing zero-byte CSV rather than
+  a header-only CSV, so callers must interpret that format explicitly.
+
+A permanent read-only gate now repeats the pilot, records machine-readable
+evidence, checks deterministic results across two runs, and verifies that none
+of the five maintained ontology products changes.
+
+This proves `robot query` compatibility for the two current governed coverage
+queries. It does not transfer graph construction, query selection, coverage
+reconciliation, report semantics, or production authority from Python.
+
+Additional good ROBOT candidates include:
+
 - structural violation queries;
 - forbidden-vocabulary checks;
 - import-policy checks;
@@ -392,8 +417,9 @@ Good ROBOT candidates include:
 
 Use:
 
-- `robot query` for informational result sets;
-- `robot verify` for queries whose returned rows are validation failures.
+- `robot query` for informational result sets after focused equivalence proof;
+- `robot verify` for queries whose returned rows are validation failures,
+  subject to a separate controlled pilot.
 
 ### Semantic diff
 
@@ -493,7 +519,7 @@ repository-code reduction.
 | Parsing and conversion | 70–100% |
 | Current SSN/SOSA closure merge and import-edge removal | 0–10% |
 | Reasoner invocation | 90–100% |
-| SPARQL querying and verification | 60–100% |
+| SPARQL querying and verification | 100% proven for the two current governed coverage `SELECT` queries; 60–100% broader potential |
 | Product construction | 30–60% |
 | Product validation | 20–50% |
 | Instance and probe testing | 15–35% |
@@ -544,7 +570,12 @@ experiment proves that production use would:
 5. simplify the total architecture rather than add another production-critical
    intermediate layer.
 
-### Phase 5: standardize other ROBOT operations — future work
+### Phase 5: standardize other ROBOT operations — in progress
+
+Read-only `robot query` execution has been evaluated and accepted for the two
+current governed COMS coverage queries. Exact ordered-row equality is required,
+and Python remains authoritative for temporary graph construction,
+reconciliation, diagnostics, and report semantics.
 
 Closure merging has been evaluated and rejected for the current governed
 SSN/SOSA fixed-closure paths because ROBOT does not preserve the exact RDF or
@@ -552,7 +583,7 @@ canonical axiom set.
 
 Potential candidates remain:
 
-- query and verify;
+- `robot verify` for failure-row validation;
 - semantic diff;
 - import extraction;
 - retained example validation.

--- a/tests/test_robot_query_equivalence_pilot.py
+++ b/tests/test_robot_query_equivalence_pilot.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+"""Focused tests for governed RDFLib versus ROBOT query equivalence."""
+from __future__ import annotations
+
+import hashlib
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT / "tools"))
+
+import robot_query_equivalence_pilot as pilot  # noqa: E402
+
+
+WORKBOOK = REPO_ROOT / "mappings/SSN2BFO-COMS.xlsx"
+
+MAINTAINED_PRODUCTS = (
+    REPO_ROOT / "SSN2BFO.ttl",
+    REPO_ROOT / "releases/current-ssn-sosa/ssn-sosa-alignment-core.ttl",
+    REPO_ROOT / "releases/current-ssn-sosa/ssn-sosa-bfo-mapping.ttl",
+    REPO_ROOT / "releases/current-ssn-sosa/ssn-sosa-bfo-projection.ttl",
+    REPO_ROOT / "releases/current-ssn-sosa/ssn-sosa-cco-extension.ttl",
+)
+
+
+def sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+class RobotQueryEquivalencePilotTests(unittest.TestCase):
+    def test_zero_byte_robot_csv_represents_zero_rows(self) -> None:
+        with tempfile.TemporaryDirectory(
+            prefix="robot-query-empty-"
+        ) as temp_dir:
+            path = Path(temp_dir) / "empty.csv"
+            path.write_bytes(b"")
+
+            header, rows = pilot.read_robot_csv(
+                path,
+                pilot.UNMAPPED_COLUMNS,
+            )
+
+            self.assertEqual(header, ())
+            self.assertEqual(rows, ())
+
+    def test_governed_queries_match_rdflib_without_product_changes(self) -> None:
+        before = {
+            path.relative_to(REPO_ROOT).as_posix(): sha256(path)
+            for path in MAINTAINED_PRODUCTS
+        }
+
+        with tempfile.TemporaryDirectory(
+            prefix="robot-query-pilot-a-"
+        ) as first_dir, tempfile.TemporaryDirectory(
+            prefix="robot-query-pilot-b-"
+        ) as second_dir:
+            first = pilot.run_pilot(WORKBOOK, Path(first_dir))
+            second = pilot.run_pilot(WORKBOOK, Path(second_dir))
+
+            self.assertTrue(first["passed"], first)
+            self.assertTrue(second["passed"], second)
+
+            for summary in (first, second):
+                self.assertEqual(summary["governed_row_count"], 105)
+
+                source_graph = summary["source_graph"]
+                self.assertEqual(source_graph["triple_count"], 1157)
+                self.assertEqual(
+                    source_graph["round_trip_triple_count"],
+                    1157,
+                )
+                self.assertTrue(source_graph["round_trip_isomorphic"])
+                self.assertEqual(source_graph["owl_imports_count"], 4)
+
+                coverage_graph = summary["coverage_graph"]
+                self.assertEqual(coverage_graph["triple_count"], 182)
+                self.assertEqual(
+                    coverage_graph["round_trip_triple_count"],
+                    182,
+                )
+                self.assertTrue(coverage_graph["round_trip_isomorphic"])
+
+                source = summary["source_query"]
+                self.assertTrue(source["passed"])
+                self.assertEqual(source["robot_return_code"], 0)
+                self.assertEqual(source["rdflib_row_count"], 91)
+                self.assertEqual(source["robot_row_count"], 91)
+                self.assertTrue(source["same_ordered_rows"])
+                self.assertEqual(source["rdflib_only_rows"], [])
+                self.assertEqual(source["robot_only_rows"], [])
+                self.assertEqual(source["robot_header"], ["term", "kind"])
+                self.assertGreater(source["robot_output_bytes"], 0)
+
+                unmapped = summary["unmapped_query"]
+                self.assertTrue(unmapped["passed"])
+                self.assertEqual(unmapped["robot_return_code"], 0)
+                self.assertEqual(unmapped["rdflib_row_count"], 0)
+                self.assertEqual(unmapped["robot_row_count"], 0)
+                self.assertTrue(unmapped["same_ordered_rows"])
+                self.assertEqual(unmapped["rdflib_only_rows"], [])
+                self.assertEqual(unmapped["robot_only_rows"], [])
+                self.assertEqual(unmapped["robot_header"], [])
+                self.assertTrue(unmapped["robot_output_exists"])
+                self.assertEqual(unmapped["robot_output_bytes"], 0)
+
+            for section in (
+                "source_graph",
+                "coverage_graph",
+                "source_query",
+                "unmapped_query",
+            ):
+                self.assertEqual(first[section], second[section])
+
+        after = {
+            path.relative_to(REPO_ROOT).as_posix(): sha256(path)
+            for path in MAINTAINED_PRODUCTS
+        }
+        self.assertEqual(before, after)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/robot_query_equivalence_pilot.py
+++ b/tools/robot_query_equivalence_pilot.py
@@ -1,0 +1,433 @@
+#!/usr/bin/env python3
+"""Compare governed RDFLib SELECT results with read-only ROBOT query results."""
+from __future__ import annotations
+
+import argparse
+import csv
+import hashlib
+import json
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable
+
+from rdflib import Graph, Literal, URIRef
+from rdflib.compare import isomorphic
+from rdflib.namespace import OWL
+
+import generate_mapping_from_coms as coms
+import robot_reconstruction_validation as reconstruction
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SOURCE_QUERY = REPO_ROOT / "queries/source-classes-and-object-properties.rq"
+UNMAPPED_QUERY = REPO_ROOT / "queries/unmapped-source-terms.rq"
+
+SOURCE_COLUMNS = ("term", "kind")
+UNMAPPED_COLUMNS = ("term", "kind", "coverageStatus")
+
+
+@dataclass(frozen=True)
+class PilotArtifacts:
+    source_graph_path: Path
+    coverage_graph_path: Path
+    rdflib_source_csv_path: Path
+    robot_source_csv_path: Path
+    rdflib_unmapped_csv_path: Path
+    robot_unmapped_csv_path: Path
+    summary_path: Path
+
+
+@dataclass(frozen=True)
+class RobotQueryResult:
+    return_code: int
+    output: str
+    output_exists: bool
+    output_bytes: int
+    header: tuple[str, ...]
+    rows: tuple[tuple[str, ...], ...]
+
+
+def artifact_paths(output_dir: Path) -> PilotArtifacts:
+    return PilotArtifacts(
+        source_graph_path=output_dir / "source-graph.ttl",
+        coverage_graph_path=output_dir / "coverage-graph.ttl",
+        rdflib_source_csv_path=output_dir / "rdflib-source-terms.csv",
+        robot_source_csv_path=output_dir / "robot-source-terms.csv",
+        rdflib_unmapped_csv_path=output_dir / "rdflib-unmapped-terms.csv",
+        robot_unmapped_csv_path=output_dir / "robot-unmapped-terms.csv",
+        summary_path=output_dir / "summary.json",
+    )
+
+
+def sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def ordered_rows(
+    rows: Iterable[dict[str, str]],
+    columns: tuple[str, ...],
+) -> tuple[tuple[str, ...], ...]:
+    return tuple(
+        tuple(row[column] for column in columns)
+        for row in rows
+    )
+
+
+def write_csv_rows(
+    path: Path,
+    columns: tuple[str, ...],
+    rows: tuple[tuple[str, ...], ...],
+) -> None:
+    with path.open("w", newline="", encoding="utf-8") as handle:
+        writer = csv.writer(handle)
+        writer.writerow(columns)
+        writer.writerows(rows)
+
+
+def read_robot_csv(
+    path: Path,
+    columns: tuple[str, ...],
+) -> tuple[tuple[str, ...], tuple[tuple[str, ...], ...]]:
+    if not path.is_file() or path.stat().st_size == 0:
+        return (), ()
+
+    with path.open(newline="", encoding="utf-8") as handle:
+        reader = csv.DictReader(handle)
+        header = tuple(reader.fieldnames or ())
+        rows = tuple(
+            tuple((row.get(column) or "") for column in columns)
+            for row in reader
+        )
+    return header, rows
+
+
+def run_robot_query(
+    robot: str,
+    input_path: Path,
+    query_path: Path,
+    output_path: Path,
+) -> RobotQueryResult:
+    output_path.unlink(missing_ok=True)
+
+    completed = subprocess.run(
+        [
+            robot,
+            "query",
+            "--input",
+            str(input_path),
+            "--query",
+            str(query_path),
+            str(output_path),
+        ],
+        cwd=REPO_ROOT,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+    header, rows = read_robot_csv(
+        output_path,
+        SOURCE_COLUMNS if query_path == SOURCE_QUERY else UNMAPPED_COLUMNS,
+    )
+    output_exists = output_path.is_file()
+
+    return RobotQueryResult(
+        return_code=completed.returncode,
+        output=reconstruction.combined_process_output(
+            completed.stdout,
+            completed.stderr,
+        ),
+        output_exists=output_exists,
+        output_bytes=output_path.stat().st_size if output_exists else 0,
+        header=header,
+        rows=rows,
+    )
+
+
+def build_coverage_graph(
+    processed_rows: Iterable[coms.ProcessedRow],
+    source_rows: Iterable[dict[str, str]],
+) -> Graph:
+    processed = tuple(processed_rows)
+    source_terms = {
+        URIRef(row["term"]): row["kind"]
+        for row in source_rows
+    }
+
+    mapped_terms = {
+        row.subject
+        for row in processed
+        if row.predicate in coms.MAPPING_PREDICATES
+    }
+    property_typing_terms = {
+        row.subject
+        for row in processed
+        if row.predicate in coms.DOMAIN_RANGE_PREDICATES
+    }
+    explicit_blank_terms = {
+        row.subject
+        for row in processed
+        if not row.predicate
+    }
+
+    graph = Graph()
+    coms.bind_prefixes(graph)
+    graph.bind("coms", coms.COMS_COVERAGE)
+
+    for term, kind in sorted(source_terms.items(), key=lambda item: str(item[0])):
+        graph.add(
+            (term, coms.COMS_COVERAGE.sourceKind, Literal(kind))
+        )
+        if term in mapped_terms:
+            status = "mapped"
+        elif term in property_typing_terms:
+            status = "covered_by_property_typing"
+        elif term in explicit_blank_terms:
+            status = "explicitly_unmapped"
+        else:
+            status = "absent_from_spreadsheet"
+        graph.add(
+            (term, coms.COMS_COVERAGE.coverageStatus, Literal(status))
+        )
+
+    return graph
+
+
+def row_differences(
+    expected: tuple[tuple[str, ...], ...],
+    actual: tuple[tuple[str, ...], ...],
+) -> tuple[list[list[str]], list[list[str]]]:
+    expected_set = set(expected)
+    actual_set = set(actual)
+    return (
+        [list(row) for row in sorted(expected_set - actual_set)],
+        [list(row) for row in sorted(actual_set - expected_set)],
+    )
+
+
+def query_passed(
+    expected_rows: tuple[tuple[str, ...], ...],
+    robot_result: RobotQueryResult,
+    expected_columns: tuple[str, ...],
+) -> bool:
+    header_is_valid = (
+        robot_result.header == expected_columns
+        or (
+            not expected_rows
+            and not robot_result.rows
+            and robot_result.header == ()
+        )
+    )
+    return (
+        robot_result.return_code == 0
+        and robot_result.output_exists
+        and header_is_valid
+        and robot_result.rows == expected_rows
+    )
+
+
+def run_pilot(
+    workbook_path: Path,
+    output_dir: Path,
+    robot_path: str | None = None,
+) -> dict[str, object]:
+    workbook_path = workbook_path.resolve()
+    output_dir.mkdir(parents=True, exist_ok=True)
+    artifacts = artifact_paths(output_dir)
+    robot = reconstruction.resolve_robot_path(robot_path)
+
+    governed = reconstruction.load_governed_coms_rows(workbook_path)
+
+    source_graph = coms.build_source_graph()
+    source_rdflib_dicts = coms.run_select_query(source_graph, SOURCE_QUERY)
+    source_rdflib_rows = ordered_rows(
+        source_rdflib_dicts,
+        SOURCE_COLUMNS,
+    )
+    source_graph.serialize(artifacts.source_graph_path, format="turtle")
+    write_csv_rows(
+        artifacts.rdflib_source_csv_path,
+        SOURCE_COLUMNS,
+        source_rdflib_rows,
+    )
+
+    source_round_trip = Graph().parse(
+        artifacts.source_graph_path,
+        format="turtle",
+    )
+    source_robot = run_robot_query(
+        robot,
+        artifacts.source_graph_path,
+        SOURCE_QUERY,
+        artifacts.robot_source_csv_path,
+    )
+
+    coverage_graph = build_coverage_graph(
+        governed.processed_rows,
+        source_rdflib_dicts,
+    )
+    coverage_rdflib_dicts = coms.run_select_query(
+        coverage_graph,
+        UNMAPPED_QUERY,
+    )
+    coverage_rdflib_rows = ordered_rows(
+        coverage_rdflib_dicts,
+        UNMAPPED_COLUMNS,
+    )
+    coverage_graph.serialize(
+        artifacts.coverage_graph_path,
+        format="turtle",
+    )
+    write_csv_rows(
+        artifacts.rdflib_unmapped_csv_path,
+        UNMAPPED_COLUMNS,
+        coverage_rdflib_rows,
+    )
+
+    coverage_round_trip = Graph().parse(
+        artifacts.coverage_graph_path,
+        format="turtle",
+    )
+    coverage_robot = run_robot_query(
+        robot,
+        artifacts.coverage_graph_path,
+        UNMAPPED_QUERY,
+        artifacts.robot_unmapped_csv_path,
+    )
+
+    source_rdflib_only, source_robot_only = row_differences(
+        source_rdflib_rows,
+        source_robot.rows,
+    )
+    coverage_rdflib_only, coverage_robot_only = row_differences(
+        coverage_rdflib_rows,
+        coverage_robot.rows,
+    )
+
+    source_query_ok = query_passed(
+        source_rdflib_rows,
+        source_robot,
+        SOURCE_COLUMNS,
+    )
+    coverage_query_ok = query_passed(
+        coverage_rdflib_rows,
+        coverage_robot,
+        UNMAPPED_COLUMNS,
+    )
+    source_round_trip_ok = isomorphic(source_graph, source_round_trip)
+    coverage_round_trip_ok = isomorphic(
+        coverage_graph,
+        coverage_round_trip,
+    )
+
+    summary: dict[str, object] = {
+        "passed": (
+            source_query_ok
+            and coverage_query_ok
+            and source_round_trip_ok
+            and coverage_round_trip_ok
+        ),
+        "robot_path": robot,
+        "workbook": str(workbook_path),
+        "governed_row_count": len(governed.processed_rows),
+        "source_graph": {
+            "triple_count": len(source_graph),
+            "round_trip_triple_count": len(source_round_trip),
+            "round_trip_isomorphic": source_round_trip_ok,
+            "owl_imports_count": len(
+                list(source_graph.triples((None, OWL.imports, None)))
+            ),
+            "sha256": sha256(artifacts.source_graph_path),
+        },
+        "coverage_graph": {
+            "triple_count": len(coverage_graph),
+            "round_trip_triple_count": len(coverage_round_trip),
+            "round_trip_isomorphic": coverage_round_trip_ok,
+            "sha256": sha256(artifacts.coverage_graph_path),
+        },
+        "source_query": {
+            "passed": source_query_ok,
+            "query": str(SOURCE_QUERY),
+            "rdflib_row_count": len(source_rdflib_rows),
+            "robot_row_count": len(source_robot.rows),
+            "same_ordered_rows": source_rdflib_rows == source_robot.rows,
+            "rdflib_only_rows": source_rdflib_only,
+            "robot_only_rows": source_robot_only,
+            "robot_return_code": source_robot.return_code,
+            "robot_output": source_robot.output,
+            "robot_output_exists": source_robot.output_exists,
+            "robot_output_bytes": source_robot.output_bytes,
+            "robot_header": list(source_robot.header),
+        },
+        "unmapped_query": {
+            "passed": coverage_query_ok,
+            "query": str(UNMAPPED_QUERY),
+            "rdflib_row_count": len(coverage_rdflib_rows),
+            "robot_row_count": len(coverage_robot.rows),
+            "same_ordered_rows": coverage_rdflib_rows == coverage_robot.rows,
+            "rdflib_only_rows": coverage_rdflib_only,
+            "robot_only_rows": coverage_robot_only,
+            "robot_return_code": coverage_robot.return_code,
+            "robot_output": coverage_robot.output,
+            "robot_output_exists": coverage_robot.output_exists,
+            "robot_output_bytes": coverage_robot.output_bytes,
+            "robot_header": list(coverage_robot.header),
+        },
+    }
+
+    artifacts.summary_path.write_text(
+        json.dumps(summary, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    return summary
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--input",
+        default=str(REPO_ROOT / "mappings/SSN2BFO-COMS.xlsx"),
+        help="Governed COMS workbook.",
+    )
+    parser.add_argument(
+        "--output-dir",
+        required=True,
+        help="Directory for temporary pilot artifacts.",
+    )
+    parser.add_argument(
+        "--robot",
+        help="Optional explicit ROBOT executable path.",
+    )
+    args = parser.parse_args(argv)
+
+    summary = run_pilot(
+        Path(args.input),
+        Path(args.output_dir),
+        args.robot,
+    )
+
+    source = summary["source_query"]
+    unmapped = summary["unmapped_query"]
+
+    print(f"Governed rows: {summary['governed_row_count']}")
+    print(f"Source graph triples: {summary['source_graph']['triple_count']}")
+    print(f"Source RDFLib rows: {source['rdflib_row_count']}")
+    print(f"Source ROBOT rows: {source['robot_row_count']}")
+    print(f"Unmapped RDFLib rows: {unmapped['rdflib_row_count']}")
+    print(f"Unmapped ROBOT rows: {unmapped['robot_row_count']}")
+    print(
+        "ROBOT empty-result bytes: "
+        f"{unmapped['robot_output_bytes']}"
+    )
+    print("Summary: PASS" if summary["passed"] else "Summary: FAIL")
+
+    for query_summary in (source, unmapped):
+        if query_summary["robot_output"]:
+            print(query_summary["robot_output"])
+
+    return 0 if summary["passed"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/run_validation_suite.py
+++ b/tools/run_validation_suite.py
@@ -398,6 +398,7 @@ def compile_check() -> StepResult:
             "tools/generate_mapping_from_coms.py",
             "tools/robot_template_generation_pilot.py",
             "tools/robot_property_chain_generation_pilot.py",
+            "tools/robot_query_equivalence_pilot.py",
             "tools/robot_reconstruction_validation.py",
             "tools/validate_robot_reconstruction.py",
             "tools/check_coms_mapping.py",
@@ -413,6 +414,7 @@ def compile_check() -> StepResult:
             "tests/test_generate_mapping_from_coms.py",
             "tests/test_robot_template_generation_pilot.py",
             "tests/test_robot_property_chain_generation_pilot.py",
+            "tests/test_robot_query_equivalence_pilot.py",
             "tests/test_robot_reconstruction_validation.py",
             "tests/test_coms_row_identity.py",
             "tests/test_product_dispositions.py",
@@ -726,13 +728,14 @@ def run_validation_suite(args: argparse.Namespace) -> int:
     if results[-1].passed:
         results.append(
             run_command(
-                "ROBOT reconstruction focused tests",
+                "ROBOT focused tests",
                 [
                     sys.executable,
                     "-m",
                     "unittest",
                     "tests.test_robot_template_generation_pilot",
                     "tests.test_robot_property_chain_generation_pilot",
+                    "tests.test_robot_query_equivalence_pilot",
                     "tests.test_robot_reconstruction_validation",
                 ],
             )


### PR DESCRIPTION
## Summary

- add a permanent read-only equivalence gate for the two governed COMS coverage queries
- compare RDFLib and ROBOT 1.9.7 results using exact ordered-row equality
- preserve Python-built source and coverage graphs as the authoritative query inputs
- handle ROBOT's zero-byte CSV representation for empty SELECT results
- verify deterministic results across two runs and protect all maintained ontology products from modification
- record the successful pilot and remaining `robot verify` work in the substitution audit

## Validation

- `make compile`
- focused ROBOT test suite: 8 tests passed
- full `make validate`: PASS
- exact source query: 91 RDFLib rows = 91 ROBOT rows
- exact unmapped query: 0 RDFLib rows = 0 ROBOT rows
- `git diff --check`
