### PR TITLE
Approve SOSA formal package scope

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: validate validate-write audit-write legacy-audit-write compile check check-coms check-sosa-next check-coms-row-identities check-coms-product-dispositions check-alignment-core check-strict-bfo-mapping check-cco-extension check-bfo-projection check-publication-metadata check-release-rendering check-release-package check-release-archive check-release-rehearsal check-placeholder-catalog-migration watch-coms coms-status post-merge-check status diffstat generate-sosa-next-products check-sosa-next-products check-sosa-next-consumer-stack check-sosa-source-version
+.PHONY: validate validate-write audit-write legacy-audit-write compile check check-coms check-sosa-next check-coms-row-identities check-coms-product-dispositions check-alignment-core check-strict-bfo-mapping check-cco-extension check-bfo-projection check-publication-metadata check-release-rendering check-release-package check-release-archive check-release-rehearsal check-placeholder-catalog-migration watch-coms coms-status post-merge-check status diffstat generate-sosa-next-products check-sosa-next-products check-sosa-next-consumer-stack check-sosa-source-version check-sosa-release-scope
 
 validate:
 	PYTHONDONTWRITEBYTECODE=1 python tools/run_validation_suite.py
@@ -36,6 +36,8 @@ compile:
 		tools/check_coms_mapping.py \
 		tools/sosa_source_version.py \
 		tools/check_sosa_source_version.py \
+		tools/sosa_release_scope.py \
+		tools/check_sosa_release_scope.py \
 		tools/check_sosa_next_mapping.py \
 		tools/generate_sosa_next_products.py \
 		tools/check_sosa_next_products.py \
@@ -50,6 +52,7 @@ compile:
 		tools/rehearse_release.py \
 		tests/test_generate_mapping_from_coms.py \
 		tests/test_sosa_source_version.py \
+		tests/test_sosa_release_scope.py \
 		tests/test_check_sosa_next_mapping.py \
 		tests/test_sosa_next_products.py \
 		tests/test_sosa_next_consumer_stack.py \
@@ -103,6 +106,10 @@ check-placeholder-catalog-migration:
 check-sosa-source-version:
 	PYTHONDONTWRITEBYTECODE=1 python -m unittest discover -s tests -p 'test_sosa_source_version.py'
 	PYTHONDONTWRITEBYTECODE=1 python tools/check_sosa_source_version.py
+
+check-sosa-release-scope: check-sosa-source-version
+	PYTHONDONTWRITEBYTECODE=1 python -m unittest discover -s tests -p 'test_sosa_release_scope.py'
+	PYTHONDONTWRITEBYTECODE=1 python tools/check_sosa_release_scope.py
 
 check-sosa-next: check-sosa-source-version
 	PYTHONDONTWRITEBYTECODE=1 python -m unittest discover -s tests -p 'test_check_sosa_next_mapping.py'

--- a/README.md
+++ b/README.md
@@ -68,12 +68,14 @@ Focused development validation:
 
 ```bash
 make check-sosa-source-version
+make check-sosa-release-scope
 make check-sosa-next
 make check-sosa-next-products
 make check-sosa-next-consumer-stack
 ```
 
 See the [source-version identity decision](reports/sosa-source-version-identity-decision.md),
+[formal package-scope decision](reports/sosa-release-package-scope-decision.md),
 [SOSA-next Development Products](src/sosa-next/docs/README.md), and the
 [formal-release integration audit](reports/sosa-next-formal-release-integration-audit.md).
 

--- a/config/sosa-release-scope.toml
+++ b/config/sosa-release-scope.toml
@@ -1,0 +1,10 @@
+schema_version = 1
+status = "approved"
+source_identity = "sosa-2023-af425a0454ec00512a5ebfa2873fe35a077f5fda"
+development_alias = "sosa-next"
+publication_model = "separate_package"
+formal_track_component = "sosa-2023-af425a0454ec00512a5ebfa2873fe35a077f5fda"
+product_order = ["alignment_core", "strict_bfo_mapping", "cco_extension"]
+integrated_product = false
+bfo_projection_product = false
+current_track_formal_release = "unchanged"

