### PR TITLE
Approve SOSA source-version identity

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: validate validate-write audit-write legacy-audit-write compile check check-coms check-sosa-next check-coms-row-identities check-coms-product-dispositions check-alignment-core check-strict-bfo-mapping check-cco-extension check-bfo-projection check-publication-metadata check-release-rendering check-release-package check-release-archive check-release-rehearsal check-placeholder-catalog-migration watch-coms coms-status post-merge-check status diffstat generate-sosa-next-products check-sosa-next-products check-sosa-next-consumer-stack
+.PHONY: validate validate-write audit-write legacy-audit-write compile check check-coms check-sosa-next check-coms-row-identities check-coms-product-dispositions check-alignment-core check-strict-bfo-mapping check-cco-extension check-bfo-projection check-publication-metadata check-release-rendering check-release-package check-release-archive check-release-rehearsal check-placeholder-catalog-migration watch-coms coms-status post-merge-check status diffstat generate-sosa-next-products check-sosa-next-products check-sosa-next-consumer-stack check-sosa-source-version
 
 validate:
 	PYTHONDONTWRITEBYTECODE=1 python tools/run_validation_suite.py
@@ -34,6 +34,8 @@ compile:
 		tools/robot_retained_example_validation_pilot.py \
 		tools/robot_verify_pilot.py \
 		tools/check_coms_mapping.py \
+		tools/sosa_source_version.py \
+		tools/check_sosa_source_version.py \
 		tools/check_sosa_next_mapping.py \
 		tools/generate_sosa_next_products.py \
 		tools/check_sosa_next_products.py \
@@ -47,6 +49,7 @@ compile:
 		tools/release_archive.py \
 		tools/rehearse_release.py \
 		tests/test_generate_mapping_from_coms.py \
+		tests/test_sosa_source_version.py \
 		tests/test_check_sosa_next_mapping.py \
 		tests/test_sosa_next_products.py \
 		tests/test_sosa_next_consumer_stack.py \
@@ -97,7 +100,11 @@ check-release-rehearsal:
 check-placeholder-catalog-migration:
 	PYTHONDONTWRITEBYTECODE=1 python -B -m unittest discover -s tests -p 'test_placeholder_catalog_migration.py'
 
-check-sosa-next:
+check-sosa-source-version:
+	PYTHONDONTWRITEBYTECODE=1 python -m unittest discover -s tests -p 'test_sosa_source_version.py'
+	PYTHONDONTWRITEBYTECODE=1 python tools/check_sosa_source_version.py
+
+check-sosa-next: check-sosa-source-version
 	PYTHONDONTWRITEBYTECODE=1 python -m unittest discover -s tests -p 'test_check_sosa_next_mapping.py'
 	PYTHONDONTWRITEBYTECODE=1 python tools/check_sosa_next_mapping.py
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,15 @@ See [Product Architecture](docs/PRODUCT-ARCHITECTURE.md) for the relationships a
 
 The repository also maintains a governed development track for the forthcoming
 SOSA source. These products are generated from
-`mappings/SOSA-next-to-BFO-COMS.xlsx`:
+`mappings/SOSA-next-to-BFO-COMS.xlsx`.
+
+The mapped source snapshot has the approved immutable project identity
+`sosa-2023-af425a0454ec00512a5ebfa2873fe35a077f5fda`. Its machine-readable authority is
+`config/sosa-source-version.toml`, which binds the development track to W3C
+`sdw-sosa-ssn` commit `af425a0454ec00512a5ebfa2873fe35a077f5fda` and the governed local declaration
+overlay.
+
+The maintained development products are:
 
 | Product | File | Use when |
 | --- | --- | --- |
@@ -51,18 +59,22 @@ obtains the other project modules transitively. External SOSA, BFO, and CCO
 dependencies remain separate consumer or validation inputs.
 
 These files are maintained authoritative development artifacts, but they are
-not part of the current formal release. The temporary `sosa-next` identity must
-be replaced by the approved source-version identity before formal publication.
+not part of the current formal release. `sosa-next` remains the development
+alias in the current paths and ontology IRIs. Future formal-release integration
+must replace that alias with `sosa-2023-af425a0454ec00512a5ebfa2873fe35a077f5fda` in formal track-specific
+paths and ontology IRIs.
 
 Focused development validation:
 
 ```bash
+make check-sosa-source-version
 make check-sosa-next
 make check-sosa-next-products
 make check-sosa-next-consumer-stack
 ```
 
-See [SOSA-next Development Products](src/sosa-next/docs/README.md) and the
+See the [source-version identity decision](reports/sosa-source-version-identity-decision.md),
+[SOSA-next Development Products](src/sosa-next/docs/README.md), and the
 [formal-release integration audit](reports/sosa-next-formal-release-integration-audit.md).
 
 ## Release

--- a/config/sosa-source-version.toml
+++ b/config/sosa-source-version.toml
@@ -1,0 +1,56 @@
+schema_version = 1
+status = "approved"
+source_identity = "sosa-2023-af425a0454ec00512a5ebfa2873fe35a077f5fda"
+development_alias = "sosa-next"
+edition_label = "Semantic Sensor Network Ontology - 2023 Edition"
+edition_version_iri = "http://www.w3.org/ns/sosa/2023/"
+w3c_tr_iri = "https://www.w3.org/TR/vocab-ssn-2023/"
+upstream_repository = "https://github.com/w3c/sdw-sosa-ssn"
+upstream_commit = "af425a0454ec00512a5ebfa2873fe35a077f5fda"
+upstream_commit_date = "2026-07-22"
+
+[[source_files]]
+local_path = "src/sosa-next/imports/sosa.ttl"
+upstream_path = "ssn/rdf/ontology/core/sosa.ttl"
+sha256 = "a1875d19988b0bd17e5cd3a61f76440b6e0f7b1e07bd30237e6fb7341c170305"
+
+[[source_files]]
+local_path = "src/sosa-next/imports/sosa-common.ttl"
+upstream_path = "ssn/rdf/ontology/core/sosa-common.ttl"
+sha256 = "31bb4a6fb3d4b8b7612998744f73b5a8194d34ef866184460ed22dc0f78a91aa"
+
+[[source_files]]
+local_path = "src/sosa-next/imports/sosa-observation.ttl"
+upstream_path = "ssn/rdf/ontology/core/sosa-observation.ttl"
+sha256 = "da6b3b2304a491c45a8822e70529f72c1d73606dda9a8b73b0c5360313ab30c3"
+
+[[source_files]]
+local_path = "src/sosa-next/imports/sosa-actuation.ttl"
+upstream_path = "ssn/rdf/ontology/core/sosa-actuation.ttl"
+sha256 = "18c840cba0a4e148048e6147cb2b5fa9b36bbf09dcb60802ce65d3ecfb3175c5"
+
+[[source_files]]
+local_path = "src/sosa-next/imports/sosa-sampling.ttl"
+upstream_path = "ssn/rdf/ontology/core/sosa-sampling.ttl"
+sha256 = "82e59f8354debaff6cdcb3e354397ea17318e4bc45dc7a8a005c1fa5404d2d70"
+
+[[source_files]]
+local_path = "src/sosa-next/imports/sosa-deprecated.ttl"
+upstream_path = "ssn/rdf/ontology/core/sosa-deprecated.ttl"
+sha256 = "5a99055ea8938f0e9384b81ad3ac1b3eaa13aaf50c54e308cab9551c88392987"
+
+[[source_files]]
+local_path = "src/sosa-next/imports/sosa-system.ttl"
+upstream_path = "ssn/rdf/ontology/extensions/sosa-system.ttl"
+sha256 = "1ac64f168163b7e6139bf632a07e35112837a58021ff706688d2c626e9cc1caf"
+
+[[source_files]]
+local_path = "src/sosa-next/imports/sample-relations.ttl"
+upstream_path = "ssn/rdf/ontology/extensions/sample-relations.ttl"
+sha256 = "0f9c8561626e9c75cb364d3c0f6cdb3197e9e72b6727b095309fc3fb1d605e32"
+
+[local_overlay]
+path = "src/sosa-next/imports/sosa-source-declaration-overlay.ttl"
+sha256 = "5cee7b4c6799df0ebff5f4c503b7495fce67f940c53711a2aecfa6896f8d3af2"
+bound_upstream_commit = "af425a0454ec00512a5ebfa2873fe35a077f5fda"
+purpose = "Locally declares sosa:Battery as an OWL class without modifying the pinned W3C source bytes."

