### PR TITLE
Document SOSA-next consumer readiness

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: validate validate-write audit-write legacy-audit-write compile check check-coms check-sosa-next check-coms-row-identities check-coms-product-dispositions check-alignment-core check-strict-bfo-mapping check-cco-extension check-bfo-projection check-publication-metadata check-release-rendering check-release-package check-release-archive check-release-rehearsal check-placeholder-catalog-migration watch-coms coms-status post-merge-check status diffstat generate-sosa-next-products check-sosa-next-products
+.PHONY: validate validate-write audit-write legacy-audit-write compile check check-coms check-sosa-next check-coms-row-identities check-coms-product-dispositions check-alignment-core check-strict-bfo-mapping check-cco-extension check-bfo-projection check-publication-metadata check-release-rendering check-release-package check-release-archive check-release-rehearsal check-placeholder-catalog-migration watch-coms coms-status post-merge-check status diffstat generate-sosa-next-products check-sosa-next-products check-sosa-next-consumer-stack
 
 validate:
 	PYTHONDONTWRITEBYTECODE=1 python tools/run_validation_suite.py
@@ -49,6 +49,7 @@ compile:
 		tests/test_generate_mapping_from_coms.py \
 		tests/test_check_sosa_next_mapping.py \
 		tests/test_sosa_next_products.py \
+		tests/test_sosa_next_consumer_stack.py \
 		tests/test_robot_diff_pilot.py \
 		tests/test_robot_extract_pilot.py \
 		tests/test_robot_query_equivalence_pilot.py \
@@ -106,6 +107,9 @@ generate-sosa-next-products:
 check-sosa-next-products:
 	PYTHONDONTWRITEBYTECODE=1 python -m unittest discover -s tests -p 'test_sosa_next_products.py'
 	PYTHONDONTWRITEBYTECODE=1 python tools/check_sosa_next_products.py
+
+check-sosa-next-consumer-stack:
+	PYTHONDONTWRITEBYTECODE=1 python -m unittest discover -s tests -p 'test_sosa_next_consumer_stack.py'
 
 check-coms:
 	PYTHONDONTWRITEBYTECODE=1 python tools/check_coms_mapping.py

--- a/README.md
+++ b/README.md
@@ -24,6 +24,47 @@ For reproducible use, prefer the tagged release assets rather than files from an
 
 See [Product Architecture](docs/PRODUCT-ARCHITECTURE.md) for the relationships among these products.
 