--- a/docs/PRODUCT-ARCHITECTURE.md
+++ b/docs/PRODUCT-ARCHITECTURE.md
@@ -204,12 +204,12 @@ make check-sosa-next-consumer-stack
 
 The SOSA-next products are not yet formal-release products. Current release
 metadata, manifest, package, archive, and rehearsal tooling remain authoritative
-only for the five-product current SSN/SOSA track. The source-identity prerequisite
-is resolved as `sosa-2023-af425a0454ec00512a5ebfa2873fe35a077f5fda`. Formal integration must replace the
-`sosa-next` development alias with that exact identity in formal track-specific
-paths and ontology IRIs and deliberately extend the release machinery. The next
-unresolved publication decision is separate-package versus combined-package
-publication.
+only for the five-product current SSN/SOSA track. The source identity is resolved
+as `sosa-2023-af425a0454ec00512a5ebfa2873fe35a077f5fda`, and the formal package
+scope is resolved as a separate three-product package containing alignment core,
+BFO mapping, and CCO extension. The current five-product formal package remains
+unchanged. Future formal integration must replace the `sosa-next` development
+alias with the approved identity in source-version formal paths and ontology IRIs.
 
 The earlier `reports/publication-product-and-import-policy.md` records the
 pre-activation lifecycle policy. For the implemented SOSA-next development