--- a/docs/PRODUCT-ARCHITECTURE.md
+++ b/docs/PRODUCT-ARCHITECTURE.md
@@ -149,6 +149,12 @@ The separate SOSA-next track is now an active maintained development track,
 not inactive scaffolding. Its sole editable mapping authority is
 `mappings/SOSA-next-to-BFO-COMS.xlsx`.
 
+Its approved immutable source-version identity is
+`sosa-2023-af425a0454ec00512a5ebfa2873fe35a077f5fda`. `config/sosa-source-version.toml` is the machine-readable
+source authority. The existing `sosa-next` component remains only the
+development alias and continues to identify the current development paths and
+ontology IRIs until formal-release integration.
+
 It consists of exactly three generated ontology products:
 
 | Product | Path | Direct axioms | Total triples |
@@ -190,6 +196,7 @@ SSN/SOSA architecture.
 Focused validation:
 
 ```bash
+make check-sosa-source-version
 make check-sosa-next
 make check-sosa-next-products
 make check-sosa-next-consumer-stack
@@ -197,10 +204,12 @@ make check-sosa-next-consumer-stack
 
 The SOSA-next products are not yet formal-release products. Current release
 metadata, manifest, package, archive, and rehearsal tooling remain authoritative
-only for the five-product current SSN/SOSA track. Formal publication is blocked
-until the temporary `sosa-next` path and ontology-IRI component is replaced by
-an approved source-version identity and the release machinery is deliberately
-extended.
+only for the five-product current SSN/SOSA track. The source-identity prerequisite
+is resolved as `sosa-2023-af425a0454ec00512a5ebfa2873fe35a077f5fda`. Formal integration must replace the
+`sosa-next` development alias with that exact identity in formal track-specific
+paths and ontology IRIs and deliberately extend the release machinery. The next
+unresolved publication decision is separate-package versus combined-package
+publication.
 
 The earlier `reports/publication-product-and-import-policy.md` records the
 pre-activation lifecycle policy. For the implemented SOSA-next development

--- a/docs/VALIDATION-AND-RELEASES.md
+++ b/docs/VALIDATION-AND-RELEASES.md
@@ -56,10 +56,15 @@ governed local paths.
 The SOSA-next development track has a separate governed catalog at
 `src/sosa-next/catalog-v001.xml`. It resolves:
 
-- nine pinned forthcoming-SOSA source files;
+- eight byte-pinned upstream SOSA files plus one governed local declaration
+  overlay;
 - the governed merged CCO/BFO validation dependency;
 - the three maintained SOSA-next project products;
 - the SOSA-next editor shell.
+
+`config/sosa-source-version.toml` is the machine-readable authority for the
+approved source identity `sosa-2023-af425a0454ec00512a5ebfa2873fe35a077f5fda`, the full upstream W3C commit,
+the eight upstream source-file hashes, and the separately governed overlay.
 
 The maintained SOSA-next project products import only other SOSA-next project
 products. They do not import the external source or target dependencies
@@ -80,12 +85,19 @@ The forthcoming-SOSA workbook and its three maintained products have separate
 focused gates:
 
 ```bash