+## SOSA-next maintained development products
+
+The repository also maintains a governed development track for the forthcoming
+SOSA source. These products are generated from
+`mappings/SOSA-next-to-BFO-COMS.xlsx`:
+
+| Product | File | Use when |
+| --- | --- | --- |
+| SOSA-next alignment core | `releases/sosa-next/sosa-alignment-core.ttl` | You need the import-free target-neutral project layer |
+| SOSA-next BFO mapping | `releases/sosa-next/sosa-bfo-mapping.ttl` | You need the governed BFO-bearing mappings |
+| SOSA-next CCO extension | `releases/sosa-next/sosa-cco-extension.ttl` | You need the complete layered SOSA-next project stack |
+
+The project import chain is:
+
+```text
+SOSA-next CCO extension
+  -> SOSA-next BFO mapping
+    -> SOSA-next alignment core
+```
+
+For development use in an ontology editor, load
+`src/sosa-next/sosa-mappings-edit.ttl` with
+`src/sosa-next/catalog-v001.xml`. The editor imports the CCO extension and
+obtains the other project modules transitively. External SOSA, BFO, and CCO
+dependencies remain separate consumer or validation inputs.
+
+These files are maintained authoritative development artifacts, but they are
+not part of the current formal release. The temporary `sosa-next` identity must
+be replaced by the approved source-version identity before formal publication.
+
+Focused development validation:
+
+```bash
+make check-sosa-next
+make check-sosa-next-products
+make check-sosa-next-consumer-stack
+```
+
+See [SOSA-next Development Products](src/sosa-next/docs/README.md) and the
+[formal-release integration audit](reports/sosa-next-formal-release-integration-audit.md).
+
 ## Release
 
 The current governed release is [`v2026-07-18`](https://github.com/BFO-Mappings/SSN-to-BFO/releases/tag/v2026-07-18).

--- a/docs/PRODUCT-ARCHITECTURE.md
+++ b/docs/PRODUCT-ARCHITECTURE.md
@@ -137,10 +137,72 @@ Development artifacts emit exactly seven governed annotations:
 
 Formal release rendering retains the stable ontology IRI, replaces the development authority status with the immutable-release status, and adds the governed formal release identity.
 
-## Inactive source scaffolding
+## Retired current-track scaffolding
 
-The former current-track editor, direct-mapping shells, development catalog, and ungoverned hierarchy-projection analysis have been retired.
+The former current-track editor, direct-mapping shells,
+development catalog, and ungoverned hierarchy-projection analysis have been
+retired.
 
-The separate `sosa-next` scaffold remains intentionally retained but inactive. Its temporary editor source, catalog, release shells, and optional local targets do not participate in current generation, validation, package construction, or publication.
+## SOSA-next maintained development track
 
-The inactive scaffold is not an alias or compatibility layer for the maintained current-track products.
+The separate SOSA-next track is now an active maintained development track,
+not inactive scaffolding. Its sole editable mapping authority is
+`mappings/SOSA-next-to-BFO-COMS.xlsx`.
+
+It consists of exactly three generated ontology products:
+
+| Product | Path | Direct axioms | Total triples |
+| --- | --- | ---: | ---: |
+| Alignment core | `releases/sosa-next/sosa-alignment-core.ttl` | 0 | 8 |
+| BFO mapping | `releases/sosa-next/sosa-bfo-mapping.ttl` | 21 | 166 |
+| CCO extension | `releases/sosa-next/sosa-cco-extension.ttl` | 24 | 125 |
+
+Their import graph is:
+
+```text
+SOSA-next alignment core
+          ↑
+SOSA-next BFO mapping
+          ↑
+SOSA-next CCO extension
+          ↑
+SOSA-next editor shell
+```
+
+The three maintained products contain 45 canonical authoritative axioms. Their
+logical union has 273 triples and is isomorphic to the integrated active
+mapping graph used during validation. The catalog-resolved editor stack,
+including ontology metadata and project imports, contains 303 distinct
+triples.
+
+The alignment core imports no project or external ontology. The BFO mapping
+imports only the alignment core. The CCO extension imports only the BFO
+mapping. The editor shell imports only the CCO extension. External SOSA, BFO,
+and CCO dependencies are resolved separately by consumers or assembled only
+in temporary validation closures; their triples are not serialized into the
+maintained project products.
+
+The initial SOSA-next product set intentionally has no integrated ontology and
+no BFO-projection product. Those products require separate consumer and
+governance justification rather than automatic duplication of the current
+SSN/SOSA architecture.
+
+Focused validation:
+
+```bash
+make check-sosa-next
+make check-sosa-next-products
+make check-sosa-next-consumer-stack
+```
+
+The SOSA-next products are not yet formal-release products. Current release
+metadata, manifest, package, archive, and rehearsal tooling remain authoritative
+only for the five-product current SSN/SOSA track. Formal publication is blocked
+until the temporary `sosa-next` path and ontology-IRI component is replaced by
+an approved source-version identity and the release machinery is deliberately
+extended.
+
+The earlier `reports/publication-product-and-import-policy.md` records the
+pre-activation lifecycle policy. For the implemented SOSA-next development
+track, `reports/sosa-next-product-contract.md` is the controlling product
+contract.

--- a/docs/VALIDATION-AND-RELEASES.md
+++ b/docs/VALIDATION-AND-RELEASES.md
@@ -10,6 +10,8 @@ It includes:
 - COMS row-identity validation
 - product-disposition validation
 - modular-product tests
+- SOSA-next maintained-product tests
+- SOSA-next catalog consumer-stack tests
 - publication-metadata validation
 - formal release-context and rendering tests
 - release-package, archive, and rehearsal tests
@@ -46,17 +48,66 @@ make check
 
 ## Dependency and catalog policy
 
-No development XML catalog is required.
+The current SSN/SOSA COMS transaction does not require a
+development XML catalog. It explicitly loads pinned local dependencies under
+`imports/` and resolves maintained current-track project imports through
+governed local paths.
 
-Validation explicitly loads the pinned local Turtle dependencies under `imports/` and resolves project-module imports through governed local paths.
+The SOSA-next development track has a separate governed catalog at
+`src/sosa-next/catalog-v001.xml`. It resolves:
 
-`imports/cco.ttl` is a flattened merged CCO/BFO validation dependency. It is not a placeholder, mapping authority, or imported component of every published product.
+- nine pinned forthcoming-SOSA source files;
+- the governed merged CCO/BFO validation dependency;
+- the three maintained SOSA-next project products;
+- the SOSA-next editor shell.
 
-The XML catalog inside a formal release package is different from a development catalog. It maps exactly the five immutable same-release version IRIs to package-relative products.
+The maintained SOSA-next project products import only other SOSA-next project
+products. They do not import the external source or target dependencies
+resolved by the catalog.
+
+`imports/cco.ttl` remains a flattened merged CCO/BFO validation dependency. It
+is not a placeholder, mapping authority, or serialized import of every
+published product.
+
+The XML catalog inside a formal current-track release package is a different
+artifact. It maps exactly the five immutable same-release version IRIs to
+package-relative products. The development SOSA-next catalog is not currently
+copied into a formal package.
+
+## SOSA-next development validation
+
+The forthcoming-SOSA workbook and its three maintained products have separate
+focused gates:
+
+```bash
+make check-sosa-next
+make check-sosa-next-products
+make check-sosa-next-consumer-stack
+```
+
+`make check-sosa-next` validates the 119 governed workbook rows, 45 active
+mappings, 26 deferred mappings, 48 explicitly unmapped rows, canonical
+identity, and a clean HermiT result for the integrated active mapping.
+
+`make check-sosa-next-products` independently rebuilds the three products,
+requires byte-identical candidate builds, validates exact hashes and triple
+counts, reconstructs the 273-triple logical graph, checks transactional
+rollback behavior, and requires zero named unsatisfiable classes in all three
+product-specific reasoning profiles.
+
+`make check-sosa-next-consumer-stack` resolves every catalog target locally,
+parses all dependency and project entries, verifies the exact project import
+graph, loads the editor closure, and confirms that external dependencies remain
+separate from the maintained project imports.
+
+These checks are included in `make check` and hosted CI. They validate
+maintained development artifacts only; they do not create a formal version
+IRI, manifest, package, archive, tag, GitHub release, or persistent-IRI
+deployment.
 
 ## Publication metadata
 
-`config/publication-metadata.toml` is the sole editable publication-metadata source.
+`config/publication-metadata.toml` is the sole editable publication-metadata source for the current five-product formal-release track.
 
 Development-mode validation:
 
@@ -85,7 +136,7 @@ Formal renderers:
 
 ## Release package
 
-`tools/build_release.py` builds a deterministic candidate package only at an explicit absent output directory.
+`tools/build_release.py` builds a deterministic current-track candidate package only at an explicit absent output directory.
 
 `tools/check_release.py validate --package-dir PATH` validates an existing package read-only.
 

--- a/reports/coms-automatic-validation-setup.md
+++ b/reports/coms-automatic-validation-setup.md
@@ -67,7 +67,9 @@ The manifest excludes itself and `SHA256SUMS` from `included_files`; `SHA256SUMS
 
 COMS is the sole editable mapping authority, and the integrated ontology plus four maintained modules replace the former current-track editor, direct-mapping shells, and ungoverned hierarchy-projection analysis. Those obsolete paths and their active Make targets are retired rather than preserved as aliases, wrappers, diagnostics, or compatibility promises.
 
-No development XML catalog is required. Validation explicitly loads the five pinned local dependency files and locally resolves maintained project-module imports. `imports/cco.ttl` remains a full flattened merged CCO/BFO validation dependency, not a placeholder, while the `sosa-next` editor, catalog, and release shells remain intentionally retained and inactive.
+The current SSN/SOSA COMS transaction requires no development XML catalog: it explicitly loads its pinned local dependencies and resolves maintained current-track project imports through governed local paths. `imports/cco.ttl` remains a full flattened merged CCO/BFO validation dependency, not a placeholder.
+
+The SOSA-next track is separately active as a maintained development track. `src/sosa-next/catalog-v001.xml` resolves its pinned source closure, merged CCO/BFO validation dependency, three maintained products, and editor shell. The SOSA-next generator and checker enforce deterministic products, exact import boundaries, product-specific reasoning closures, and catalog-resolved consumer loading. This development activation does not add SOSA-next products to the current formal package or release machinery.
 
 The catalog generated inside a formal release package is unaffected: it remains package-relative, maps exactly the five immutable version IRIs in governed product order, and is byte-validated with the rest of the 13-file package. This migration does not configure redirects, deploy persistent IRIs, choose an actual release identity, or publish a release.
 

--- a/reports/sosa-next-formal-release-integration-audit.md
+++ b/reports/sosa-next-formal-release-integration-audit.md
@@ -1,0 +1,240 @@
+# SOSA-next Formal-Release Integration Audit
+
+## Purpose
+
+This audit identifies the changes required to move the three maintained
+SOSA-next development products into a deterministic formal release. It does
+not approve a source-version identity and does not modify release metadata,
+manifest, package, archive, rehearsal, or publication code.
+
+## Current development baseline
+
+The maintained development products are:
+
+| Product | Path | Direct axioms | Logical triples | Total triples |
+| --- | --- | ---: | ---: | ---: |
+| Alignment core | `releases/sosa-next/sosa-alignment-core.ttl` | 0 | 0 | 8 |
+| BFO mapping | `releases/sosa-next/sosa-bfo-mapping.ttl` | 21 | 157 | 166 |
+| CCO extension | `releases/sosa-next/sosa-cco-extension.ttl` | 24 | 116 | 125 |
+
+The three products contain 45 canonical authoritative axioms. Their logical
+union contains 273 triples and is isomorphic to the integrated active mapping
+graph used for validation.
+
+The catalog-resolved editor closure is:
+
+```text
+editor
+  -> CCO extension
+    -> BFO mapping
+      -> alignment core
+```
+
+That local project stack contains 303 distinct triples. Maintained project
+products import no external source or target ontology.
+
+## Formal-publication blocker
+
+The temporary component `sosa-next` is not an approved source-version identity.
+Before formal publication, the project must approve an immutable identity for
+the mapped SOSA source and replace `sosa-next` in:
+
+- package paths;
+- stable ontology IRIs;
+- formal version-IRI suffixes;
+- catalog mappings;
+- release notes and user documentation;
+- manifest product records and source evidence.
+
+No formal-release implementation should guess this identity.
+
+## Current formal-release authority
+
+The existing formal-release system is intentionally specific to the current
+SSN/SOSA track:
+
+- publication metadata defines exactly five products in canonical order:
+  integrated, alignment core, strict BFO mapping, BFO projection, and CCO
+  extension;
+- the manifest schema and Python model require those five product records;
+- package construction requires the current-track product paths;
+- the package layout contains 13 regular files;
+- the package catalog maps five same-release version IRIs;
+- the archive authority requires 17 members, including the
+  `current-ssn-sosa/` directory;
+- release rehearsal expects the current package directories and rebuilds the
+  same package and archive twice;
+- release notes require current-track headings, counts, import graph, and BFO
+  projection notice.
+
+The SOSA-next development products must not be inserted into those fixed
+inventories piecemeal.
+
+## Required integration decisions
+
+### Track identity and release scope
+
+Approve:
+
+1. the immutable SOSA source-version identity;
+2. the package directory name;
+3. the stable ontology-IRI namespace;
+4. whether the formal release contains only the three modular products or any
+   additional consumer artifact;
+5. whether current-track and forthcoming-track products are released together
+   or as separate release packages.
+
+The existing three-product contract excludes an integrated ontology and BFO
+projection unless separately justified.
+
+### Publication metadata
+
+The current metadata loader requires one exact five-product inventory. Formal
+integration therefore requires one of these governed designs:
+
+- a track-specific publication-metadata document for the SOSA source version;
+- or a generalized metadata schema with explicit track records and a canonical
+  product order per track.
+
+The design must preserve strict rejection of unknown fields, duplicate paths,
+duplicate stable IRIs, unsafe paths, and noncanonical ordering.
+
+### Formal rendering
+
+Formal rendering must:
+
+- preserve each approved stable ontology IRI;
+- add immutable same-release version IRIs;
+- substitute immutable-release authority status;
+- add release date and version information;
+- rewrite only project imports to same-release version IRIs;
+- preserve the development logical graph;
+- prohibit temporary development identities;
+- validate each product independently and as a project stack.
+
+### Manifest and schema
+
+The manifest model and JSON schema must gain a deliberate SOSA-source-version
+product inventory. Required evidence includes:
+
+- workbook identity and SHA-256;
+- all pinned source-file identities and SHA-256 values;
+- generator, checker, canonicalization, and publication modules;
+- development and formal product hashes;
+- exact direct-axiom and triple counts;
+- project import counts;
+- product-specific reasoning results;
+- catalog-consumption validation;
+- toolchain identity.
+
+A schema revision may be preferable to overloading schema version 1.
+
+### Package layout
+
+A formal package needs an explicit canonical layout. At minimum it requires:
+
+- license;
+- release notes;
+- checksum inventory;
+- the three formal ontology products;
+- a package-relative project catalog;
+- canonical manifest;
+- governed SOSA-next COMS workbook;
+- governed publication metadata;
+- sufficient pinned-source evidence to identify the mapped source closure.
+
+The project must decide whether pinned external ontology files are recorded
+only by identity and hash, as in the current release, or redistributed when
+their licenses permit. No dependency should be copied implicitly.
+
+### Package catalog
+
+The package catalog must map exactly the formal same-release version IRIs to
+the three package-relative products. It must not contain:
+
+- development IRIs;
+- the temporary `sosa-next` identity;
+- remote dependency redirects;
+- the editor shell unless that shell is explicitly approved as a release
+  artifact.
+
+### Archive
+
+Archive integration requires a new canonical member inventory, member count,
+directory inventory, and test authority. Existing raw-USTAR invariants should
+remain unchanged:
+
+- deterministic member order;
+- fixed metadata and zero timestamps;
+- canonical octal fields;
+- zero padding;
+- exactly two terminal zero records;
+- external lowercase SHA-256 sidecar.
+
+### Release notes
+
+The release-note template must describe:
+
+- the approved SOSA source version;
+- the three included products;
+- consumer selection guidance;
+- the project import graph;
+- active, deferred, and explicitly unmapped counts;
+- reasoning and catalog-consumption validation;
+- known limitations;
+- the absence of integrated and projection products;
+- dependency and license scope;
+- deterministic reproduction commands.
+
+### Release rehearsal and CI
+
+Rehearsal must build and validate two isolated copies of the new formal
+package and archive from the same commit, with network access blocked, then
+compare every retained byte. Hosted CI should validate development products
+continuously but should not create a formal package without explicit release
+context and approved release notes.
+
+## Recommended implementation sequence
+
+1. **Approve the immutable SOSA source-version identity.**
+2. **Choose separate-package versus combined-package publication.**
+3. **Define track-specific publication metadata and formal product order.**
+4. **Implement formal rendering and same-release import rewriting.**
+5. **Add a new manifest/schema authority and exact evidence model.**
+6. **Implement package construction and read-only package validation.**
+7. **Implement the canonical package catalog.**
+8. **Extend deterministic archive construction and validation.**
+9. **Add release notes, rehearsal, and hosted-CI regressions.**
+10. **Run a synthetic release context before any actual publication.**
+
+Each stage should preserve current-track release bytes and behavior.
+
+## Acceptance criteria for a future formal-release PR
+
+A future implementation is ready only when:
+
+1. no path, ontology IRI, catalog entry, or release note retains `sosa-next`;
+2. all formal products are deterministic across independent processes;
+3. formal rendering preserves the development logical graphs;
+4. same-release project imports resolve wholly inside the package;
+5. external dependencies are identified and governed without accidental
+   network resolution;
+6. manifest, package, catalog, archive, and sidecar bytes are canonical;
+7. two isolated rehearsals produce byte-identical results;
+8. all product reasoning profiles have zero named unsatisfiable classes;
+9. current-track release behavior and bytes remain unchanged;
+10. the actual source-version identity and release notes have been explicitly
+    approved.
+
+## Non-goals of this branch
+
+This release-readiness branch does not:
+
+- select the final SOSA source-version identity;
+- change `config/publication-metadata.toml`;
+- change release manifest or schema code;
+- change package, archive, or rehearsal code;
+- add SOSA-next products to the current formal release;
+- modify the SOSA-next workbook;
+- resolve deferred or explicitly unmapped rows;
+- publish a release or deploy persistent IRIs.

--- a/src/sosa-next/docs/README.md
+++ b/src/sosa-next/docs/README.md
@@ -1,3 +1,101 @@
-# Forthcoming SOSA-only docs
+# SOSA-next Maintained Development Products
 
-Add forthcoming SOSA-only mapping documentation here after completed mapping content is inserted.
+## Status
+
+The SOSA-next track is a governed maintained development track for the
+forthcoming SOSA source. It is generated from
+`mappings/SOSA-next-to-BFO-COMS.xlsx`.
+
+The temporary name `sosa-next` identifies the development track. It is not an
+approved formal source-version identity and must not appear in a formal release
+path or ontology IRI.
+
+## Products
+
+| Product | Path | Ontology IRI |
+| --- | --- | --- |
+| Alignment core | `releases/sosa-next/sosa-alignment-core.ttl` | `http://www.sks.ai/SSN2BFO/development/sosa-next/alignment-core` |
+| BFO mapping | `releases/sosa-next/sosa-bfo-mapping.ttl` | `http://www.sks.ai/SSN2BFO/development/sosa-next/bfo-mapping` |
+| CCO extension | `releases/sosa-next/sosa-cco-extension.ttl` | `http://www.sks.ai/SSN2BFO/development/sosa-next/cco-extension` |
+
+The project import chain is:
+
+```text
+CCO extension
+  owl:imports -> BFO mapping
+    owl:imports -> alignment core
+```
+
+The alignment core currently asserts no target-neutral mapping axiom but
+provides the stable import boundary required by the product contract.
+
+The initial product set has no integrated ontology and no BFO-projection
+product.
+
+## Consumer loading
+
+For the complete project mapping stack, load the CCO extension. Its project
+imports provide the BFO mapping and alignment core transitively.
+
+For development use in Protégé or another catalog-aware ontology editor, load:
+
+```text
+src/sosa-next/sosa-mappings-edit.ttl
+```
+
+with:
+
+```text
+src/sosa-next/catalog-v001.xml
+```
+
+The editor imports only the CCO extension.
+
+The catalog also resolves the pinned forthcoming-SOSA source files and the
+governed merged CCO/BFO validation dependency. Those external source and target
+ontologies are not imported by the maintained project products. A consumer
+that requires their declarations or full semantics must load the applicable
+dependencies separately.
+
+## Validation
+
+Run:
+
+```bash
+make check-sosa-next
+make check-sosa-next-products
+make check-sosa-next-consumer-stack
+```
+
+The product checker enforces:
+
+- 119 governed rows and 119 unique RowIDs;
+- 45 active canonical authoritative axioms;
+- 26 deferred rows with no direct axiom;
+- 48 explicitly unmapped rows with no direct axiom;
+- exact product partitioning;
+- deterministic byte-identical independent builds;
+- canonical metadata and project import boundaries;
+- exact product hashes and triple counts;
+- a 273-triple modular logical union;
+- zero named unsatisfiable classes in all reasoning profiles;
+- current-track byte preservation.
+
+The consumer-stack checker enforces:
+
+- 14 unique local catalog mappings;
+- parseable catalog targets;
+- the exact editor-to-product import closure;
+- 303 distinct triples in the local editor project stack;
+- no external dependency import from a maintained project product.
+
+## Formal-release status
+
+These products are not part of the current formal release package. Current
+release metadata, manifest, package, archive, and rehearsal tooling remains
+specific to the current five-product SSN/SOSA track.
+
+See:
+
+- `reports/sosa-next-product-contract.md`
+- `reports/sosa-next-formal-release-integration-audit.md`

--- a/tests/test_sosa_next_consumer_stack.py
+++ b/tests/test_sosa_next_consumer_stack.py
@@ -1,0 +1,328 @@
+#!/usr/bin/env python3
+"""End-to-end catalog consumption tests for the SOSA-next project stack."""
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+from xml.etree import ElementTree
+
+from rdflib import Graph, URIRef
+from rdflib.namespace import OWL, RDF
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+CATALOG = REPO_ROOT / "src/sosa-next/catalog-v001.xml"
+
+CATALOG_NAMESPACE = (
+    "urn:oasis:names:tc:entity:xmlns:xml:catalog"
+)
+
+ALIGNMENT_CORE = (
+    "http://www.sks.ai/SSN2BFO/"
+    "development/sosa-next/alignment-core"
+)
+BFO_MAPPING = (
+    "http://www.sks.ai/SSN2BFO/"
+    "development/sosa-next/bfo-mapping"
+)
+CCO_EXTENSION = (
+    "http://www.sks.ai/SSN2BFO/"
+    "development/sosa-next/cco-extension"
+)
+EDITOR = (
+    "http://www.sks.ai/SSN2BFO/"
+    "development/sosa-next/edit"
+)
+
+PROJECT_IRIS = (
+    ALIGNMENT_CORE,
+    BFO_MAPPING,
+    CCO_EXTENSION,
+    EDITOR,
+)
+
+EXPECTED_PROJECT_PATHS = {
+    ALIGNMENT_CORE: (
+        REPO_ROOT
+        / "releases/sosa-next/sosa-alignment-core.ttl"
+    ),
+    BFO_MAPPING: (
+        REPO_ROOT
+        / "releases/sosa-next/sosa-bfo-mapping.ttl"
+    ),
+    CCO_EXTENSION: (
+        REPO_ROOT
+        / "releases/sosa-next/sosa-cco-extension.ttl"
+    ),
+    EDITOR: (
+        REPO_ROOT
+        / "src/sosa-next/sosa-mappings-edit.ttl"
+    ),
+}
+
+EXPECTED_IMPORTS = {
+    ALIGNMENT_CORE: frozenset(),
+    BFO_MAPPING: frozenset({ALIGNMENT_CORE}),
+    CCO_EXTENSION: frozenset({BFO_MAPPING}),
+    EDITOR: frozenset({CCO_EXTENSION}),
+}
+
+EXPECTED_TRIPLE_COUNTS = {
+    ALIGNMENT_CORE: 8,
+    BFO_MAPPING: 166,
+    CCO_EXTENSION: 125,
+    EDITOR: 4,
+}
+
+EXPECTED_EDITOR_CLOSURE = (
+    EDITOR,
+    CCO_EXTENSION,
+    BFO_MAPPING,
+    ALIGNMENT_CORE,
+)
+
+EXPECTED_DEPENDENCY_IRIS = frozenset(
+    {
+        "http://www.w3.org/ns/sosa/",
+        "http://www.w3.org/ns/sosa/common/",
+        "http://www.w3.org/ns/sosa/act/",
+        "http://www.w3.org/ns/sosa/dep/",
+        "http://www.w3.org/ns/sosa/obs/",
+        "http://www.w3.org/ns/sosa/sam/",
+        "http://www.w3.org/ns/sosa/systems/",
+        "http://www.w3.org/ns/sosa/sampling/",
+        (
+            "http://www.sks.ai/SSN2BFO/"
+            "development/sosa-next/"
+            "source-declaration-overlay"
+        ),
+        (
+            "https://www.commoncoreontologies.org/"
+            "CommonCoreOntologiesMerged"
+        ),
+    }
+)
+
+
+def load_catalog() -> tuple[
+    tuple[tuple[str, str], ...],
+    dict[str, Path],
+]:
+    root = ElementTree.parse(CATALOG).getroot()
+
+    entries = tuple(
+        (
+            element.attrib["name"],
+            element.attrib["uri"],
+        )
+        for element in root.findall(
+            f".//{{{CATALOG_NAMESPACE}}}uri"
+        )
+    )
+
+    resolved = {
+        name: (CATALOG.parent / relative).resolve()
+        for name, relative in entries
+    }
+
+    return entries, resolved
+
+
+def load_project_graphs(
+    catalog: dict[str, Path],
+) -> dict[str, Graph]:
+    graphs: dict[str, Graph] = {}
+
+    for ontology_iri in PROJECT_IRIS:
+        graph = Graph()
+        graph.parse(
+            catalog[ontology_iri],
+            format="turtle",
+        )
+        graphs[ontology_iri] = graph
+
+    return graphs
+
+
+class SosaNextConsumerStackTests(unittest.TestCase):
+    def test_catalog_entries_are_unique_local_and_parseable(
+        self,
+    ) -> None:
+        entries, catalog = load_catalog()
+
+        self.assertEqual(len(entries), 14)
+        self.assertEqual(len(catalog), 14)
+
+        for public_iri, target in catalog.items():
+            with self.subTest(public_iri=public_iri):
+                self.assertTrue(
+                    target.is_file(),
+                    target,
+                )
+
+                target.relative_to(
+                    REPO_ROOT.resolve()
+                )
+
+                graph = Graph()
+                graph.parse(
+                    target,
+                    format="turtle",
+                )
+
+                self.assertGreater(
+                    len(graph),
+                    0,
+                    target,
+                )
+
+    def test_editor_resolves_exact_project_stack(
+        self,
+    ) -> None:
+        _, catalog = load_catalog()
+
+        self.assertEqual(
+            {
+                ontology_iri: catalog[ontology_iri]
+                for ontology_iri in PROJECT_IRIS
+            },
+            {
+                ontology_iri: path.resolve()
+                for ontology_iri, path
+                in EXPECTED_PROJECT_PATHS.items()
+            },
+        )
+
+        graphs = load_project_graphs(catalog)
+
+        for ontology_iri, graph in graphs.items():
+            with self.subTest(
+                ontology_iri=ontology_iri
+            ):
+                ontology = URIRef(ontology_iri)
+
+                ontology_declarations = set(
+                    graph.triples(
+                        (
+                            None,
+                            RDF.type,
+                            OWL.Ontology,
+                        )
+                    )
+                )
+
+                self.assertEqual(
+                    ontology_declarations,
+                    {
+                        (
+                            ontology,
+                            RDF.type,
+                            OWL.Ontology,
+                        )
+                    },
+                )
+
+                import_triples = set(
+                    graph.triples(
+                        (
+                            None,
+                            OWL.imports,
+                            None,
+                        )
+                    )
+                )
+
+                self.assertEqual(
+                    import_triples,
+                    {
+                        (
+                            ontology,
+                            OWL.imports,
+                            URIRef(imported),
+                        )
+                        for imported in EXPECTED_IMPORTS[
+                            ontology_iri
+                        ]
+                    },
+                )
+
+                self.assertEqual(
+                    len(graph),
+                    EXPECTED_TRIPLE_COUNTS[
+                        ontology_iri
+                    ],
+                )
+
+        pending = [EDITOR]
+        closure: list[str] = []
+
+        while pending:
+            ontology_iri = pending.pop(0)
+
+            if ontology_iri in closure:
+                continue
+
+            closure.append(ontology_iri)
+
+            pending.extend(
+                sorted(
+                    str(imported)
+                    for imported in graphs[
+                        ontology_iri
+                    ].objects(
+                        URIRef(ontology_iri),
+                        OWL.imports,
+                    )
+                )
+            )
+
+        self.assertEqual(
+            tuple(closure),
+            EXPECTED_EDITOR_CLOSURE,
+        )
+
+        combined = Graph()
+
+        for ontology_iri in closure:
+            for triple in graphs[ontology_iri]:
+                combined.add(triple)
+
+        self.assertEqual(len(combined), 303)
+
+    def test_external_dependencies_remain_separate_inputs(
+        self,
+    ) -> None:
+        _, catalog = load_catalog()
+
+        self.assertEqual(
+            frozenset(catalog) - frozenset(PROJECT_IRIS),
+            EXPECTED_DEPENDENCY_IRIS,
+        )
+
+        graphs = load_project_graphs(catalog)
+
+        observed_project_imports = frozenset(
+            str(imported)
+            for graph in graphs.values()
+            for _, _, imported in graph.triples(
+                (
+                    None,
+                    OWL.imports,
+                    None,
+                )
+            )
+        )
+
+        self.assertTrue(
+            observed_project_imports
+            <= frozenset(PROJECT_IRIS)
+        )
+
+        self.assertTrue(
+            observed_project_imports
+            .isdisjoint(EXPECTED_DEPENDENCY_IRIS)
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/run_validation_suite.py
+++ b/tools/run_validation_suite.py
@@ -421,6 +421,7 @@ def compile_check() -> StepResult:
             "tests/test_generate_mapping_from_coms.py",
             "tests/test_check_sosa_next_mapping.py",
             "tests/test_sosa_next_products.py",
+            "tests/test_sosa_next_consumer_stack.py",
             "tests/test_robot_template_generation_pilot.py",
             "tests/test_robot_property_chain_generation_pilot.py",
             "tests/test_robot_diff_pilot.py",
@@ -535,6 +536,22 @@ def run_validation_suite(args: argparse.Namespace) -> int:
                     "tests",
                     "-p",
                     "test_sosa_next_products.py",
+                ],
+            )
+        )
+    if results[-1].passed:
+        results.append(
+            run_command(
+                "SOSA-next catalog consumer-stack focused tests",
+                [
+                    sys.executable,
+                    "-m",
+                    "unittest",
+                    "discover",
+                    "-s",
+                    "tests",
+                    "-p",
+                    "test_sosa_next_consumer_stack.py",
                 ],
             )
         )


### PR DESCRIPTION
## Summary

- adds a catalog-resolved SOSA-next consumer-stack regression;
- updates active documentation to describe SOSA-next as a maintained development track;
- adds a formal-release integration audit without performing formal-release integration.

## Validation

- complete `make check`: PASS;
- SOSA-next consumer-stack regression: PASS;
- SOSA-next maintained-product validation: PASS;
- current-SOSA protected product hashes remain byte-identical;
- all pinned SOSA-next source files remain unchanged from the branch baseline;
- formal-release machinery remains unchanged;
- `git diff --check`: PASS.

## Scope boundaries

- no SOSA-next workbook changes;
- no deferred or explicitly unmapped rows resolved;
- no SOSA-next products added to the current formal release;
- no formal-release metadata, manifest, package, archive, or rehearsal machinery changes;
- no final SOSA source-version identity selected or invented;
- no release publication or persistent-IRI deployment.

The temporary `sosa-next` identity remains development-only and is explicitly prohibited from formal publication. The formal-release integration audit records approval of an immutable SOSA source-version identity as the first blocker before future release integration.
