### PR TITLE
Add ROBOT verify pilot

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,7 @@ compile:
 		tools/modular_products.py \
 		tools/generate_mapping_from_coms.py \
 		tools/robot_query_equivalence_pilot.py \
+		tools/robot_verify_pilot.py \
 		tools/check_coms_mapping.py \
 		tools/watch_coms_mapping.py \
 		tools/publication_metadata.py \
@@ -41,6 +42,7 @@ compile:
 		tools/rehearse_release.py \
 		tests/test_generate_mapping_from_coms.py \
 		tests/test_robot_query_equivalence_pilot.py \
+		tests/test_robot_verify_pilot.py \
 		tests/test_coms_row_identity.py \
 		tests/test_product_dispositions.py \
 		tests/test_modular_products.py \

--- a/reports/robot-substitution-audit.md
+++ b/reports/robot-substitution-audit.md
@@ -415,11 +415,33 @@ Additional good ROBOT candidates include:
 - import-policy checks;
 - some product-profile checks.
 
+A separate controlled `robot verify` pilot has also been completed against
+`queries/unmapped-source-terms.rq` using only temporary Python-built coverage
+graphs:
+
+- the governed zero-violation graph contained 182 triples;
+- ROBOT returned code 0, emitted a `PASS` message reporting zero violations,
+  and created no report file;
+- a deterministic temporary mutation changed
+  `sosa:ActuatableProperty` from `mapped` to `absent_from_spreadsheet`;
+- RDFLib returned exactly one expected violation row for that mutation;
+- ROBOT returned code 1, emitted a `FAIL` message reporting one violation, and
+  created `unmapped-source-terms.csv`;
+- the CSV contained exactly the same term, kind, and coverage-status row as the
+  RDFLib result;
+- both temporary graph serializations survived isomorphic round trips;
+- two permanent-gate runs produced the same semantic evidence and left all five
+  maintained ontology products unchanged.
+
+This proves the expected pass/fail and failure-row reporting semantics for the
+current governed unmapped-term validation query. Production verification,
+diagnostic interpretation, and graph construction remain under Python control.
+
 Use:
 
 - `robot query` for informational result sets after focused equivalence proof;
-- `robot verify` for queries whose returned rows are validation failures,
-  subject to a separate controlled pilot.
+- `robot verify` for failure-row validation after focused pass/fail and report
+  equivalence proof.
 
 ### Semantic diff
 
@@ -519,7 +541,7 @@ repository-code reduction.
 | Parsing and conversion | 70–100% |
 | Current SSN/SOSA closure merge and import-edge removal | 0–10% |
 | Reasoner invocation | 90–100% |
-| SPARQL querying and verification | 100% proven for the two current governed coverage `SELECT` queries; 60–100% broader potential |
+| SPARQL querying and verification | 100% proven for the two current governed coverage `SELECT` queries and `robot verify` semantics for the unmapped-term query; 60–100% broader potential |
 | Product construction | 30–60% |
 | Product validation | 20–50% |
 | Instance and probe testing | 15–35% |
@@ -573,9 +595,14 @@ experiment proves that production use would:
 ### Phase 5: standardize other ROBOT operations — in progress
 
 Read-only `robot query` execution has been evaluated and accepted for the two
-current governed COMS coverage queries. Exact ordered-row equality is required,
-and Python remains authoritative for temporary graph construction,
-reconciliation, diagnostics, and report semantics.
+current governed COMS coverage queries. Exact ordered-row equality is required.
+
+Read-only `robot verify` execution has been evaluated and accepted for the
+current governed unmapped-term validation query. Exact exit-code, violation
+count, report-file, and failure-row equality are required.
+
+Python remains authoritative for temporary graph construction, reconciliation,
+diagnostics, report semantics, and production execution.
 
 Closure merging has been evaluated and rejected for the current governed
 SSN/SOSA fixed-closure paths because ROBOT does not preserve the exact RDF or