+make check-sosa-source-version
 make check-sosa-next
 make check-sosa-next-products
 make check-sosa-next-consumer-stack
 ```
 
-`make check-sosa-next` validates the 119 governed workbook rows, 45 active
+`make check-sosa-source-version` validates the approved immutable source
+identity, exact source and overlay hashes, root SOSA edition version IRI, and
+overlay binding to the approved full upstream commit. It performs no network
+resolution.
+
+`make check-sosa-next` depends on the source-version gate and validates the 119
+governed workbook rows, 45 active
 mappings, 26 deferred mappings, 48 explicitly unmapped rows, canonical
 identity, and a clean HermiT result for the integrated active mapping.
 

--- a/reports/sosa-next-formal-release-integration-audit.md
+++ b/reports/sosa-next-formal-release-integration-audit.md
@@ -3,9 +3,13 @@
 ## Purpose
 
 This audit identifies the changes required to move the three maintained
-SOSA-next development products into a deterministic formal release. It does
-not approve a source-version identity and does not modify release metadata,
-manifest, package, archive, rehearsal, or publication code.
+SOSA-next development products into a deterministic formal release. The
+source-version identity prerequisite that was unresolved when this audit was
+created is now approved and recorded by
+`config/sosa-source-version.toml` and
+`reports/sosa-source-version-identity-decision.md`. This audit still does not
+modify release metadata, manifest, package, archive, rehearsal, or publication
+code.
 
 ## Current development baseline
 
@@ -33,20 +37,34 @@ editor
 That local project stack contains 303 distinct triples. Maintained project
 products import no external source or target ontology.
 
-## Formal-publication blocker
+## Resolved source-identity prerequisite
 
-The temporary component `sosa-next` is not an approved source-version identity.
-Before formal publication, the project must approve an immutable identity for
-the mapped SOSA source and replace `sosa-next` in:
+The approved immutable source-version identity is:
 
-- package paths;
+`sosa-2023-af425a0454ec00512a5ebfa2873fe35a077f5fda`
+
+It denotes the Semantic Sensor Network Ontology - 2023 Edition source snapshot
+pinned to the full W3C upstream commit:
+
+`af425a0454ec00512a5ebfa2873fe35a077f5fda`
+
+`config/sosa-source-version.toml` is the machine-readable authority. The
+development alias remains `sosa-next`; current development paths and ontology
+IRIs are intentionally not renamed by the source-identity milestone.
+
+During future formal-release integration, the exact approved identity must
+replace `sosa-next` in:
+
+- track-specific package paths;
 - stable ontology IRIs;
 - formal version-IRI suffixes;
 - catalog mappings;
 - release notes and user documentation;
 - manifest product records and source evidence.
 
-No formal-release implementation should guess this identity.
+Abbreviated commit identities are not permitted. This resolves the
+source-identity selection prerequisite but does not itself perform any
+formal-release integration.
 
 ## Current formal-release authority
 
@@ -74,15 +92,17 @@ inventories piecemeal.
 
 ### Track identity and release scope
 
-Approve:
+The track identity is resolved as
+`sosa-2023-af425a0454ec00512a5ebfa2873fe35a077f5fda`. Any formal track-specific path or stable ontology-IRI
+namespace that replaces the development alias must use that exact component
+unless a later explicit governance change supersedes this decision.
 
-1. the immutable SOSA source-version identity;
-2. the package directory name;
-3. the stable ontology-IRI namespace;
-4. whether the formal release contains only the three modular products or any
-   additional consumer artifact;
-5. whether current-track and forthcoming-track products are released together
-   or as separate release packages.
+The remaining release-scope decisions are:
+
+1. whether the approved source-version track is published as a separate package
+   or combined with the current SSN/SOSA track;
+2. whether its formal release contains only the three modular products or an
+   additional separately approved consumer artifact.
 
 The existing three-product contract excludes an integrated ontology and BFO
 projection unless separately justified.
@@ -196,16 +216,15 @@ context and approved release notes.
 
 ## Recommended implementation sequence
 
-1. **Approve the immutable SOSA source-version identity.**
-2. **Choose separate-package versus combined-package publication.**
-3. **Define track-specific publication metadata and formal product order.**
-4. **Implement formal rendering and same-release import rewriting.**
-5. **Add a new manifest/schema authority and exact evidence model.**
-6. **Implement package construction and read-only package validation.**
-7. **Implement the canonical package catalog.**
-8. **Extend deterministic archive construction and validation.**
-9. **Add release notes, rehearsal, and hosted-CI regressions.**
-10. **Run a synthetic release context before any actual publication.**
+1. **Choose separate-package versus combined-package publication.**
+2. **Define track-specific publication metadata and formal product order.**
+3. **Implement formal rendering and same-release import rewriting.**
+4. **Add a new manifest/schema authority and exact evidence model.**
+5. **Implement package construction and read-only package validation.**
+6. **Implement the canonical package catalog.**
+7. **Extend deterministic archive construction and validation.**
+8. **Add release notes, rehearsal, and hosted-CI regressions.**
+9. **Run a synthetic release context before any actual publication.**
 
 Each stage should preserve current-track release bytes and behavior.
 
@@ -213,7 +232,7 @@ Each stage should preserve current-track release bytes and behavior.
 
 A future implementation is ready only when:
 
-1. no path, ontology IRI, catalog entry, or release note retains `sosa-next`;
+1. no formal track-specific package path, formal ontology IRI, package catalog entry, or release note retains `sosa-next`;
 2. all formal products are deterministic across independent processes;
 3. formal rendering preserves the development logical graphs;
 4. same-release project imports resolve wholly inside the package;
@@ -223,14 +242,14 @@ A future implementation is ready only when:
 7. two isolated rehearsals produce byte-identical results;
 8. all product reasoning profiles have zero named unsatisfiable classes;
 9. current-track release behavior and bytes remain unchanged;
-10. the actual source-version identity and release notes have been explicitly
-    approved.
+10. the formal package records the approved source-version authority and the
+    release notes have been explicitly approved.
 
-## Non-goals of this branch
+## Non-goals of the source-identity milestone
 
-This release-readiness branch does not:
+The source-identity milestone does not:
 
-- select the final SOSA source-version identity;
+- rename the current `sosa-next` development paths or ontology IRIs;
 - change `config/publication-metadata.toml`;
 - change release manifest or schema code;
 - change package, archive, or rehearsal code;

--- a/reports/sosa-next-product-contract.md
+++ b/reports/sosa-next-product-contract.md
@@ -8,9 +8,11 @@ by `tools/generate_sosa_next_products.py` and validated by the focused
 SOSA-next product checker and repository validation suite. It does not
 publish a formal release.
 
-The temporary term `sosa-next` identifies the development track only. A formal
-release must replace it in package paths and ontology IRIs with the approved
-source-version identity. No production path or ontology IRI may retain
+The approved immutable source-version identity is
+`sosa-2023-af425a0454ec00512a5ebfa2873fe35a077f5fda`, governed by `config/sosa-source-version.toml`. The
+temporary term `sosa-next` remains the development alias only. A formal release
+must replace it in track-specific package paths and ontology IRIs with the
+approved identity. No formal production path or ontology IRI may retain
 `sosa-next`.
 
 ## Authoritative inputs
@@ -18,6 +20,8 @@ source-version identity. No production path or ontology IRI may retain
 The maintained products are generated from:
 
 - `mappings/SOSA-next-to-BFO-COMS.xlsx`, as the sole editable mapping source;
+- `config/sosa-source-version.toml`, as the machine-readable source-version
+  authority;
 - the pinned SOSA-next source closure under `src/sosa-next/imports/`;
 - `src/sosa-next/catalog-v001.xml`;
 - repository-governed BFO and CCO imports;
@@ -253,7 +257,8 @@ The first maintained-product implementation must satisfy all of the following:
 7. two independent builds produce byte-identical products;
 8. all product hashes and exact triple counts are asserted by focused tests;
 9. all three reasoning profiles have zero named unsatisfiable classes;
-10. the pinned SOSA-next source files remain byte-identical;
+10. the approved source-version authority validates and the pinned SOSA-next
+    source files remain byte-identical;
 11. the current-SOSA maintained products remain byte-identical;
 12. the current-SOSA generator and release tests remain unchanged in behavior;
 13. temporary COMS resolver configuration is restored after success and
@@ -275,7 +280,7 @@ The current-SOSA byte-preservation gate must protect:
 
 Formal release integration is a later phase. Before release:
 
-- the approved SOSA source-version identity must replace `sosa-next` in package
+- `sosa-2023-af425a0454ec00512a5ebfa2873fe35a077f5fda` must replace `sosa-next` in formal track-specific package
   paths and ontology IRIs;
 - release products must receive date-based version IRIs under
   `http://www.sks.ai/SSN2BFO/releases/<release-id>/`;

--- a/reports/sosa-source-version-identity-decision.md
+++ b/reports/sosa-source-version-identity-decision.md
@@ -1,0 +1,126 @@
+# SOSA Source-Version Identity Decision
+
+## Decision
+
+The approved immutable project identity for the governed SOSA source snapshot
+is:
+
+`sosa-2023-af425a0454ec00512a5ebfa2873fe35a077f5fda`
+
+The machine-readable authority for this decision is:
+
+`config/sosa-source-version.toml`
+
+The temporary component `sosa-next` remains the development alias used by the
+current development paths and ontology IRIs. This decision does not rename
+those development artifacts. During future formal-release integration,
+`sosa-next` must be replaced by the approved identity above in every formal
+track-specific path, ontology IRI, version-IRI suffix, catalog mapping,
+manifest product record, release note, and source-evidence record.
+
+## Source represented by the identity
+
+The source is the Semantic Sensor Network Ontology - 2023 Edition, whose SOSA
+root ontology uses the version IRI:
+
+`http://www.w3.org/ns/sosa/2023/`
+
+The repository pins eight upstream Turtle files from the W3C
+`sdw-sosa-ssn` repository at the full upstream commit:
+
+`af425a0454ec00512a5ebfa2873fe35a077f5fda`
+
+The locally maintained declaration overlay is separately governed and is bound
+to that same upstream commit.
+
+## Provenance proof
+
+The source-identity audit independently fetched the exact W3C commit and
+compared the repository's eight pinned upstream files against all Turtle blobs
+at that commit by SHA-256.
+
+Each local upstream file had exactly one byte-identical match:
+
+| Local file | Upstream path |
+| --- | --- |
+| `src/sosa-next/imports/sosa.ttl` | `ssn/rdf/ontology/core/sosa.ttl` |
+| `src/sosa-next/imports/sosa-common.ttl` | `ssn/rdf/ontology/core/sosa-common.ttl` |
+| `src/sosa-next/imports/sosa-observation.ttl` | `ssn/rdf/ontology/core/sosa-observation.ttl` |
+| `src/sosa-next/imports/sosa-actuation.ttl` | `ssn/rdf/ontology/core/sosa-actuation.ttl` |
+| `src/sosa-next/imports/sosa-sampling.ttl` | `ssn/rdf/ontology/core/sosa-sampling.ttl` |
+| `src/sosa-next/imports/sosa-deprecated.ttl` | `ssn/rdf/ontology/core/sosa-deprecated.ttl` |
+| `src/sosa-next/imports/sosa-system.ttl` | `ssn/rdf/ontology/extensions/sosa-system.ttl` |
+| `src/sosa-next/imports/sample-relations.ttl` | `ssn/rdf/ontology/extensions/sample-relations.ttl` |
+
+The repository therefore identifies a specific immutable upstream Git state,
+rather than relying only on the broader `2023` edition label.
+
+## Naming rationale
+
+The bare component `sosa-2023` is not sufficiently precise for this project's
+formal source identity because the governed mapping is tied to the bytes of a
+specific upstream source snapshot.
+
+The approved identity therefore combines:
+
+1. the upstream edition family: `sosa-2023`; and
+2. the complete lowercase 40-character upstream Git commit:
+   `af425a0454ec00512a5ebfa2873fe35a077f5fda`.
+
+The full commit is used rather than an abbreviated Git identifier so the
+project identity does not depend on abbreviation length or future repository
+growth.
+
+## Authority and validation
+
+`config/sosa-source-version.toml` is the sole machine-readable authority for:
+
+- the approved source identity;
+- the development alias;
+- the edition label and SOSA edition version IRI;
+- the upstream repository and full commit;
+- the eight upstream local/upstream path pairs and SHA-256 values;
+- the local declaration overlay, its SHA-256, its upstream binding, and its
+  purpose.
+
+Run:
+
+```bash
+make check-sosa-source-version
+```
+
+The source-version checker rejects noncanonical or abbreviated identities,
+unexpected authority fields, unsafe source paths, source-file hash drift,
+overlay hash drift, a root SOSA version-IRI mismatch, or an overlay that no
+longer records the approved upstream commit.
+
+The governed SOSA-next mapping checker derives its `SOURCE_FILES` and
+`PINNED_SOURCE_SHA256` compatibility interfaces from this authority rather than
+maintaining a second source-pin table.
+
+## Formal-release consequence
+
+The source-identity approval prerequisite recorded in
+`reports/sosa-next-formal-release-integration-audit.md` is resolved.
+
+The next unresolved formal-release architecture decision is whether the
+approved source-version track is published as:
+
+- a separate release package; or
+- part of a combined package with the current SSN/SOSA track.
+
+No choice between those publication models is made here.
+
+## Non-goals
+
+This decision does not:
+
+- rename `src/sosa-next/` or `releases/sosa-next/`;
+- change any maintained SOSA-next development ontology IRI;
+- modify any pinned W3C source ontology;
+- modify the local declaration overlay;
+- change the governed SOSA-next workbook or mapping dispositions;
+- change current-SOSA products;
+- change formal-release metadata, manifest, package, archive, or rehearsal
+  machinery;
+- create a formal release, tag, deployment, or persistent-IRI redirect.