--- a/docs/VALIDATION-AND-RELEASES.md
+++ b/docs/VALIDATION-AND-RELEASES.md
@@ -86,6 +86,7 @@ focused gates:
 
 ```bash
 make check-sosa-source-version
+make check-sosa-release-scope
 make check-sosa-next
 make check-sosa-next-products
 make check-sosa-next-consumer-stack
@@ -95,6 +96,12 @@ make check-sosa-next-consumer-stack
 identity, exact source and overlay hashes, root SOSA edition version IRI, and
 overlay binding to the approved full upstream commit. It performs no network
 resolution.
+
+`make check-sosa-release-scope` validates that the approved formal publication
+model is a separate package with exactly three ontology products in canonical
+order, excludes integrated and BFO-projection products, uses the approved source
+identity as the formal track component, and preserves the current formal package
+contract unchanged.
 
 `make check-sosa-next` depends on the source-version gate and validates the 119
 governed workbook rows, 45 active

--- a/reports/sosa-next-formal-release-integration-audit.md
+++ b/reports/sosa-next-formal-release-integration-audit.md
@@ -88,24 +88,24 @@ SSN/SOSA track:
 The SOSA-next development products must not be inserted into those fixed
 inventories piecemeal.
 
-## Required integration decisions
-
-### Track identity and release scope
+## Resolved package-scope decision
 
 The track identity is resolved as
-`sosa-2023-af425a0454ec00512a5ebfa2873fe35a077f5fda`. Any formal track-specific path or stable ontology-IRI
-namespace that replaces the development alias must use that exact component
-unless a later explicit governance change supersedes this decision.
+`sosa-2023-af425a0454ec00512a5ebfa2873fe35a077f5fda`.
 
-The remaining release-scope decisions are:
+The package scope is also resolved:
 
-1. whether the approved source-version track is published as a separate package
-   or combined with the current SSN/SOSA track;
-2. whether its formal release contains only the three modular products or an
-   additional separately approved consumer artifact.
+- the source-version track is published as a separate formal package;
+- its formal ontology-product order is alignment core, BFO mapping, then CCO
+  extension;
+- no integrated ontology is included;
+- no BFO-projection product is included;
+- the current five-product SSN/SOSA formal package contract remains unchanged.
 
-The existing three-product contract excludes an integrated ontology and BFO
-projection unless separately justified.
+`config/sosa-release-scope.toml` is the machine-readable authority and
+`reports/sosa-release-package-scope-decision.md` records the rationale.
+
+Any additional formal ontology product requires a separate governance decision.
 
 ### Publication metadata
 
@@ -216,15 +216,14 @@ context and approved release notes.
 
 ## Recommended implementation sequence
 
-1. **Choose separate-package versus combined-package publication.**
-2. **Define track-specific publication metadata and formal product order.**
-3. **Implement formal rendering and same-release import rewriting.**
-4. **Add a new manifest/schema authority and exact evidence model.**
-5. **Implement package construction and read-only package validation.**
-6. **Implement the canonical package catalog.**
-7. **Extend deterministic archive construction and validation.**
-8. **Add release notes, rehearsal, and hosted-CI regressions.**
-9. **Run a synthetic release context before any actual publication.**
+1. **Define track-specific publication metadata for the separate package.**
+2. **Implement formal rendering and same-release import rewriting.**
+3. **Add a source-version manifest/schema authority and exact evidence model.**
+4. **Implement separate-package construction and read-only validation.**
+5. **Implement the canonical package catalog.**
+6. **Implement the separate package's deterministic archive authority.**
+7. **Add release notes, rehearsal, and hosted-CI regressions.**
+8. **Run a synthetic source-version release context before actual publication.**
 
 Each stage should preserve current-track release bytes and behavior.
 

--- a/reports/sosa-release-package-scope-decision.md
+++ b/reports/sosa-release-package-scope-decision.md
@@ -1,0 +1,120 @@
+# SOSA Formal Package-Scope Decision
+
+## Decision
+
+The approved SOSA source-version track will be published as a separate formal
+release package rather than combined with the current SSN/SOSA formal package.
+
+The package contains exactly three ontology products, in this canonical order:
+
+1. alignment core;
+2. BFO mapping;
+3. CCO extension.
+
+No integrated ontology and no BFO-projection product are approved for this
+formal source-version package.
+
+The canonical machine product keys are:
+
+1. `alignment_core`;
+2. `strict_bfo_mapping`;
+3. `cco_extension`.
+
+`BFO mapping` remains the human-facing product name; `strict_bfo_mapping` is
+the canonical machine key already used by the maintained SOSA-next generator
+and the existing formal manifest vocabulary.
+
+The machine-readable authority for this decision is:
+
+`config/sosa-release-scope.toml`
+
+## Source-version track
+
+The package scope applies to the approved source identity:
+
+`sosa-2023-af425a0454ec00512a5ebfa2873fe35a077f5fda`
+
+The temporary `sosa-next` component remains the development alias. Future
+formal package paths and stable track-specific ontology IRIs must use the
+approved source identity rather than the development alias.
+
+## Rationale
+
+The current formal-release machinery is an exact contract for the existing
+SSN/SOSA track. It defines and validates:
+
+- exactly five formal products;
+- a fixed five-product manifest order;
+- exactly five product-specific HermiT results;
+- exactly 13 package files;
+- exactly 17 archive members;
+- a package catalog for exactly five same-release product IRIs;
+- the `current-ssn-sosa/` package directory;
+- release-note requirements that include the current BFO-projection notice;
+- rehearsal fixtures that require `current-ssn-sosa`, `evidence`, and `sources`.
+
+The schema-1 manifest regression suite explicitly rejects a sixth product.
+
+Combining the new three-product source-version track with that package would
+therefore require changing the semantics of the existing formal package
+authority, not merely adding a parallel release track.
+
+A separate package preserves the current package contract exactly while
+allowing the source-version package to define its own:
+
+- three-product publication metadata;
+- manifest/schema authority;
+- package-relative catalog;
+- evidence inventory;
+- archive member inventory;
+- release notes;
+- deterministic rehearsal.
+
+## Current-track preservation rule
+
+The existing current SSN/SOSA formal-release machinery remains unchanged.
+
+The source-version package must be implemented through separate track-specific
+authorities or explicit generalized infrastructure whose current-track behavior
+and bytes remain exactly preserved.
+
+No source-version product may be inserted into the existing five-product
+current package inventory.
+
+## Formal product inventory
+
+The formal source-version package inherits the maintained three-product
+partition:
+
+| Product | Formal package status |
+| --- | --- |
+| Alignment core | included |
+| BFO mapping | included |
+| CCO extension | included |
+| Integrated ontology | excluded |
+| BFO projection | excluded |
+
+An additional ontology product requires a separate governance decision before
+it can enter the formal package contract.
+
+## Consequence for future implementation
+
+The next formal-release milestone is to define track-specific publication
+metadata and formal rendering for the separate source-version package.
+
+That work must use the approved source identity as the formal track component
+and must not modify the current five-product publication metadata or package
+contract merely to accommodate the new package.
+
+## Non-goals
+
+This decision does not:
+
+- build the source-version formal package;
+- modify current formal-release metadata;
+- modify the current manifest schema or Python manifest model;
+- modify current package construction or validation;
+- modify current archive construction or validation;
+- modify current release rehearsal;
+- rename maintained `sosa-next` development artifacts;
+- publish a release, tag, archive, or persistent-IRI deployment.

--- a/src/sosa-next/docs/README.md
+++ b/src/sosa-next/docs/README.md
@@ -65,6 +65,7 @@ Run:
 
 ```bash
 make check-sosa-source-version