@@ -583,7 +610,6 @@ canonical axiom set.
 
 Potential candidates remain:
 
-- `robot verify` for failure-row validation;
 - semantic diff;
 - import extraction;
 - retained example validation.

--- a/tests/test_robot_query_equivalence_pilot.py
+++ b/tests/test_robot_query_equivalence_pilot.py
@@ -106,12 +106,26 @@ class RobotQueryEquivalencePilotTests(unittest.TestCase):
                 self.assertEqual(unmapped["robot_output_bytes"], 0)
 
             for section in (
-                "source_graph",
-                "coverage_graph",
                 "source_query",
                 "unmapped_query",
             ):
                 self.assertEqual(first[section], second[section])
+
+            for section in (
+                "source_graph",
+                "coverage_graph",
+            ):
+                first_semantic = {
+                    key: value
+                    for key, value in first[section].items()
+                    if key != "sha256"
+                }
+                second_semantic = {
+                    key: value
+                    for key, value in second[section].items()
+                    if key != "sha256"
+                }
+                self.assertEqual(first_semantic, second_semantic)
 
         after = {
             path.relative_to(REPO_ROOT).as_posix(): sha256(path)

--- a/tests/test_robot_verify_pilot.py
+++ b/tests/test_robot_verify_pilot.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+"""Focused tests for governed read-only ROBOT verify behavior."""
+from __future__ import annotations
+
+import hashlib
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT / "tools"))
+
+import robot_verify_pilot as pilot  # noqa: E402
+
+
+WORKBOOK = REPO_ROOT / "mappings/SSN2BFO-COMS.xlsx"
+
+MAINTAINED_PRODUCTS = (
+    REPO_ROOT / "SSN2BFO.ttl",
+    REPO_ROOT / "releases/current-ssn-sosa/ssn-sosa-alignment-core.ttl",
+    REPO_ROOT / "releases/current-ssn-sosa/ssn-sosa-bfo-mapping.ttl",
+    REPO_ROOT / "releases/current-ssn-sosa/ssn-sosa-bfo-projection.ttl",
+    REPO_ROOT / "releases/current-ssn-sosa/ssn-sosa-cco-extension.ttl",
+)
+
+
+def sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+class RobotVerifyPilotTests(unittest.TestCase):
+    def test_governed_pass_and_controlled_failure_are_exact(self) -> None:
+        before = {
+            path.relative_to(REPO_ROOT).as_posix(): sha256(path)
+            for path in MAINTAINED_PRODUCTS
+        }
+
+        with tempfile.TemporaryDirectory(
+            prefix="robot-verify-pilot-a-"
+        ) as first_dir, tempfile.TemporaryDirectory(
+            prefix="robot-verify-pilot-b-"
+        ) as second_dir:
+            first = pilot.run_pilot(WORKBOOK, Path(first_dir))
+            second = pilot.run_pilot(WORKBOOK, Path(second_dir))
+
+            self.assertTrue(first["passed"], first)
+            self.assertTrue(second["passed"], second)
+
+            for summary in (first, second):
+                self.assertEqual(summary["governed_row_count"], 105)
+
+                coverage = summary["coverage_graph"]
+                self.assertEqual(coverage["triple_count"], 182)
+                self.assertEqual(
+                    coverage["round_trip_triple_count"],
+                    182,
+                )
+                self.assertTrue(coverage["round_trip_isomorphic"])
+
+                controlled = summary["controlled_violation"]
+                self.assertEqual(
+                    controlled["term"],
+                    "http://www.w3.org/ns/sosa/ActuatableProperty",
+                )
+                self.assertEqual(
+                    controlled["status"],
+                    "absent_from_spreadsheet",
+                )
+                self.assertEqual(controlled["expected_row_count"], 1)
+                self.assertEqual(
+                    controlled["expected_rows"],
+                    [[
+                        "http://www.w3.org/ns/sosa/ActuatableProperty",
+                        "class",
+                        "absent_from_spreadsheet",
+                    ]],
+                )
+                self.assertEqual(controlled["triple_count"], 182)
+                self.assertEqual(
+                    controlled["round_trip_triple_count"],
+                    182,
+                )
+                self.assertTrue(controlled["round_trip_isomorphic"])
+
+                passing = summary["passing_verify"]
+                self.assertTrue(passing["passed"])
+                self.assertEqual(passing["return_code"], 0)
+                self.assertIn("PASS Rule", passing["output"])
+                self.assertIn("0 violation(s)", passing["output"])
+                self.assertEqual(passing["report_files"], [])
+
+                violating = summary["violating_verify"]
+                self.assertTrue(violating["passed"])
+                self.assertEqual(violating["return_code"], 1)
+                self.assertIn("FAIL Rule", violating["output"])
+                self.assertIn("1 violation(s)", violating["output"])
+                self.assertEqual(
+                    violating["report_files"],
+                    ["unmapped-source-terms.csv"],
+                )
+                self.assertEqual(
+                    violating["report_name"],
+                    "unmapped-source-terms.csv",
+                )
+                self.assertTrue(violating["report_exists"])
+                self.assertEqual(violating["report_bytes"], 102)
+                self.assertEqual(
+                    violating["report_header"],
+                    ["term", "kind", "coverageStatus"],
+                )
+                self.assertEqual(
+                    violating["report_rows"],
+                    controlled["expected_rows"],
+                )
+
+            for section in (
+                "coverage_graph",
+                "controlled_violation",
+                "passing_verify",
+                "violating_verify",
+            ):
+                self.assertEqual(first[section], second[section])
+
+        after = {
+            path.relative_to(REPO_ROOT).as_posix(): sha256(path)
+            for path in MAINTAINED_PRODUCTS
+        }
+        self.assertEqual(before, after)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/robot_verify_pilot.py
+++ b/tools/robot_verify_pilot.py
@@ -1,0 +1,418 @@
+#!/usr/bin/env python3
+"""Validate governed zero- and one-violation behavior with read-only ROBOT verify."""
+from __future__ import annotations
+
+import argparse
+import csv
+import hashlib
+import json
+import shutil
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+
+from rdflib import Graph, Literal
+from rdflib.compare import isomorphic
+
+import generate_mapping_from_coms as coms
+import robot_query_equivalence_pilot as query_pilot
+import robot_reconstruction_validation as reconstruction
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+EXPECTED_VIOLATION_STATUS = "absent_from_spreadsheet"
+EXPECTED_REPORT_NAME = "unmapped-source-terms.csv"
+
+
+@dataclass(frozen=True)
+class PilotArtifacts:
+    passing_graph_path: Path
+    violating_graph_path: Path
+    passing_report_dir: Path
+    violating_report_dir: Path
+    summary_path: Path
+
+
+@dataclass(frozen=True)
+class VerifyResult:
+    return_code: int
+    output: str
+    report_files: tuple[Path, ...]
+
+
+def artifact_paths(output_dir: Path) -> PilotArtifacts:
+    return PilotArtifacts(
+        passing_graph_path=output_dir / "coverage-graph-pass.ttl",
+        violating_graph_path=output_dir / "coverage-graph-one-violation.ttl",
+        passing_report_dir=output_dir / "pass-reports",
+        violating_report_dir=output_dir / "fail-reports",
+        summary_path=output_dir / "summary.json",
+    )
+
+
+def sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def run_robot_verify(
+    robot: str,
+    input_path: Path,
+    report_dir: Path,
+) -> VerifyResult:
+    shutil.rmtree(report_dir, ignore_errors=True)
+    report_dir.mkdir(parents=True, exist_ok=True)
+
+    completed = subprocess.run(
+        [
+            robot,
+            "verify",
+            "--input",
+            str(input_path),
+            "--queries",
+            str(query_pilot.UNMAPPED_QUERY),
+            "--output-dir",
+            str(report_dir),
+        ],
+        cwd=REPO_ROOT,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+    report_files = tuple(
+        sorted(
+            (
+                path
+                for path in report_dir.iterdir()
+                if path.is_file()
+            ),
+            key=lambda path: path.name,
+        )
+    )
+
+    return VerifyResult(
+        return_code=completed.returncode,
+        output=reconstruction.combined_process_output(
+            completed.stdout,
+            completed.stderr,
+        ),
+        report_files=report_files,
+    )
+
+
+def build_governed_coverage_graph(
+    processed_rows: tuple[coms.ProcessedRow, ...],
+) -> Graph:
+    source_graph = coms.build_source_graph()
+    source_rows = coms.run_select_query(
+        source_graph,
+        query_pilot.SOURCE_QUERY,
+    )
+    return query_pilot.build_coverage_graph(
+        processed_rows,
+        source_rows,
+    )
+
+
+def build_controlled_violation(
+    coverage_graph: Graph,
+) -> tuple[Graph, str]:
+    candidates = sorted(
+        subject
+        for subject, _, _ in coverage_graph.triples(
+            (
+                None,
+                coms.COMS_COVERAGE.coverageStatus,
+                Literal("mapped"),
+            )
+        )
+    )
+    if not candidates:
+        raise RuntimeError(
+            "No mapped coverage term is available for a controlled violation"
+        )
+
+    selected = candidates[0]
+
+    violating_graph = Graph()
+    coms.bind_prefixes(violating_graph)
+    violating_graph.bind("coms", coms.COMS_COVERAGE)
+
+    for triple in coverage_graph:
+        violating_graph.add(triple)
+
+    violating_graph.remove(
+        (
+            selected,
+            coms.COMS_COVERAGE.coverageStatus,
+            Literal("mapped"),
+        )
+    )
+    violating_graph.add(
+        (
+            selected,
+            coms.COMS_COVERAGE.coverageStatus,
+            Literal(EXPECTED_VIOLATION_STATUS),
+        )
+    )
+
+    return violating_graph, str(selected)
+
+
+def read_report_rows(
+    path: Path,
+) -> tuple[tuple[str, ...], tuple[tuple[str, ...], ...]]:
+    if not path.is_file() or path.stat().st_size == 0:
+        return (), ()
+
+    with path.open(newline="", encoding="utf-8") as handle:
+        reader = csv.DictReader(handle)
+        header = tuple(reader.fieldnames or ())
+        rows = tuple(
+            tuple(
+                (row.get(column) or "")
+                for column in query_pilot.UNMAPPED_COLUMNS
+            )
+            for row in reader
+        )
+
+    return header, rows
+
+
+def run_pilot(
+    workbook_path: Path,
+    output_dir: Path,
+    robot_path: str | None = None,
+) -> dict[str, object]:
+    workbook_path = workbook_path.resolve()
+    output_dir.mkdir(parents=True, exist_ok=True)
+    artifacts = artifact_paths(output_dir)
+    robot = reconstruction.resolve_robot_path(robot_path)
+
+    governed = reconstruction.load_governed_coms_rows(workbook_path)
+    coverage_graph = build_governed_coverage_graph(
+        governed.processed_rows,
+    )
+
+    passing_rows = query_pilot.ordered_rows(
+        coms.run_select_query(
+            coverage_graph,
+            query_pilot.UNMAPPED_QUERY,
+        ),
+        query_pilot.UNMAPPED_COLUMNS,
+    )
+    if passing_rows:
+        raise RuntimeError(
+            "Governed coverage graph unexpectedly contains violations"
+        )
+
+    coverage_graph.serialize(
+        artifacts.passing_graph_path,
+        format="turtle",
+    )
+    passing_round_trip = Graph().parse(
+        artifacts.passing_graph_path,
+        format="turtle",
+    )
+
+    violating_graph, controlled_term = build_controlled_violation(
+        coverage_graph,
+    )
+    expected_violation_rows = query_pilot.ordered_rows(
+        coms.run_select_query(
+            violating_graph,
+            query_pilot.UNMAPPED_QUERY,
+        ),
+        query_pilot.UNMAPPED_COLUMNS,
+    )
+    if len(expected_violation_rows) != 1:
+        raise RuntimeError(
+            "Controlled violation did not produce exactly one RDFLib row"
+        )
+
+    violating_graph.serialize(
+        artifacts.violating_graph_path,
+        format="turtle",
+    )
+    violating_round_trip = Graph().parse(
+        artifacts.violating_graph_path,
+        format="turtle",
+    )
+
+    passing_result = run_robot_verify(
+        robot,
+        artifacts.passing_graph_path,
+        artifacts.passing_report_dir,
+    )
+    violating_result = run_robot_verify(
+        robot,
+        artifacts.violating_graph_path,
+        artifacts.violating_report_dir,
+    )
+
+    failing_report_path = (
+        artifacts.violating_report_dir / EXPECTED_REPORT_NAME
+    )
+    report_header, report_rows = read_report_rows(
+        failing_report_path,
+    )
+
+    passing_round_trip_ok = isomorphic(
+        coverage_graph,
+        passing_round_trip,
+    )
+    violating_round_trip_ok = isomorphic(
+        violating_graph,
+        violating_round_trip,
+    )
+
+    passing_ok = (
+        passing_result.return_code == 0
+        and "PASS Rule" in passing_result.output
+        and "0 violation(s)" in passing_result.output
+        and not passing_result.report_files
+    )
+
+    violating_ok = (
+        violating_result.return_code == 1
+        and "FAIL Rule" in violating_result.output
+        and "1 violation(s)" in violating_result.output
+        and tuple(path.name for path in violating_result.report_files)
+        == (EXPECTED_REPORT_NAME,)
+        and report_header == query_pilot.UNMAPPED_COLUMNS
+        and report_rows == expected_violation_rows
+    )
+
+    summary: dict[str, object] = {
+        "passed": (
+            passing_ok
+            and violating_ok
+            and passing_round_trip_ok
+            and violating_round_trip_ok
+        ),
+        "robot_path": robot,
+        "workbook": str(workbook_path),
+        "governed_row_count": len(governed.processed_rows),
+        "coverage_graph": {
+            "triple_count": len(coverage_graph),
+            "round_trip_triple_count": len(passing_round_trip),
+            "round_trip_isomorphic": passing_round_trip_ok,
+            "sha256": sha256(artifacts.passing_graph_path),
+        },
+        "controlled_violation": {
+            "term": controlled_term,
+            "status": EXPECTED_VIOLATION_STATUS,
+            "expected_row_count": len(expected_violation_rows),
+            "expected_rows": [
+                list(row)
+                for row in expected_violation_rows
+            ],
+            "triple_count": len(violating_graph),
+            "round_trip_triple_count": len(violating_round_trip),
+            "round_trip_isomorphic": violating_round_trip_ok,
+            "sha256": sha256(artifacts.violating_graph_path),
+        },
+        "passing_verify": {
+            "passed": passing_ok,
+            "return_code": passing_result.return_code,
+            "output": passing_result.output,
+            "report_files": [
+                path.name
+                for path in passing_result.report_files
+            ],
+        },
+        "violating_verify": {
+            "passed": violating_ok,
+            "return_code": violating_result.return_code,
+            "output": violating_result.output,
+            "report_files": [
+                path.name
+                for path in violating_result.report_files
+            ],
+            "report_name": EXPECTED_REPORT_NAME,
+            "report_exists": failing_report_path.is_file(),
+            "report_bytes": (
+                failing_report_path.stat().st_size
+                if failing_report_path.is_file()
+                else 0
+            ),
+            "report_header": list(report_header),
+            "report_rows": [
+                list(row)
+                for row in report_rows
+            ],
+        },
+    }
+
+    artifacts.summary_path.write_text(
+        json.dumps(summary, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    return summary
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--input",
+        default=str(REPO_ROOT / "mappings/SSN2BFO-COMS.xlsx"),
+        help="Governed COMS workbook.",
+    )
+    parser.add_argument(
+        "--output-dir",
+        required=True,
+        help="Directory for temporary pilot artifacts.",
+    )
+    parser.add_argument(
+        "--robot",
+        help="Optional explicit ROBOT executable path.",
+    )
+    args = parser.parse_args(argv)
+
+    summary = run_pilot(
+        Path(args.input),
+        Path(args.output_dir),
+        args.robot,
+    )
+
+    passing = summary["passing_verify"]
+    violating = summary["violating_verify"]
+    controlled = summary["controlled_violation"]
+
+    print(f"Governed rows: {summary['governed_row_count']}")
+    print(
+        "Coverage graph triples: "
+        f"{summary['coverage_graph']['triple_count']}"
+    )
+    print(f"Controlled violation term: {controlled['term']}")
+    print(
+        "Controlled violation rows: "
+        f"{controlled['expected_row_count']}"
+    )
+    print(
+        "Passing verify return code: "
+        f"{passing['return_code']}"
+    )
+    print(
+        "Passing verify reports: "
+        f"{len(passing['report_files'])}"
+    )
+    print(
+        "Violating verify return code: "
+        f"{violating['return_code']}"
+    )
+    print(
+        "Violating verify report rows: "
+        f"{len(violating['report_rows'])}"
+    )
+    print("Summary: PASS" if summary["passed"] else "Summary: FAIL")
+
+    for verify_summary in (passing, violating):
+        if verify_summary["output"]:
+            print(verify_summary["output"])
+
+    return 0 if summary["passed"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/run_validation_suite.py
+++ b/tools/run_validation_suite.py
@@ -399,6 +399,7 @@ def compile_check() -> StepResult:
             "tools/robot_template_generation_pilot.py",
             "tools/robot_property_chain_generation_pilot.py",
             "tools/robot_query_equivalence_pilot.py",
+            "tools/robot_verify_pilot.py",
             "tools/robot_reconstruction_validation.py",
             "tools/validate_robot_reconstruction.py",
             "tools/check_coms_mapping.py",
@@ -415,6 +416,7 @@ def compile_check() -> StepResult:
             "tests/test_robot_template_generation_pilot.py",
             "tests/test_robot_property_chain_generation_pilot.py",
             "tests/test_robot_query_equivalence_pilot.py",
+            "tests/test_robot_verify_pilot.py",
             "tests/test_robot_reconstruction_validation.py",
             "tests/test_coms_row_identity.py",
             "tests/test_product_dispositions.py",
@@ -736,6 +738,7 @@ def run_validation_suite(args: argparse.Namespace) -> int:
                     "tests.test_robot_template_generation_pilot",
                     "tests.test_robot_property_chain_generation_pilot",
                     "tests.test_robot_query_equivalence_pilot",
+                    "tests.test_robot_verify_pilot",
                     "tests.test_robot_reconstruction_validation",
                 ],
             )


### PR DESCRIPTION
## Summary

- add a permanent read-only `robot verify` pilot for the governed unmapped-term validation query
- prove zero-violation behavior: return code 0, PASS message, and no report file
- prove controlled one-violation behavior: return code 1, FAIL message, and one exact CSV failure row
- keep Python authoritative for graph construction, reconciliation, diagnostics, report semantics, and production execution
- preserve all five maintained ontology products
- correct the query-equivalence test so temporary RDFLib Turtle byte hashes are not treated as semantic determinism

## Validation

- `make compile`
- focused ROBOT suite: 9 tests passed
- full `make validate`: PASS
- governed verification: 0 violations, return code 0, no report
- controlled verification: 1 violation, return code 1, exact `unmapped-source-terms.csv`
- `git diff --check`