--- a/src/sosa-next/docs/README.md
+++ b/src/sosa-next/docs/README.md
@@ -6,9 +6,11 @@ The SOSA-next track is a governed maintained development track for the
 forthcoming SOSA source. It is generated from
 `mappings/SOSA-next-to-BFO-COMS.xlsx`.
 
-The temporary name `sosa-next` identifies the development track. It is not an
-approved formal source-version identity and must not appear in a formal release
-path or ontology IRI.
+The approved immutable source-version identity is
+`sosa-2023-af425a0454ec00512a5ebfa2873fe35a077f5fda`, governed by `config/sosa-source-version.toml` and bound
+to W3C upstream commit `af425a0454ec00512a5ebfa2873fe35a077f5fda`. The temporary name `sosa-next`
+remains the development alias used by the current development paths and ontology
+IRIs. It must not be used as the track identity in a future formal release.
 
 ## Products
 
@@ -62,10 +64,15 @@ dependencies separately.
 Run:
 
 ```bash
+make check-sosa-source-version
 make check-sosa-next
 make check-sosa-next-products
 make check-sosa-next-consumer-stack
 ```
+
+The source-version checker enforces the approved source identity, exact hashes
+for all eight upstream files and the local declaration overlay, the root SOSA
+edition version IRI, and the overlay's binding to the approved upstream commit.
 
 The product checker enforces:
 
@@ -93,9 +100,12 @@ The consumer-stack checker enforces:
 
 These products are not part of the current formal release package. Current
 release metadata, manifest, package, archive, and rehearsal tooling remains
-specific to the current five-product SSN/SOSA track.
+specific to the current five-product SSN/SOSA track. Future formal integration
+must replace the `sosa-next` development alias with `sosa-2023-af425a0454ec00512a5ebfa2873fe35a077f5fda` in
+formal track-specific paths and ontology IRIs.
 
 See:
 
+- `reports/sosa-source-version-identity-decision.md`
 - `reports/sosa-next-product-contract.md`
 - `reports/sosa-next-formal-release-integration-audit.md`

--- a/src/sosa-next/imports/README.md
+++ b/src/sosa-next/imports/README.md
@@ -11,6 +11,12 @@ The following eight files are byte-for-byte copies from the W3C
 
 `af425a0454ec00512a5ebfa2873fe35a077f5fda`
 
+The approved immutable project source identity for this exact upstream snapshot
+is `sosa-2023-af425a0454ec00512a5ebfa2873fe35a077f5fda`. `config/sosa-source-version.toml` is the sole
+machine-readable authority for the identity, upstream/local path pairs, hashes,
+and local overlay binding. The table below is human-readable provenance
+documentation rather than a second source-pin authority.
+
 | Local file | SHA-256 |
 |---|---|
 | `sosa.ttl` | `a1875d19988b0bd17e5cd3a61f76440b6e0f7b1e07bd30237e6fb7341c170305` |
@@ -23,8 +29,10 @@ The following eight files are byte-for-byte copies from the W3C
 | `sample-relations.ttl` | `0f9c8561626e9c75cb364d3c0f6cdb3197e9e72b6727b095309fc3fb1d605e32` |
 
 Do not edit these eight files directly. Any upstream update must replace the
-relevant files from an explicitly selected commit and update the enforced
-digests, tests, and this documentation in the same change.
+relevant files from an explicitly selected commit and update
+`config/sosa-source-version.toml`, the focused source-version tests, and this
+documentation in the same governed change. A new upstream commit constitutes a
+new source snapshot and therefore requires an explicit source-identity decision.
 
 ## Local declaration overlay
 
@@ -44,6 +52,12 @@ its upstream usage without modifying the pinned source.
 files. It also resolves the merged CCO/BFO dependency to the repository-level
 `imports/cco.ttl`.
 
+Validate the source authority and pinned bytes with:
+
+```bash
+make check-sosa-source-version
+```
+
 Run the governed workbook and HermiT validation with:
 
 ```bash
@@ -52,5 +66,6 @@ PYTHONPATH=tools \
 python tools/check_sosa_next_mapping.py
 ```
 
-The checker enforces the source-file digests before parsing the workbook or
+The mapping checker derives its governed source paths and digests from the
+source-version authority and validates them before parsing the workbook or
 running reasoning.

--- a/tests/test_check_sosa_next_mapping.py
+++ b/tests/test_check_sosa_next_mapping.py
@@ -18,6 +18,7 @@ import check_sosa_next_mapping as checker  # noqa: E402
 GOVERNED_INPUTS = (
     REPO_ROOT / "mappings/SOSA-next-to-BFO-COMS.xlsx",
     REPO_ROOT / "src/sosa-next/catalog-v001.xml",
+    checker.SOURCE_VERSION_CONFIG,
     *checker.SOURCE_FILES,
 )
 
@@ -118,6 +119,26 @@ class CheckSosaNextMappingTests(unittest.TestCase):
 
             for summary in (first, second):
                 self.assertTrue(summary["passed"], summary)