+make check-sosa-release-scope
 make check-sosa-next
 make check-sosa-next-products
 make check-sosa-next-consumer-stack
@@ -98,14 +99,18 @@ The consumer-stack checker enforces:
 
 ## Formal-release status
 
-These products are not part of the current formal release package. Current
-release metadata, manifest, package, archive, and rehearsal tooling remains
-specific to the current five-product SSN/SOSA track. Future formal integration
-must replace the `sosa-next` development alias with `sosa-2023-af425a0454ec00512a5ebfa2873fe35a077f5fda` in
-formal track-specific paths and ontology IRIs.
+These products are not part of the current formal release package. Their formal
+publication model is approved as a separate three-product package containing
+alignment core, BFO mapping, and CCO extension. Current release metadata,
+manifest, package, archive, and rehearsal tooling remains specific to the current
+five-product SSN/SOSA track and remains unchanged. Future formal integration must
+replace the `sosa-next` development alias with
+`sosa-2023-af425a0454ec00512a5ebfa2873fe35a077f5fda` in source-version formal
+paths and ontology IRIs.
 
 See:
 
 - `reports/sosa-source-version-identity-decision.md`
+- `reports/sosa-release-package-scope-decision.md`
 - `reports/sosa-next-product-contract.md`
 - `reports/sosa-next-formal-release-integration-audit.md`