+                self.assertEqual(
+                    summary["source_identity"],
+                    checker.SOURCE_IDENTITY,
+                )
+                self.assertEqual(
+                    summary["source_version_authority"],
+                    "config/sosa-source-version.toml",
+                )
+                self.assertEqual(
+                    summary["source_version_authority_sha256"],
+                    sha256(checker.SOURCE_VERSION_CONFIG),
+                )
+                self.assertEqual(
+                    summary["source_edition_version_iri"],
+                    checker.SOURCE_VERSION_AUTHORITY.edition_version_iri,
+                )
+                self.assertEqual(
+                    summary["source_upstream_commit"],
+                    checker.SOURCE_VERSION_AUTHORITY.upstream_commit,
+                )
                 self.assertEqual(summary["source_triple_count"], 1207)
                 self.assertEqual(
                     summary["source_sha256"],
@@ -254,6 +275,11 @@ class CheckSosaNextMappingTests(unittest.TestCase):
                 )
 
             stable_sections = (
+                "source_identity",
+                "source_version_authority",
+                "source_version_authority_sha256",
+                "source_edition_version_iri",
+                "source_upstream_commit",
                 "source_sha256",
                 "source_triple_count",
                 "governed_row_count",

--- a/tests/test_sosa_next_products.py
+++ b/tests/test_sosa_next_products.py
@@ -23,6 +23,7 @@ PROTECTED_PATHS = (
     products.METADATA_PATH,
     *products.CURRENT_SOSA_PRODUCTS.values(),
     *products.MAINTAINED_PRODUCTS.values(),
+    checker.products.mapping_checker.SOURCE_VERSION_CONFIG,
     *checker.products.mapping_checker.SOURCE_FILES,
 )
 

--- a/tests/test_sosa_source_version.py
+++ b/tests/test_sosa_source_version.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+"""Focused tests for the immutable SOSA source-version authority."""
+
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+import sys
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT / "tools"))
+
+import check_sosa_source_version as checker  # noqa: E402
+import sosa_source_version as source_version  # noqa: E402
+
+
+EXPECTED_COMMIT = "af425a0454ec00512a5ebfa2873fe35a077f5fda"
+EXPECTED_IDENTITY = f"sosa-2023-{EXPECTED_COMMIT}"
+
+
+class SosaSourceVersionTests(unittest.TestCase):
+    def test_approved_identity_uses_full_upstream_commit(self) -> None:
+        authority = source_version.load_source_version_authority()
+
+        self.assertEqual(authority.schema_version, 1)
+        self.assertEqual(authority.status, "approved")
+        self.assertEqual(authority.source_identity, EXPECTED_IDENTITY)
+        self.assertEqual(authority.development_alias, "sosa-next")
+        self.assertEqual(authority.upstream_commit, EXPECTED_COMMIT)
+        self.assertEqual(
+            authority.upstream_repository,
+            "https://github.com/w3c/sdw-sosa-ssn",
+        )
+        self.assertEqual(
+            authority.edition_version_iri,
+            "http://www.w3.org/ns/sosa/2023/",
+        )
+        self.assertEqual(len(authority.source_files), 8)
+
+    def test_governed_source_bytes_and_metadata_match(self) -> None:
+        summary = checker.run_check()
+
+        self.assertTrue(summary["passed"])
+        self.assertEqual(summary["source_identity"], EXPECTED_IDENTITY)
+        self.assertEqual(summary["upstream_commit"], EXPECTED_COMMIT)
+        self.assertEqual(summary["upstream_source_file_count"], 8)
+        self.assertEqual(len(summary["source_sha256"]), 9)
+
+    def test_abbreviated_commit_identity_is_rejected(self) -> None:
+        original = source_version.CONFIG_PATH.read_text(
+            encoding="utf-8"
+        )
+        altered = original.replace(
+            EXPECTED_IDENTITY,
+            "sosa-2023-af425a0",
+            1,
+        )
+        self.assertNotEqual(original, altered)
+
+        with tempfile.TemporaryDirectory(
+            prefix="sosa-source-version-test-"
+        ) as directory:
+            config_path = Path(directory) / "source-version.toml"
+            config_path.write_text(altered, encoding="utf-8")
+
+            with self.assertRaisesRegex(
+                RuntimeError,
+                "complete approved upstream commit",
+            ):
+                source_version.load_source_version_authority(
+                    config_path
+                )
+
+    def test_wrong_source_digest_is_rejected(self) -> None:
+        authority = source_version.load_source_version_authority()
+        first = authority.source_files[0]
+
+        bad_authority = source_version.SourceVersionAuthority(
+            schema_version=authority.schema_version,
+            status=authority.status,
+            source_identity=authority.source_identity,
+            development_alias=authority.development_alias,
+            edition_label=authority.edition_label,
+            edition_version_iri=authority.edition_version_iri,
+            w3c_tr_iri=authority.w3c_tr_iri,
+            upstream_repository=authority.upstream_repository,
+            upstream_commit=authority.upstream_commit,
+            upstream_commit_date=authority.upstream_commit_date,
+            source_files=(
+                source_version.SourceFile(
+                    local_path=first.local_path,
+                    upstream_path=first.upstream_path,
+                    sha256="0" * 64,
+                ),
+                *authority.source_files[1:],
+            ),
+            overlay_path=authority.overlay_path,
+            overlay_sha256=authority.overlay_sha256,
+            overlay_bound_upstream_commit=(
+                authority.overlay_bound_upstream_commit
+            ),
+            overlay_purpose=authority.overlay_purpose,
+        )
+
+        with self.assertRaisesRegex(
+            RuntimeError,
+            "SHA-256 mismatch",
+        ):
+            source_version.validate_source_version_files(
+                bad_authority
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/check_sosa_next_mapping.py
+++ b/tools/check_sosa_next_mapping.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import argparse
-import hashlib
 import json
 import re
 import shutil
@@ -15,6 +14,7 @@ from rdflib.collection import Collection
 
 import generate_mapping_from_coms as coms
 import robot_reconstruction_validation as robot_validation
+import sosa_source_version as source_version
 
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -22,39 +22,26 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 WORKBOOK = REPO_ROOT / "mappings/SOSA-next-to-BFO-COMS.xlsx"
 CATALOG = REPO_ROOT / "src/sosa-next/catalog-v001.xml"
 
-SOURCE_FILES = (
-    REPO_ROOT / "src/sosa-next/imports/sosa.ttl",
-    REPO_ROOT / "src/sosa-next/imports/sosa-common.ttl",
-    REPO_ROOT / "src/sosa-next/imports/sosa-observation.ttl",
-    REPO_ROOT / "src/sosa-next/imports/sosa-actuation.ttl",
-    REPO_ROOT / "src/sosa-next/imports/sosa-sampling.ttl",
-    REPO_ROOT / "src/sosa-next/imports/sosa-deprecated.ttl",
-    REPO_ROOT / "src/sosa-next/imports/sosa-system.ttl",
-    REPO_ROOT / "src/sosa-next/imports/sample-relations.ttl",
-    REPO_ROOT
-    / "src/sosa-next/imports/sosa-source-declaration-overlay.ttl",
+SOURCE_VERSION_AUTHORITY = (
+    source_version.load_source_version_authority()
+)
+SOURCE_VERSION_CONFIG = source_version.CONFIG_PATH
+SOURCE_IDENTITY = SOURCE_VERSION_AUTHORITY.source_identity
+
+SOURCE_FILES = tuple(
+    REPO_ROOT / item.local_path
+    for item in SOURCE_VERSION_AUTHORITY.source_files
+) + (
+    REPO_ROOT / SOURCE_VERSION_AUTHORITY.overlay_path,
 )
 
 PINNED_SOURCE_SHA256 = {
-    SOURCE_FILES[0]:
-        "a1875d19988b0bd17e5cd3a61f76440b6e0f7b1e07bd30237e6fb7341c170305",
-    SOURCE_FILES[1]:
-        "31bb4a6fb3d4b8b7612998744f73b5a8194d34ef866184460ed22dc0f78a91aa",
-    SOURCE_FILES[2]:
-        "da6b3b2304a491c45a8822e70529f72c1d73606dda9a8b73b0c5360313ab30c3",
-    SOURCE_FILES[3]:
-        "18c840cba0a4e148048e6147cb2b5fa9b36bbf09dcb60802ce65d3ecfb3175c5",
-    SOURCE_FILES[4]:
-        "82e59f8354debaff6cdcb3e354397ea17318e4bc45dc7a8a005c1fa5404d2d70",
-    SOURCE_FILES[5]:
-        "5a99055ea8938f0e9384b81ad3ac1b3eaa13aaf50c54e308cab9551c88392987",
-    SOURCE_FILES[6]:
-        "1ac64f168163b7e6139bf632a07e35112837a58021ff706688d2c626e9cc1caf",
-    SOURCE_FILES[7]:
-        "0f9c8561626e9c75cb364d3c0f6cdb3197e9e72b6727b095309fc3fb1d605e32",
-    SOURCE_FILES[8]:
-        "5cee7b4c6799df0ebff5f4c503b7495fce67f940c53711a2aecfa6896f8d3af2",
+    REPO_ROOT / item.local_path: item.sha256
+    for item in SOURCE_VERSION_AUTHORITY.source_files
 }
+PINNED_SOURCE_SHA256[
+    REPO_ROOT / SOURCE_VERSION_AUTHORITY.overlay_path
+] = SOURCE_VERSION_AUTHORITY.overlay_sha256
 
 ONTOLOGY_IRI = URIRef(
     "http://www.sks.ai/SSN2BFO/development/sosa-next/active-mappings"
@@ -80,37 +67,13 @@ SOURCE_NAMESPACES = {
 }
 
 
-def sha256_file(path: Path) -> str:
-    """Return a bounded-memory SHA-256 digest."""
-
-    digest = hashlib.sha256()
-    with path.open("rb") as handle:
-        for block in iter(lambda: handle.read(1024 * 1024), b""):
-            digest.update(block)
-    return digest.hexdigest()
-
-
 def validate_source_pins() -> dict[str, str]:
-    """Require every governed source file to match its pinned digest."""
+    """Validate governed source bytes through the source authority."""
 
-    actual = {}
-
-    for path, expected in PINNED_SOURCE_SHA256.items():
-        if not path.is_file():
-            raise RuntimeError(f"Required pinned source is missing: {path}")
-
-        digest = sha256_file(path)
-        relative_path = path.relative_to(REPO_ROOT).as_posix()
-        actual[relative_path] = digest
-
-        if digest != expected:
-            raise RuntimeError(
-                f"Pinned source SHA-256 mismatch for {relative_path}: "
-                f"expected {expected}, got {digest}"
-            )
-
-    return actual
-
+    return source_version.validate_source_version_files(
+        SOURCE_VERSION_AUTHORITY,
+        REPO_ROOT,
+    )
 
 def resolve_robot(robot_path: str | None) -> str:
     """Resolve an explicit ROBOT path or use the governed installer."""
@@ -342,6 +305,9 @@ def run_check(
     summary_path = output_dir / "summary.json"
 
     source_hashes = validate_source_pins()
+    source_authority_sha256 = source_version.sha256_file(
+        SOURCE_VERSION_CONFIG
+    )
     source_graph = build_merged_source(merged_source_path)
 
     rows, workbook_stats = coms.read_workbook(WORKBOOK)
@@ -485,6 +451,19 @@ def run_check(
         "workbook": str(WORKBOOK),
         "catalog": str(CATALOG),
         "robot_path": robot,
+        "source_identity": SOURCE_IDENTITY,
+        "source_version_authority": (
+            SOURCE_VERSION_CONFIG.relative_to(REPO_ROOT).as_posix()
+        ),
+        "source_version_authority_sha256": (
+            source_authority_sha256
+        ),
+        "source_edition_version_iri": (
+            SOURCE_VERSION_AUTHORITY.edition_version_iri
+        ),
+        "source_upstream_commit": (
+            SOURCE_VERSION_AUTHORITY.upstream_commit
+        ),
         "source_files": [str(path) for path in SOURCE_FILES],
         "source_sha256": source_hashes,
         "source_triple_count": len(source_graph),

--- a/tools/check_sosa_source_version.py
+++ b/tools/check_sosa_source_version.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+"""Validate the approved immutable SOSA source-version authority."""
+
+from __future__ import annotations
+
+from rdflib import Graph, URIRef
+from rdflib.namespace import OWL, RDF
+
+import sosa_source_version as source_version
+
+
+ROOT_SOSA_ONTOLOGY = URIRef("http://www.w3.org/ns/sosa/")
+
+
+def run_check() -> dict[str, object]:
+    authority = source_version.load_source_version_authority()
+    source_hashes = source_version.validate_source_version_files(authority)
+
+    root_entries = [
+        item
+        for item in authority.source_files
+        if item.local_path == "src/sosa-next/imports/sosa.ttl"
+    ]
+    if len(root_entries) != 1:
+        raise RuntimeError(
+            "Source authority must contain exactly one root sosa.ttl entry"
+        )
+
+    root_graph = Graph()
+    root_graph.parse(
+        source_version.REPO_ROOT / root_entries[0].local_path,
+        format="turtle",
+    )
+
+    ontology_declarations = set(
+        root_graph.triples((None, RDF.type, OWL.Ontology))
+    )
+    if ontology_declarations != {
+        (ROOT_SOSA_ONTOLOGY, RDF.type, OWL.Ontology)
+    }:
+        raise RuntimeError(
+            "Pinned root SOSA file has unexpected ontology declaration"
+        )
+
+    version_iris = {
+        str(value)
+        for value in root_graph.objects(
+            ROOT_SOSA_ONTOLOGY,
+            OWL.versionIRI,
+        )
+    }
+    if version_iris != {authority.edition_version_iri}:
+        raise RuntimeError(
+            "Pinned root SOSA versionIRI does not match source authority: "
+            f"{sorted(version_iris)}"
+        )
+
+    overlay_graph = Graph()
+    overlay_graph.parse(
+        source_version.REPO_ROOT / authority.overlay_path,
+        format="turtle",
+    )
+    overlay_version_info = {
+        str(value)
+        for value in overlay_graph.objects(None, OWL.versionInfo)
+    }
+    expected_overlay_text = (
+        f"Upstream commit {authority.upstream_commit}"
+    )
+    if expected_overlay_text not in overlay_version_info:
+        raise RuntimeError(
+            "Local source-declaration overlay does not record the approved "
+            "upstream commit"
+        )
+
+    return {
+        "schema_version": authority.schema_version,
+        "status": authority.status,
+        "source_identity": authority.source_identity,
+        "development_alias": authority.development_alias,
+        "edition_label": authority.edition_label,
+        "edition_version_iri": authority.edition_version_iri,
+        "upstream_repository": authority.upstream_repository,
+        "upstream_commit": authority.upstream_commit,
+        "upstream_commit_date": authority.upstream_commit_date,
+        "upstream_source_file_count": len(authority.source_files),
+        "local_overlay_path": authority.overlay_path,
+        "source_sha256": source_hashes,
+        "passed": True,
+    }
+
+
+def main() -> int:
+    try:
+        summary = run_check()
+    except Exception as exc:
+        print(f"SOSA source-version authority: FAIL\n{exc}")
+        return 1
+
+    print(f"Status: {summary['status']}")
+    print(f"Source identity: {summary['source_identity']}")
+    print(f"Development alias: {summary['development_alias']}")
+    print(f"Edition: {summary['edition_label']}")
+    print(f"Edition version IRI: {summary['edition_version_iri']}")
+    print(f"Upstream repository: {summary['upstream_repository']}")
+    print(f"Upstream commit: {summary['upstream_commit']}")
+    print(f"Upstream commit date: {summary['upstream_commit_date']}")
+    print(
+        "Upstream source files: "
+        f"{summary['upstream_source_file_count']}"
+    )
+    print(f"Local overlay: {summary['local_overlay_path']}")
+
+    for file_path, digest in sorted(
+        summary["source_sha256"].items()
+    ):
+        print(f"  {digest}  {file_path}")
+
+    print("Summary: PASS")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/run_validation_suite.py
+++ b/tools/run_validation_suite.py
@@ -406,6 +406,8 @@ def compile_check() -> StepResult:
             "tools/robot_reconstruction_validation.py",
             "tools/validate_robot_reconstruction.py",
             "tools/check_coms_mapping.py",
+            "tools/sosa_source_version.py",
+            "tools/check_sosa_source_version.py",
             "tools/check_sosa_next_mapping.py",
             "tools/generate_sosa_next_products.py",
             "tools/check_sosa_next_products.py",
@@ -419,6 +421,7 @@ def compile_check() -> StepResult:
             "tools/release_archive.py",
             "tools/rehearse_release.py",
             "tests/test_generate_mapping_from_coms.py",
+            "tests/test_sosa_source_version.py",
             "tests/test_check_sosa_next_mapping.py",
             "tests/test_sosa_next_products.py",
             "tests/test_sosa_next_consumer_stack.py",
@@ -504,6 +507,22 @@ def run_validation_suite(args: argparse.Namespace) -> int:
                     "tests",
                     "-p",
                     "test_coms_row_identity.py",
+                ],
+            )
+        )
+    if results[-1].passed:
+        results.append(
+            run_command(
+                "SOSA source-version authority focused tests",
+                [
+                    sys.executable,
+                    "-m",
+                    "unittest",
+                    "discover",
+                    "-s",
+                    "tests",
+                    "-p",
+                    "test_sosa_source_version.py",
                 ],
             )
         )
@@ -823,6 +842,16 @@ def run_validation_suite(args: argparse.Namespace) -> int:
             run_command(
                 "COMS workbook freshness and candidate quality check",
                 [sys.executable, "tools/check_coms_mapping.py", "--check-only"],
+            )
+        )
+    if results[-1].passed:
+        results.append(
+            run_command(
+                "SOSA source-version authority check",
+                [
+                    sys.executable,
+                    "tools/check_sosa_source_version.py",
+                ],
             )
         )
     if results[-1].passed:

--- a/tools/sosa_source_version.py
+++ b/tools/sosa_source_version.py
@@ -1,0 +1,373 @@
+#!/usr/bin/env python3
+"""Load and validate the approved SOSA source-version authority."""
+
+from __future__ import annotations
+
+import hashlib
+import re
+import tomllib
+from dataclasses import dataclass
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+CONFIG_PATH = REPO_ROOT / "config/sosa-source-version.toml"
+
+FULL_GIT_SHA = re.compile(r"^[0-9a-f]{40}$")
+SHA256 = re.compile(r"^[0-9a-f]{64}$")
+SOURCE_IDENTITY = re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+)*$")
+
+EXPECTED_REPOSITORY = "https://github.com/w3c/sdw-sosa-ssn"
+EXPECTED_EDITION_LABEL = "Semantic Sensor Network Ontology - 2023 Edition"
+EXPECTED_EDITION_VERSION_IRI = "http://www.w3.org/ns/sosa/2023/"
+EXPECTED_W3C_TR_IRI = "https://www.w3.org/TR/vocab-ssn-2023/"
+EXPECTED_DEVELOPMENT_ALIAS = "sosa-next"
+
+
+@dataclass(frozen=True)
+class SourceFile:
+    local_path: str
+    upstream_path: str
+    sha256: str
+
+
+@dataclass(frozen=True)
+class SourceVersionAuthority:
+    schema_version: int
+    status: str
+    source_identity: str
+    development_alias: str
+    edition_label: str
+    edition_version_iri: str
+    w3c_tr_iri: str
+    upstream_repository: str
+    upstream_commit: str
+    upstream_commit_date: str
+    source_files: tuple[SourceFile, ...]
+    overlay_path: str
+    overlay_sha256: str
+    overlay_bound_upstream_commit: str
+    overlay_purpose: str
+
+
+def sha256_file(file_path: Path) -> str:
+    digest = hashlib.sha256()
+    with file_path.open("rb") as handle:
+        for block in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def _require_exact_keys(
+    value: dict[str, object],
+    expected: set[str],
+    label: str,
+) -> None:
+    actual = set(value)
+    if actual != expected:
+        missing = sorted(expected - actual)
+        extra = sorted(actual - expected)
+        raise RuntimeError(
+            f"{label}: noncanonical keys; missing={missing}; extra={extra}"
+        )
+
+
+def _require_string(value: object, label: str) -> str:
+    if not isinstance(value, str) or not value:
+        raise RuntimeError(f"{label}: expected nonempty string")
+    return value
+
+
+def _require_safe_relative_path(value: object, label: str) -> str:
+    text = _require_string(value, label)
+    file_path = Path(text)
+    if (
+        file_path.is_absolute()
+        or ".." in file_path.parts
+        or text.startswith("./")
+        or "\\" in text
+        or "//" in text
+    ):
+        raise RuntimeError(f"{label}: unsafe or noncanonical path {text!r}")
+    if file_path.as_posix() != text:
+        raise RuntimeError(f"{label}: noncanonical path {text!r}")
+    return text
+
+
+def load_source_version_authority(
+    config_path: Path = CONFIG_PATH,
+) -> SourceVersionAuthority:
+    with config_path.open("rb") as handle:
+        document = tomllib.load(handle)
+
+    _require_exact_keys(
+        document,
+        {
+            "schema_version",
+            "status",
+            "source_identity",
+            "development_alias",
+            "edition_label",
+            "edition_version_iri",
+            "w3c_tr_iri",
+            "upstream_repository",
+            "upstream_commit",
+            "upstream_commit_date",
+            "source_files",
+            "local_overlay",
+        },
+        "document",
+    )
+
+    schema_version = document["schema_version"]
+    if isinstance(schema_version, bool) or schema_version != 1:
+        raise RuntimeError(
+            f"schema_version: expected integer 1, got {schema_version!r}"
+        )
+
+    status = _require_string(document["status"], "status")
+    if status != "approved":
+        raise RuntimeError(f"status: expected 'approved', got {status!r}")
+
+    upstream_commit = _require_string(
+        document["upstream_commit"],
+        "upstream_commit",
+    )
+    if FULL_GIT_SHA.fullmatch(upstream_commit) is None:
+        raise RuntimeError(
+            "upstream_commit: expected full lowercase 40-character Git SHA"
+        )
+
+    source_identity = _require_string(
+        document["source_identity"],
+        "source_identity",
+    )
+    if SOURCE_IDENTITY.fullmatch(source_identity) is None:
+        raise RuntimeError(
+            f"source_identity: noncanonical component {source_identity!r}"
+        )
+
+    expected_identity = f"sosa-2023-{upstream_commit}"
+    if source_identity != expected_identity:
+        raise RuntimeError(
+            "source_identity: must use the complete approved upstream commit; "
+            f"expected {expected_identity!r}, got {source_identity!r}"
+        )
+
+    development_alias = _require_string(
+        document["development_alias"],
+        "development_alias",
+    )
+    if development_alias != EXPECTED_DEVELOPMENT_ALIAS:
+        raise RuntimeError(
+            "development_alias: expected "
+            f"{EXPECTED_DEVELOPMENT_ALIAS!r}, got {development_alias!r}"
+        )
+
+    edition_label = _require_string(
+        document["edition_label"],
+        "edition_label",
+    )
+    if edition_label != EXPECTED_EDITION_LABEL:
+        raise RuntimeError(
+            f"edition_label: expected {EXPECTED_EDITION_LABEL!r}"
+        )
+
+    edition_version_iri = _require_string(
+        document["edition_version_iri"],
+        "edition_version_iri",
+    )
+    if edition_version_iri != EXPECTED_EDITION_VERSION_IRI:
+        raise RuntimeError(
+            "edition_version_iri: expected "
+            f"{EXPECTED_EDITION_VERSION_IRI!r}"
+        )
+
+    w3c_tr_iri = _require_string(
+        document["w3c_tr_iri"],
+        "w3c_tr_iri",
+    )
+    if w3c_tr_iri != EXPECTED_W3C_TR_IRI:
+        raise RuntimeError(
+            f"w3c_tr_iri: expected {EXPECTED_W3C_TR_IRI!r}"
+        )
+
+    upstream_repository = _require_string(
+        document["upstream_repository"],
+        "upstream_repository",
+    )
+    if upstream_repository != EXPECTED_REPOSITORY:
+        raise RuntimeError(
+            f"upstream_repository: expected {EXPECTED_REPOSITORY!r}"
+        )
+
+    upstream_commit_date = _require_string(
+        document["upstream_commit_date"],
+        "upstream_commit_date",
+    )
+    if re.fullmatch(r"\d{4}-\d{2}-\d{2}", upstream_commit_date) is None:
+        raise RuntimeError(
+            "upstream_commit_date: expected canonical YYYY-MM-DD"
+        )
+
+    raw_source_files = document["source_files"]
+    if not isinstance(raw_source_files, list):
+        raise RuntimeError("source_files: expected array of tables")
+    if len(raw_source_files) != 8:
+        raise RuntimeError(
+            f"source_files: expected exactly 8 upstream files, got "
+            f"{len(raw_source_files)}"
+        )
+
+    source_files: list[SourceFile] = []
+    local_paths: set[str] = set()
+    upstream_paths: set[str] = set()
+
+    for index, raw_item in enumerate(raw_source_files):
+        label = f"source_files[{index}]"
+        if not isinstance(raw_item, dict):
+            raise RuntimeError(f"{label}: expected table")
+        _require_exact_keys(
+            raw_item,
+            {"local_path", "upstream_path", "sha256"},
+            label,
+        )
+
+        local_path = _require_safe_relative_path(
+            raw_item["local_path"],
+            f"{label}.local_path",
+        )
+        upstream_path = _require_safe_relative_path(
+            raw_item["upstream_path"],
+            f"{label}.upstream_path",
+        )
+        digest = _require_string(
+            raw_item["sha256"],
+            f"{label}.sha256",
+        )
+
+        if not local_path.startswith("src/sosa-next/imports/"):
+            raise RuntimeError(
+                f"{label}.local_path: outside governed SOSA source directory"
+            )
+        if not local_path.endswith(".ttl"):
+            raise RuntimeError(f"{label}.local_path: expected Turtle file")
+        if not upstream_path.endswith(".ttl"):
+            raise RuntimeError(f"{label}.upstream_path: expected Turtle file")
+        if SHA256.fullmatch(digest) is None:
+            raise RuntimeError(
+                f"{label}.sha256: expected lowercase SHA-256"
+            )
+        if local_path in local_paths:
+            raise RuntimeError(
+                f"{label}.local_path: duplicate {local_path!r}"
+            )
+        if upstream_path in upstream_paths:
+            raise RuntimeError(
+                f"{label}.upstream_path: duplicate {upstream_path!r}"
+            )
+
+        local_paths.add(local_path)
+        upstream_paths.add(upstream_path)
+        source_files.append(
+            SourceFile(
+                local_path=local_path,
+                upstream_path=upstream_path,
+                sha256=digest,
+            )
+        )
+
+    raw_overlay = document["local_overlay"]
+    if not isinstance(raw_overlay, dict):
+        raise RuntimeError("local_overlay: expected table")
+
+    _require_exact_keys(
+        raw_overlay,
+        {
+            "path",
+            "sha256",
+            "bound_upstream_commit",
+            "purpose",
+        },
+        "local_overlay",
+    )
+
+    overlay_path = _require_safe_relative_path(
+        raw_overlay["path"],
+        "local_overlay.path",
+    )
+    overlay_sha256 = _require_string(
+        raw_overlay["sha256"],
+        "local_overlay.sha256",
+    )
+    overlay_bound_upstream_commit = _require_string(
+        raw_overlay["bound_upstream_commit"],
+        "local_overlay.bound_upstream_commit",
+    )
+    overlay_purpose = _require_string(
+        raw_overlay["purpose"],
+        "local_overlay.purpose",
+    )
+
+    if SHA256.fullmatch(overlay_sha256) is None:
+        raise RuntimeError(
+            "local_overlay.sha256: expected lowercase SHA-256"
+        )
+    if overlay_path in local_paths:
+        raise RuntimeError(
+            "local_overlay.path: overlay must remain separate from upstream files"
+        )
+    if overlay_bound_upstream_commit != upstream_commit:
+        raise RuntimeError(
+            "local_overlay.bound_upstream_commit: must equal upstream_commit"
+        )
+
+    return SourceVersionAuthority(
+        schema_version=1,
+        status=status,
+        source_identity=source_identity,
+        development_alias=development_alias,
+        edition_label=edition_label,
+        edition_version_iri=edition_version_iri,
+        w3c_tr_iri=w3c_tr_iri,
+        upstream_repository=upstream_repository,
+        upstream_commit=upstream_commit,
+        upstream_commit_date=upstream_commit_date,
+        source_files=tuple(source_files),
+        overlay_path=overlay_path,
+        overlay_sha256=overlay_sha256,
+        overlay_bound_upstream_commit=overlay_bound_upstream_commit,
+        overlay_purpose=overlay_purpose,
+    )
+
+
+def validate_source_version_files(
+    authority: SourceVersionAuthority,
+    repo_root: Path = REPO_ROOT,
+) -> dict[str, str]:
+    expected = {
+        item.local_path: item.sha256
+        for item in authority.source_files
+    }
+    expected[authority.overlay_path] = authority.overlay_sha256
+
+    actual: dict[str, str] = {}
+
+    for relative_path, expected_digest in expected.items():
+        file_path = repo_root / relative_path
+        if not file_path.is_file() or file_path.is_symlink():
+            raise RuntimeError(
+                f"Required governed source file is missing or not regular: "
+                f"{relative_path}"
+            )
+
+        actual_digest = sha256_file(file_path)
+        actual[relative_path] = actual_digest
+
+        if actual_digest != expected_digest:
+            raise RuntimeError(
+                f"SHA-256 mismatch for {relative_path}: "
+                f"expected {expected_digest}, got {actual_digest}"
+            )
+
+    return actual


### PR DESCRIPTION
## Summary

- approves the immutable SOSA source-version identity:
  `sosa-2023-af425a0454ec00512a5ebfa2873fe35a077f5fda`;
- establishes `config/sosa-source-version.toml` as the machine-readable source authority;
- binds the governed source closure to W3C `sdw-sosa-ssn` commit `af425a0454ec00512a5ebfa2873fe35a077f5fda`;
- centralizes all SOSA source paths and SHA-256 pins under that authority;
- adds focused and canonical source-version validation;
- records the source-identity governance decision and updates active documentation;
- keeps `sosa-next` unchanged as the development alias until formal-release integration.

## Provenance

An independent audit fetched the exact W3C upstream commit and compared the eight pinned upstream Turtle files against every Turtle blob at that commit.

Each governed upstream file had exactly one byte-identical match.

The local `sosa-source-declaration-overlay.ttl` remains separately governed and bound to the same upstream commit.

## Validation

- complete `make check`: PASS;
- source-version authority focused tests: PASS;
- source-version authority checker: PASS;
- SOSA-next governed mapping validation: PASS;
- SOSA-next maintained-product validation: PASS;
- SOSA-next consumer-stack validation: PASS;
- current-SOSA protected hashes unchanged;
- maintained SOSA-next product hashes unchanged;
- all nine governed SOSA source/overlay hashes unchanged;
- SOSA-next workbook unchanged;
- formal-release machinery unchanged;
- `git diff --check`: PASS.

## Scope boundaries

- no pinned W3C source ontology changes;
- no local declaration-overlay changes;
- no SOSA-next workbook or mapping-disposition changes;
- no maintained development product byte changes;
- no current-SOSA product byte changes;
- no formal-release metadata, manifest, package, archive, or rehearsal changes;
- no development path or ontology-IRI rename;
- no release publication or persistent-IRI deployment.

The source-identity prerequisite is now resolved. The next unresolved formal-release architecture decision is separate-package versus combined-package publication.