--- a/tests/test_sosa_release_scope.py
+++ b/tests/test_sosa_release_scope.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python3
+"""Focused tests for the SOSA formal-package scope authority."""
+
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+import sys
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT / "tools"))
+
+import check_sosa_release_scope as checker  # noqa: E402
+import sosa_release_scope as release_scope  # noqa: E402
+import sosa_source_version as source_version  # noqa: E402
+
+
+class SosaReleaseScopeTests(unittest.TestCase):
+    def test_approved_scope_is_separate_three_product_package(
+        self,
+    ) -> None:
+        scope = release_scope.load_release_scope()
+        source = source_version.load_source_version_authority()
+
+        self.assertEqual(scope.schema_version, 1)
+        self.assertEqual(scope.status, "approved")
+        self.assertEqual(
+            scope.source_identity,
+            source.source_identity,
+        )
+        self.assertEqual(
+            scope.development_alias,
+            "sosa-next",
+        )
+        self.assertEqual(
+            scope.publication_model,
+            "separate_package",
+        )
+        self.assertEqual(
+            scope.formal_track_component,
+            source.source_identity,
+        )
+        self.assertEqual(
+            scope.product_order,
+            (
+                "alignment_core",
+                "strict_bfo_mapping",
+                "cco_extension",
+            ),
+        )
+        self.assertFalse(scope.integrated_product)
+        self.assertFalse(scope.bfo_projection_product)
+        self.assertEqual(
+            scope.current_track_formal_release,
+            "unchanged",
+        )
+
+    def test_checker_reports_approved_scope(self) -> None:
+        summary = checker.run_check()
+
+        self.assertTrue(summary["passed"])
+        self.assertEqual(
+            summary["publication_model"],
+            "separate_package",
+        )
+        self.assertEqual(
+            summary["product_order"],
+            (
+                "alignment_core",
+                "strict_bfo_mapping",
+                "cco_extension",
+            ),
+        )
+
+    def test_combined_package_is_rejected(self) -> None:
+        original = release_scope.CONFIG_PATH.read_text(
+            encoding="utf-8"
+        )
+        altered = original.replace(
+            'publication_model = "separate_package"',
+            'publication_model = "combined_package"',
+            1,
+        )
+        self.assertNotEqual(original, altered)
+
+        with tempfile.TemporaryDirectory(
+            prefix="sosa-release-scope-test-"
+        ) as directory:
+            config_path = Path(directory) / "scope.toml"
+            config_path.write_text(altered, encoding="utf-8")
+
+            with self.assertRaisesRegex(
+                RuntimeError,
+                "approved model",
+            ):
+                release_scope.load_release_scope(config_path)
+
+    def test_public_label_key_is_rejected(self) -> None:
+        original = release_scope.CONFIG_PATH.read_text(
+            encoding="utf-8"
+        )
+        altered = original.replace(
+            '"strict_bfo_mapping"',
+            '"bfo_mapping"',
+            1,
+        )
+        self.assertNotEqual(original, altered)
+
+        with tempfile.TemporaryDirectory(
+            prefix="sosa-release-scope-test-"
+        ) as directory:
+            config_path = Path(directory) / "scope.toml"
+            config_path.write_text(altered, encoding="utf-8")
+
+            with self.assertRaisesRegex(
+                RuntimeError,
+                "approved order",
+            ):
+                release_scope.load_release_scope(config_path)
+
+    def test_extra_formal_product_is_rejected(self) -> None:
+        original = release_scope.CONFIG_PATH.read_text(
+            encoding="utf-8"
+        )
+        altered = original.replace(
+            'product_order = ["alignment_core", "strict_bfo_mapping", "cco_extension"]',
+            'product_order = ["alignment_core", "strict_bfo_mapping", "cco_extension", "integrated"]',
+            1,
+        )
+        self.assertNotEqual(original, altered)
+
+        with tempfile.TemporaryDirectory(
+            prefix="sosa-release-scope-test-"
+        ) as directory:
+            config_path = Path(directory) / "scope.toml"
+            config_path.write_text(altered, encoding="utf-8")
+
+            with self.assertRaisesRegex(
+                RuntimeError,
+                "approved order",
+            ):
+                release_scope.load_release_scope(config_path)
+
+    def test_source_identity_mismatch_is_rejected(self) -> None:
+        original = release_scope.CONFIG_PATH.read_text(
+            encoding="utf-8"
+        )
+        altered = original.replace(
+            'source_identity = "sosa-2023-',
+            'source_identity = "wrong-',
+            1,
+        )
+        self.assertNotEqual(original, altered)
+
+        with tempfile.TemporaryDirectory(
+            prefix="sosa-release-scope-test-"
+        ) as directory:
+            config_path = Path(directory) / "scope.toml"
+            config_path.write_text(altered, encoding="utf-8")
+
+            with self.assertRaisesRegex(
+                RuntimeError,
+                "must equal the approved SOSA source-version identity",
+            ):
+                release_scope.load_release_scope(config_path)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/check_sosa_release_scope.py
+++ b/tools/check_sosa_release_scope.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""Validate the approved SOSA formal-package scope authority."""
+
+from __future__ import annotations
+
+import sosa_release_scope
+
+
+def run_check() -> dict[str, object]:
+    scope = sosa_release_scope.load_release_scope()
+
+    return {
+        "schema_version": scope.schema_version,
+        "status": scope.status,
+        "source_identity": scope.source_identity,
+        "development_alias": scope.development_alias,
+        "publication_model": scope.publication_model,
+        "formal_track_component": scope.formal_track_component,
+        "product_order": scope.product_order,
+        "integrated_product": scope.integrated_product,
+        "bfo_projection_product": scope.bfo_projection_product,
+        "current_track_formal_release": (
+            scope.current_track_formal_release
+        ),
+        "passed": True,
+    }
+
+
+def main() -> int:
+    try:
+        summary = run_check()
+    except Exception as exc:
+        print(f"SOSA release-package scope: FAIL\n{exc}")
+        return 1
+
+    print(f"Status: {summary['status']}")
+    print(f"Source identity: {summary['source_identity']}")
+    print(f"Development alias: {summary['development_alias']}")
+    print(f"Publication model: {summary['publication_model']}")
+    print(
+        "Formal track component: "
+        f"{summary['formal_track_component']}"
+    )
+    print(
+        "Product order: "
+        + ", ".join(summary["product_order"])
+    )
+    print(
+        "Integrated product: "
+        f"{summary['integrated_product']}"
+    )
+    print(
+        "BFO projection product: "
+        f"{summary['bfo_projection_product']}"
+    )
+    print(
+        "Current-track formal release: "
+        f"{summary['current_track_formal_release']}"
+    )
+    print("Summary: PASS")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/run_validation_suite.py
+++ b/tools/run_validation_suite.py
@@ -408,6 +408,8 @@ def compile_check() -> StepResult:
             "tools/check_coms_mapping.py",
             "tools/sosa_source_version.py",
             "tools/check_sosa_source_version.py",
+            "tools/sosa_release_scope.py",
+            "tools/check_sosa_release_scope.py",
             "tools/check_sosa_next_mapping.py",
             "tools/generate_sosa_next_products.py",
             "tools/check_sosa_next_products.py",
@@ -422,6 +424,7 @@ def compile_check() -> StepResult:
             "tools/rehearse_release.py",
             "tests/test_generate_mapping_from_coms.py",
             "tests/test_sosa_source_version.py",
+            "tests/test_sosa_release_scope.py",
             "tests/test_check_sosa_next_mapping.py",
             "tests/test_sosa_next_products.py",
             "tests/test_sosa_next_consumer_stack.py",
@@ -523,6 +526,22 @@ def run_validation_suite(args: argparse.Namespace) -> int:
                     "tests",
                     "-p",
                     "test_sosa_source_version.py",
+                ],
+            )
+        )
+    if results[-1].passed:
+        results.append(
+            run_command(
+                "SOSA formal package-scope focused tests",
+                [
+                    sys.executable,
+                    "-m",
+                    "unittest",
+                    "discover",
+                    "-s",
+                    "tests",
+                    "-p",
+                    "test_sosa_release_scope.py",
                 ],
             )
         )
@@ -851,6 +870,16 @@ def run_validation_suite(args: argparse.Namespace) -> int:
                 [
                     sys.executable,
                     "tools/check_sosa_source_version.py",
+                ],
+            )
+        )
+    if results[-1].passed:
+        results.append(
+            run_command(
+                "SOSA formal package-scope check",
+                [
+                    sys.executable,
+                    "tools/check_sosa_release_scope.py",
                 ],
             )
         )

--- a/tools/sosa_release_scope.py
+++ b/tools/sosa_release_scope.py
@@ -1,0 +1,203 @@
+#!/usr/bin/env python3
+"""Load and validate the approved SOSA formal-package scope decision."""
+
+from __future__ import annotations
+
+import tomllib
+from dataclasses import dataclass
+from pathlib import Path
+
+import sosa_source_version
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+CONFIG_PATH = REPO_ROOT / "config/sosa-release-scope.toml"
+
+EXPECTED_PUBLICATION_MODEL = "separate_package"
+EXPECTED_PRODUCT_ORDER = (
+    "alignment_core",
+    "strict_bfo_mapping",
+    "cco_extension",
+)
+EXPECTED_CURRENT_TRACK_POLICY = "unchanged"
+
+
+@dataclass(frozen=True)
+class SosaReleaseScope:
+    schema_version: int
+    status: str
+    source_identity: str
+    development_alias: str
+    publication_model: str
+    formal_track_component: str
+    product_order: tuple[str, ...]
+    integrated_product: bool
+    bfo_projection_product: bool
+    current_track_formal_release: str
+
+
+def _require_exact_keys(
+    value: dict[str, object],
+    expected: set[str],
+    label: str,
+) -> None:
+    actual = set(value)
+    if actual != expected:
+        missing = sorted(expected - actual)
+        extra = sorted(actual - expected)
+        raise RuntimeError(
+            f"{label}: noncanonical keys; missing={missing}; extra={extra}"
+        )
+
+
+def _require_string(value: object, label: str) -> str:
+    if not isinstance(value, str) or not value:
+        raise RuntimeError(f"{label}: expected nonempty string")
+    return value
+
+
+def _require_boolean(value: object, label: str) -> bool:
+    if not isinstance(value, bool):
+        raise RuntimeError(f"{label}: expected boolean")
+    return value
+
+
+def load_release_scope(
+    config_path: Path = CONFIG_PATH,
+) -> SosaReleaseScope:
+    with config_path.open("rb") as handle:
+        document = tomllib.load(handle)
+
+    _require_exact_keys(
+        document,
+        {
+            "schema_version",
+            "status",
+            "source_identity",
+            "development_alias",
+            "publication_model",
+            "formal_track_component",
+            "product_order",
+            "integrated_product",
+            "bfo_projection_product",
+            "current_track_formal_release",
+        },
+        "document",
+    )
+
+    schema_version = document["schema_version"]
+    if isinstance(schema_version, bool) or schema_version != 1:
+        raise RuntimeError(
+            f"schema_version: expected integer 1, got {schema_version!r}"
+        )
+
+    status = _require_string(document["status"], "status")
+    if status != "approved":
+        raise RuntimeError(
+            f"status: expected 'approved', got {status!r}"
+        )
+
+    source_authority = (
+        sosa_source_version.load_source_version_authority()
+    )
+
+    source_identity = _require_string(
+        document["source_identity"],
+        "source_identity",
+    )
+    if source_identity != source_authority.source_identity:
+        raise RuntimeError(
+            "source_identity: must equal the approved SOSA source-version "
+            f"identity {source_authority.source_identity!r}"
+        )
+
+    development_alias = _require_string(
+        document["development_alias"],
+        "development_alias",
+    )
+    if development_alias != source_authority.development_alias:
+        raise RuntimeError(
+            "development_alias: must equal the source-version authority"
+        )
+
+    publication_model = _require_string(
+        document["publication_model"],
+        "publication_model",
+    )
+    if publication_model != EXPECTED_PUBLICATION_MODEL:
+        raise RuntimeError(
+            "publication_model: approved model is "
+            f"{EXPECTED_PUBLICATION_MODEL!r}"
+        )
+
+    formal_track_component = _require_string(
+        document["formal_track_component"],
+        "formal_track_component",
+    )
+    if formal_track_component != source_identity:
+        raise RuntimeError(
+            "formal_track_component: must equal the approved source identity"
+        )
+
+    raw_product_order = document["product_order"]
+    if not isinstance(raw_product_order, list):
+        raise RuntimeError("product_order: expected array")
+
+    if not all(
+        isinstance(value, str) and value
+        for value in raw_product_order
+    ):
+        raise RuntimeError(
+            "product_order: expected nonempty product strings"
+        )
+
+    product_order = tuple(raw_product_order)
+    if product_order != EXPECTED_PRODUCT_ORDER:
+        raise RuntimeError(
+            "product_order: approved order is "
+            f"{EXPECTED_PRODUCT_ORDER!r}"
+        )
+
+    if len(set(product_order)) != len(product_order):
+        raise RuntimeError("product_order: duplicate product key")
+
+    integrated_product = _require_boolean(
+        document["integrated_product"],
+        "integrated_product",
+    )
+    if integrated_product:
+        raise RuntimeError(
+            "integrated_product: not approved for the formal source-version package"
+        )
+
+    bfo_projection_product = _require_boolean(
+        document["bfo_projection_product"],
+        "bfo_projection_product",
+    )
+    if bfo_projection_product:
+        raise RuntimeError(
+            "bfo_projection_product: not approved for the formal source-version package"
+        )
+
+    current_track_formal_release = _require_string(
+        document["current_track_formal_release"],
+        "current_track_formal_release",
+    )
+    if current_track_formal_release != EXPECTED_CURRENT_TRACK_POLICY:
+        raise RuntimeError(
+            "current_track_formal_release: current formal package contract "
+            "must remain unchanged"
+        )
+
+    return SosaReleaseScope(
+        schema_version=1,
+        status=status,
+        source_identity=source_identity,
+        development_alias=development_alias,
+        publication_model=publication_model,
+        formal_track_component=formal_track_component,
+        product_order=product_order,
+        integrated_product=integrated_product,
+        bfo_projection_product=bfo_projection_product,
+        current_track_formal_release=current_track_formal_release,
+    )


### PR DESCRIPTION
## Summary

- approves a separate formal release package for the governed SOSA source-version track;
- binds that package to source identity
  `sosa-2023-af425a0454ec00512a5ebfa2873fe35a077f5fda`;
- fixes the canonical formal product order as:
  `alignment_core`, `strict_bfo_mapping`, `cco_extension`;
- excludes an integrated ontology and BFO-projection product;
- preserves the current five-product SSN/SOSA formal release contract unchanged;
- adds machine-readable package-scope authority and focused validation;
- updates the formal-release integration audit and active documentation.

## Rationale

The existing formal package is intentionally exact:

- five formal products;
- fixed five-product manifest order;
- five product-specific HermiT results;
- 13 package files;
- 17 archive members;
- a current-track package-relative catalog;
- `current-ssn-sosa/` package structure.

The schema-1 manifest regression suite explicitly rejects a sixth product.

A separate source-version package therefore preserves the existing formal
contract rather than redefining it as a combined multi-track package.

## Product naming

`BFO mapping` remains the human-facing product name.

`strict_bfo_mapping` is the canonical machine key, matching both the maintained
SOSA-next generator and the existing formal manifest vocabulary.

## Validation

- complete `make check`: PASS;
- SOSA source-version authority: PASS;
- SOSA formal package-scope focused tests: PASS;
- SOSA formal package-scope checker: PASS;
- SOSA-next maintained-product validation: PASS;
- SOSA-next consumer-stack validation: PASS;
- current-SOSA protected hashes unchanged;
- maintained SOSA-next product hashes unchanged;
- pinned SOSA source/overlay hashes unchanged;
- SOSA-next workbook unchanged;
- existing formal-release machinery unchanged;
- `git diff --check`: PASS.

## Scope boundaries

This PR does not:

- build a formal source-version release package;
- modify current publication metadata;
- modify the current manifest schema or manifest model;
- modify current package, archive, or rehearsal machinery;
- change maintained SOSA-next product bytes;
- change the governed SOSA-next workbook;
- change pinned W3C source bytes;
- rename `sosa-next` development artifacts;
- publish a release, archive, tag, or persistent-IRI deployment.

The next formal-release milestone is track-specific publication metadata and
formal rendering for the separate source-version package.
