### PR TITLE
Govern product-role materialization

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: validate validate-write audit-write legacy-audit-write compile check check-coms check-sosa-next check-coms-row-identities check-coms-product-dispositions check-alignment-core check-strict-bfo-mapping check-cco-extension check-bfo-projection check-publication-metadata check-release-rendering check-release-package check-release-archive check-release-rehearsal check-placeholder-catalog-migration watch-coms coms-status post-merge-check status diffstat generate-sosa-next-products check-sosa-next-products check-sosa-next-consumer-stack check-sosa-source-version check-sosa-release-scope
+.PHONY: validate validate-write audit-write legacy-audit-write compile check check-coms check-sosa-next check-coms-row-identities check-coms-product-dispositions check-alignment-core check-strict-bfo-mapping check-cco-extension check-bfo-projection check-publication-metadata check-release-rendering check-release-package check-release-archive check-release-rehearsal check-placeholder-catalog-migration watch-coms coms-status post-merge-check status diffstat generate-sosa-next-products check-sosa-next-products check-sosa-next-consumer-stack check-sosa-source-version check-product-role-policy check-sosa-release-scope
 
 validate:
 	PYTHONDONTWRITEBYTECODE=1 python tools/run_validation_suite.py
@@ -36,6 +36,8 @@ compile:
 		tools/check_coms_mapping.py \
 		tools/sosa_source_version.py \
 		tools/check_sosa_source_version.py \
+		tools/product_role_policy.py \
+		tools/check_product_role_policy.py \
 		tools/sosa_release_scope.py \
 		tools/check_sosa_release_scope.py \
 		tools/check_sosa_next_mapping.py \
@@ -52,6 +54,7 @@ compile:
 		tools/rehearse_release.py \
 		tests/test_generate_mapping_from_coms.py \
 		tests/test_sosa_source_version.py \
+		tests/test_product_role_policy.py \
 		tests/test_sosa_release_scope.py \
 		tests/test_check_sosa_next_mapping.py \
 		tests/test_sosa_next_products.py \
@@ -107,7 +110,11 @@ check-sosa-source-version:
 	PYTHONDONTWRITEBYTECODE=1 python -m unittest discover -s tests -p 'test_sosa_source_version.py'
 	PYTHONDONTWRITEBYTECODE=1 python tools/check_sosa_source_version.py
 
-check-sosa-release-scope: check-sosa-source-version
+check-product-role-policy: check-sosa-source-version
+	PYTHONDONTWRITEBYTECODE=1 python -m unittest discover -s tests -p 'test_product_role_policy.py'
+	PYTHONDONTWRITEBYTECODE=1 python tools/check_product_role_policy.py
+
+check-sosa-release-scope: check-product-role-policy
 	PYTHONDONTWRITEBYTECODE=1 python -m unittest discover -s tests -p 'test_sosa_release_scope.py'
 	PYTHONDONTWRITEBYTECODE=1 python tools/check_sosa_release_scope.py
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,11 @@ For reproducible use, prefer the tagged release assets rather than files from an
 | Alignment core | `releases/current-ssn-sosa/ssn-sosa-alignment-core.ttl` | You want the target-neutral SSN/SOSA alignment layer |
 | BFO projection | `releases/current-ssn-sosa/ssn-sosa-bfo-projection.ttl` | You need the designated projection layer; it currently adds no direct mapping axioms |
 
+The current BFO Projection remains a maintained development artifact pending
+the product-role migration, but because it currently contributes no direct
+weakened projection axiom it is not targeted for the next official formal
+release.
+
 See [Product Architecture](docs/PRODUCT-ARCHITECTURE.md) for the relationships among these products.
 
 ## SOSA-next maintained development products
@@ -59,15 +64,17 @@ obtains the other project modules transitively. External SOSA, BFO, and CCO
 dependencies remain separate consumer or validation inputs.
 
 These files are maintained authoritative development artifacts, but they are
-not part of the current formal release. `sosa-next` remains the development
-alias in the current paths and ontology IRIs. Future formal-release integration
-must replace that alias with `sosa-2023-af425a0454ec00512a5ebfa2873fe35a077f5fda` in formal track-specific
-paths and ontology IRIs.
+not yet the final formal product inventory. Under the uniform product-role
+policy, the formal SOSA-2023 target is Integrated, BFO Mapping, and CCO
+Extension. The current zero-axiom Alignment Core is scheduled for retirement
+from that track, while BFO Projection remains omitted until a weakened
+consequence is approved. `sosa-next` remains only the development alias.
 
 Focused development validation:
 
 ```bash
 make check-sosa-source-version
+make check-product-role-policy
 make check-sosa-release-scope
 make check-sosa-next
 make check-sosa-next-products

--- a/config/product-role-policy.toml
+++ b/config/product-role-policy.toml
@@ -1,0 +1,37 @@
+schema_version = 1
+status = "approved"
+role_order = ["integrated", "alignment_core", "strict_bfo_mapping", "bfo_projection", "cco_extension"]
+materialization_rule = "direct_logical_content_or_distinct_consumer_function"
+empty_role_boundary_is_sufficient = false
+
+[roles.integrated]
+human_label = "Integrated"
+inclusion_basis = "distinct_consumer_function"
+
+[roles.alignment_core]
+human_label = "Alignment Core"
+inclusion_basis = "direct_product_specific_logical_content"
+
+[roles.strict_bfo_mapping]
+human_label = "BFO Mapping"
+inclusion_basis = "direct_product_specific_logical_content"
+
+[roles.bfo_projection]
+human_label = "BFO Projection"
+inclusion_basis = "direct_product_specific_logical_content"
+
+[roles.cco_extension]
+human_label = "CCO Extension"
+inclusion_basis = "direct_product_specific_logical_content"
+
+[[tracks]]
+track_key = "current-ssn-sosa"
+formal_product_order = ["integrated", "alignment_core", "strict_bfo_mapping", "cco_extension"]
+omitted_product_roles = ["bfo_projection"]
+role_status = { integrated = "materialize_consumer_function", alignment_core = "materialize_direct_content", strict_bfo_mapping = "materialize_direct_content", bfo_projection = "omit_no_substantive_content_or_distinct_function", cco_extension = "materialize_direct_content" }
+
+[[tracks]]
+track_key = "sosa-2023-af425a0454ec00512a5ebfa2873fe35a077f5fda"
+formal_product_order = ["integrated", "strict_bfo_mapping", "cco_extension"]
+omitted_product_roles = ["alignment_core", "bfo_projection"]
+role_status = { integrated = "materialize_consumer_function", alignment_core = "omit_no_substantive_content_or_distinct_function", strict_bfo_mapping = "materialize_direct_content", bfo_projection = "omit_no_substantive_content_or_distinct_function", cco_extension = "materialize_direct_content" }

--- a/config/sosa-release-scope.toml
+++ b/config/sosa-release-scope.toml
@@ -1,10 +1,10 @@
-schema_version = 1
+schema_version = 2
 status = "approved"
 source_identity = "sosa-2023-af425a0454ec00512a5ebfa2873fe35a077f5fda"
 development_alias = "sosa-next"
 publication_model = "separate_package"
 formal_track_component = "sosa-2023-af425a0454ec00512a5ebfa2873fe35a077f5fda"
-product_order = ["alignment_core", "strict_bfo_mapping", "cco_extension"]
-integrated_product = false
-bfo_projection_product = false
-current_track_formal_release = "unchanged"
+product_role_policy = "config/product-role-policy.toml"
+formal_product_order = ["integrated", "strict_bfo_mapping", "cco_extension"]
+omitted_product_roles = ["alignment_core", "bfo_projection"]
+current_track_formal_release = "pending_product_role_policy_migration"

--- a/docs/PRODUCT-ARCHITECTURE.md
+++ b/docs/PRODUCT-ARCHITECTURE.md
@@ -202,14 +202,21 @@ make check-sosa-next-products
 make check-sosa-next-consumer-stack
 ```
 
-The SOSA-next products are not yet formal-release products. Current release
-metadata, manifest, package, archive, and rehearsal tooling remain authoritative
-only for the five-product current SSN/SOSA track. The source identity is resolved
-as `sosa-2023-af425a0454ec00512a5ebfa2873fe35a077f5fda`, and the formal package
-scope is resolved as a separate three-product package containing alignment core,
-BFO mapping, and CCO extension. The current five-product formal package remains
-unchanged. Future formal integration must replace the `sosa-next` development
-alias with the approved identity in source-version formal paths and ontology IRIs.
+The maintained SOSA-next development products have not yet been migrated to
+the uniform product-role policy. All mapping tracks use the same five product
+roles, but a role is materialized only for direct product-specific logical
+content or a distinct consumer function.
+
+The current-track formal target is Integrated, Alignment Core, BFO Mapping,
+and CCO Extension; its import-only BFO Projection is pending retirement before
+the next official release.
+
+The SOSA-2023 formal target is Integrated, BFO Mapping, and CCO Extension. Its
+current zero-direct-axiom Alignment Core is scheduled for retirement, and BFO
+Projection remains omitted until a weakened consequence is approved. The
+source-version track remains a separate package and uses
+`sosa-2023-af425a0454ec00512a5ebfa2873fe35a077f5fda` as its formal track
+identity.
 
 The earlier `reports/publication-product-and-import-policy.md` records the
 pre-activation lifecycle policy. For the implemented SOSA-next development

--- a/docs/VALIDATION-AND-RELEASES.md
+++ b/docs/VALIDATION-AND-RELEASES.md
@@ -86,6 +86,7 @@ focused gates:
 
 ```bash
 make check-sosa-source-version
+make check-product-role-policy
 make check-sosa-release-scope
 make check-sosa-next
 make check-sosa-next-products
@@ -97,11 +98,15 @@ identity, exact source and overlay hashes, root SOSA edition version IRI, and
 overlay binding to the approved full upstream commit. It performs no network
 resolution.
 
-`make check-sosa-release-scope` validates that the approved formal publication
-model is a separate package with exactly three ontology products in canonical
-order, excludes integrated and BFO-projection products, uses the approved source
-identity as the formal track component, and preserves the current formal package
-contract unchanged.
+`make check-product-role-policy` validates the uniform five-role product
+taxonomy and the rule that a role is materialized only for direct logical
+content or a distinct consumer function.
+
+`make check-sosa-release-scope` validates that the approved publication model
+remains a separate source-version package, that its formal target inventory is
+derived from the product-role policy, and that the current formal package is
+marked pending migration to the same role policy before its next official
+release.
 
 `make check-sosa-next` depends on the source-version gate and validates the 119
 governed workbook rows, 45 active

--- a/reports/product-role-inclusion-policy.md
+++ b/reports/product-role-inclusion-policy.md
@@ -1,0 +1,141 @@
+# Product-Role Inclusion Policy
+
+## Decision
+
+Every governed SSN-to-BFO mapping track uses the same five product roles:
+
+1. Integrated;
+2. Alignment Core;
+3. BFO Mapping;
+4. BFO Projection;
+5. CCO Extension.
+
+Uniformity applies to the role taxonomy and inclusion criteria, not to the
+number of ontology files materialized for every track.
+
+A role is materialized only when it has either:
+
+1. direct product-specific logical content; or
+2. a distinct documented consumer function that is not supplied merely by
+   loading another materialized product.
+
+An empty ontology used only to reserve an import boundary, namespace, future
+slot, or visually uniform architecture does not satisfy the inclusion rule.
+
+The machine-readable authority is:
+
+`config/product-role-policy.toml`
+
+## Role criteria
+
+### Integrated
+
+Integrated may be materialized when it provides a distinct complete consumer
+entry point, including the governed dependency-loading behavior of the track.
+
+Its justification is therefore consumer function rather than mere duplication
+of the modular logical union.
+
+### Alignment Core
+
+Alignment Core is materialized only when the track contains direct
+target-neutral alignment axioms assigned to that role.
+
+A zero-direct-axiom alignment shell is not sufficient.
+
+### BFO Mapping
+
+BFO Mapping is materialized when the track contains direct governed BFO-bearing
+mapping axioms assigned to that role.
+
+The canonical machine key remains `strict_bfo_mapping`.
+
+### BFO Projection
+
+BFO Projection is materialized only when at least one approved weakened but
+sound BFO consequence is assigned directly to that role.
+
+Importing the strict BFO mapping without adding a projection consequence does
+not provide a distinct consumer function and is not sufficient for formal
+publication.
+
+### CCO Extension
+
+CCO Extension is materialized when the track contains direct governed
+CCO-bearing or mixed BFO/CCO axioms assigned to that role.
+
+## Current SSN/SOSA target inventory
+
+The next official current-track release targets:
+
+1. Integrated;
+2. Alignment Core;
+3. BFO Mapping;
+4. CCO Extension.
+
+BFO Projection is omitted because no direct weakened projection axiom is
+currently approved and its import-only closure is already supplied by the
+strict BFO mapping.
+
+The existing maintained import-only BFO-projection artifact remains in the
+repository until a separate implementation migration removes it from current
+generation and formal-release machinery. This policy changes publication
+intent before changing maintained bytes.
+
+## SOSA 2023 source-version target inventory
+
+For
+`sosa-2023-af425a0454ec00512a5ebfa2873fe35a077f5fda`,
+the formal target inventory is:
+
+1. Integrated;
+2. BFO Mapping;
+3. CCO Extension.
+
+Alignment Core is omitted because the current governed mapping contains no
+direct target-neutral alignment axiom.
+
+BFO Projection is omitted because no weakened BFO consequence is approved.
+
+Integrated is included because it is intended to provide the distinct complete
+consumer entry point for the source-version track, including governed source
+and target dependency loading. The exact implementation and formal rendering
+of that entry point remains a later milestone.
+
+The currently maintained three-product development set is not changed by this
+policy-only milestone. Its empty Alignment Core remains temporarily until the
+subsequent generation migration.
+
+## Relationship to prior decisions
+
+This policy supersedes only the product-inventory portions of:
+
+- `reports/publication-product-and-import-policy.md`; and
+- `reports/sosa-release-package-scope-decision.md`.
+
+It does not supersede:
+
+- the COMS mapping authorities;
+- strict-versus-weakened mapping semantics;
+- the approved SOSA source identity;
+- the decision to keep the SOSA source-version track in a separate package;
+- the use of `strict_bfo_mapping` as the canonical machine key.
+
+## Migration rule
+
+Governance is changed before implementation.
+
+A subsequent implementation milestone must:
+
+- remove the current import-only BFO Projection from formal publication
+  metadata, manifest/schema inventories, package/catalog/archive inventories,
+  reasoning-result inventories, release notes, and maintained generation if no
+  development-only reason remains;
+- add a SOSA-2023 Integrated product with a distinct complete-consumer role;
+- retire the zero-direct-axiom SOSA-2023 Alignment Core and remove the
+  BFO-mapping import edge to it;
+- update the SOSA-2023 editor/catalog consumer stack accordingly;
+- preserve all governed mapping axioms and mapping dispositions;
+- prove byte changes are exactly those required by the product-role migration.
+
+No ontology-product bytes are changed by this policy milestone itself.

--- a/reports/sosa-next-formal-release-integration-audit.md
+++ b/reports/sosa-next-formal-release-integration-audit.md
@@ -88,24 +88,28 @@ SSN/SOSA track:
 The SOSA-next development products must not be inserted into those fixed
 inventories piecemeal.
 
-## Resolved package-scope decision
+## Resolved package boundary and superseded fixed inventory
 
 The track identity is resolved as
 `sosa-2023-af425a0454ec00512a5ebfa2873fe35a077f5fda`.
 
-The package scope is also resolved:
+The source-version track remains a separate formal package.
 
-- the source-version track is published as a separate formal package;
-- its formal ontology-product order is alignment core, BFO mapping, then CCO
-  extension;
-- no integrated ontology is included;
-- no BFO-projection product is included;
-- the current five-product SSN/SOSA formal package contract remains unchanged.
+The earlier fixed three-product inventory is superseded by the uniform
+product-role policy in `config/product-role-policy.toml`.
 
-`config/sosa-release-scope.toml` is the machine-readable authority and
-`reports/sosa-release-package-scope-decision.md` records the rationale.
+The current SOSA-2023 formal target is:
 
-Any additional formal ontology product requires a separate governance decision.
+- Integrated;
+- BFO Mapping;
+- CCO Extension.
+
+Alignment Core is omitted while it has no direct target-neutral axiom.
+BFO Projection is omitted while no weakened consequence is approved.
+
+The current five-product formal machinery is now pending migration to the same
+role policy before the next official current-track release; its import-only BFO
+Projection is not part of the target formal inventory.
 
 ### Publication metadata
 
@@ -202,7 +206,7 @@ The release-note template must describe:
 - active, deferred, and explicitly unmapped counts;
 - reasoning and catalog-consumption validation;
 - known limitations;
-- the absence of integrated and projection products;
+- the inclusion and omission rationale for every product role;
 - dependency and license scope;
 - deterministic reproduction commands.
 
@@ -240,7 +244,7 @@ A future implementation is ready only when:
 6. manifest, package, catalog, archive, and sidecar bytes are canonical;
 7. two isolated rehearsals produce byte-identical results;
 8. all product reasoning profiles have zero named unsatisfiable classes;
-9. current-track release behavior and bytes remain unchanged;
+9. current-track governed mapping content remains unchanged while its formal product inventory is migrated explicitly to the shared role policy;
 10. the formal package records the approved source-version authority and the
     release notes have been explicitly approved.
 

--- a/reports/sosa-next-product-contract.md
+++ b/reports/sosa-next-product-contract.md
@@ -181,6 +181,30 @@ A BFO projection may be introduced only through a separate policy change that:
 - maintains a separate product and import boundary;
 - adds exact reconstruction and reasoning tests.
 
+## Formal target under the uniform product-role policy
+
+The maintained development artifacts above remain unchanged until a dedicated
+generation migration is performed.
+
+For formal publication, the controlling repository-wide policy is
+`reports/product-role-inclusion-policy.md`.
+
+The current SOSA-2023 formal target inventory is:
+
+1. Integrated;
+2. BFO Mapping;
+3. CCO Extension.
+
+The maintained zero-direct-axiom Alignment Core is not justified as a formal
+product merely to preserve an import boundary and is scheduled for retirement
+during the implementation migration.
+
+BFO Projection remains absent because no weakened consequence is approved.
+
+Integrated is newly justified as the distinct complete consumer entry point;
+its exact dependency imports and deterministic rendering must be implemented
+and validated in the later product-generation milestone.
+
 ## Generation architecture
 
 The implementation uses the dedicated SOSA-next generation adapter:

--- a/reports/sosa-release-package-scope-decision.md
+++ b/reports/sosa-release-package-scope-decision.md
@@ -1,120 +1,88 @@
 # SOSA Formal Package-Scope Decision
 
-## Decision
+## Current status
 
-The approved SOSA source-version track will be published as a separate formal
-release package rather than combined with the current SSN/SOSA formal package.
+The package-boundary portion of this decision remains approved:
 
-The package contains exactly three ontology products, in this canonical order:
+The governed SOSA source-version track will be published as a separate formal
+package rather than inserted into the current SSN/SOSA package.
 
-1. alignment core;
-2. BFO mapping;
-3. CCO extension.
+The original fixed three-product inventory from this decision is superseded by:
 
-No integrated ontology and no BFO-projection product are approved for this
-formal source-version package.
+`reports/product-role-inclusion-policy.md`
 
-The canonical machine product keys are:
+and its machine-readable authority:
 
-1. `alignment_core`;
-2. `strict_bfo_mapping`;
-3. `cco_extension`.
-
-`BFO mapping` remains the human-facing product name; `strict_bfo_mapping` is
-the canonical machine key already used by the maintained SOSA-next generator
-and the existing formal manifest vocabulary.
-
-The machine-readable authority for this decision is:
-
-`config/sosa-release-scope.toml`
+`config/product-role-policy.toml`
 
 ## Source-version track
 
-The package scope applies to the approved source identity:
+The package applies to:
 
 `sosa-2023-af425a0454ec00512a5ebfa2873fe35a077f5fda`
 
-The temporary `sosa-next` component remains the development alias. Future
-formal package paths and stable track-specific ontology IRIs must use the
-approved source identity rather than the development alias.
+The temporary `sosa-next` component remains a development alias and must not
+become the formal track identity.
 
-## Rationale
+## Why the separate-package boundary remains
 
-The current formal-release machinery is an exact contract for the existing
-SSN/SOSA track. It defines and validates:
+The existing current-track release system was built around a single track.
+The SOSA source-version mapping has its own immutable upstream-source identity,
+mapping dispositions, product inventory, evidence, and eventual package
+catalog.
 
-- exactly five formal products;
-- a fixed five-product manifest order;
-- exactly five product-specific HermiT results;
-- exactly 13 package files;
-- exactly 17 archive members;
-- a package catalog for exactly five same-release product IRIs;
-- the `current-ssn-sosa/` package directory;
-- release-note requirements that include the current BFO-projection notice;
-- rehearsal fixtures that require `current-ssn-sosa`, `evidence`, and `sources`.
+Keeping the track in a separate package preserves explicit provenance and
+prevents one package manifest from conflating mappings against different source
+snapshots.
 
-The schema-1 manifest regression suite explicitly rejects a sixth product.
+The separate-package decision does not require every track to publish the same
+number of ontology products.
 
-Combining the new three-product source-version track with that package would
-therefore require changing the semantics of the existing formal package
-authority, not merely adding a parallel release track.
+## Superseded inventory decision
 
-A separate package preserves the current package contract exactly while
-allowing the source-version package to define its own:
+The earlier version of this decision required:
 
-- three-product publication metadata;
-- manifest/schema authority;
-- package-relative catalog;
-- evidence inventory;
-- archive member inventory;
-- release notes;
-- deterministic rehearsal.
+- Alignment Core;
+- BFO Mapping;
+- CCO Extension;
 
-## Current-track preservation rule
+and excluded Integrated and BFO Projection.
 
-The existing current SSN/SOSA formal-release machinery remains unchanged.
+That fixed inventory is superseded.
 
-The source-version package must be implemented through separate track-specific
-authorities or explicit generalized infrastructure whose current-track behavior
-and bytes remain exactly preserved.
+All tracks now use the uniform five-role taxonomy governed by
+`config/product-role-policy.toml`.
 
-No source-version product may be inserted into the existing five-product
-current package inventory.
+For the current SOSA source-version state, the formal target inventory is:
 
-## Formal product inventory
+1. Integrated;
+2. BFO Mapping;
+3. CCO Extension.
 
-The formal source-version package inherits the maintained three-product
-partition:
+Alignment Core is omitted while it has no direct target-neutral mapping axiom.
 
-| Product | Formal package status |
-| --- | --- |
-| Alignment core | included |
-| BFO mapping | included |
-| CCO extension | included |
-| Integrated ontology | excluded |
-| BFO projection | excluded |
+BFO Projection is omitted while it has no approved weakened BFO consequence.
 
-An additional ontology product requires a separate governance decision before
-it can enter the formal package contract.
+## Current-track consequence
 
-## Consequence for future implementation
+The earlier requirement that the current five-product formal package remain
+unchanged is also superseded.
 
-The next formal-release milestone is to define track-specific publication
-metadata and formal rendering for the separate source-version package.
+Before the next official current-track release, its formal inventory must be
+migrated to the uniform product-role policy. The current import-only BFO
+Projection is therefore not approved for that future formal package unless a
+direct weakened projection consequence is approved before release.
 
-That work must use the approved source identity as the formal track component
-and must not modify the current five-product publication metadata or package
-contract merely to accommodate the new package.
+This governance change does not itself alter current product bytes or formal
+release machinery.
 
-## Non-goals
+## Next implementation milestones
 
-This decision does not:
+Implementation should proceed separately:
 
-- build the source-version formal package;
-- modify current formal-release metadata;
-- modify the current manifest schema or Python manifest model;
-- modify current package construction or validation;
-- modify current archive construction or validation;
-- modify current release rehearsal;
-- rename maintained `sosa-next` development artifacts;
-- publish a release, tag, archive, or persistent-IRI deployment.
+1. migrate maintained/current formal machinery to the role policy;
+2. migrate the SOSA-2023 maintained product set;
+3. define source-version publication metadata and formal rendering;
+4. implement its separate manifest, package, catalog, archive, and rehearsal.
+
+No ontology bytes are changed by this decision record.

--- a/src/sosa-next/docs/README.md
+++ b/src/sosa-next/docs/README.md
@@ -65,6 +65,7 @@ Run:
 
 ```bash
 make check-sosa-source-version
+make check-product-role-policy
 make check-sosa-release-scope
 make check-sosa-next
 make check-sosa-next-products
@@ -99,14 +100,14 @@ The consumer-stack checker enforces:
 
 ## Formal-release status
 
-These products are not part of the current formal release package. Their formal
-publication model is approved as a separate three-product package containing
-alignment core, BFO mapping, and CCO extension. Current release metadata,
-manifest, package, archive, and rehearsal tooling remains specific to the current
-five-product SSN/SOSA track and remains unchanged. Future formal integration must
-replace the `sosa-next` development alias with
-`sosa-2023-af425a0454ec00512a5ebfa2873fe35a077f5fda` in source-version formal
-paths and ontology IRIs.
+These maintained development products have not yet been migrated to the
+uniform product-role policy. The formal SOSA-2023 target inventory is
+Integrated, BFO Mapping, and CCO Extension. The current zero-direct-axiom
+Alignment Core is temporary and is scheduled for retirement during the
+generation migration; BFO Projection remains omitted until a weakened
+consequence is approved. The source-version package remains separate, and
+formal paths and ontology IRIs must use the approved immutable source identity
+rather than the `sosa-next` development alias.
 
 See:
 

--- a/tests/test_product_role_policy.py
+++ b/tests/test_product_role_policy.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+"""Focused tests for the uniform ontology product-role policy."""
+
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+import sys
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT / "tools"))
+
+import product_role_policy as policy  # noqa: E402
+import sosa_source_version as source_version  # noqa: E402
+
+
+class ProductRolePolicyTests(unittest.TestCase):
+    def test_uniform_five_role_taxonomy(self) -> None:
+        value = policy.load_product_role_policy()
+
+        self.assertEqual(
+            value.role_order,
+            (
+                "integrated",
+                "alignment_core",
+                "strict_bfo_mapping",
+                "bfo_projection",
+                "cco_extension",
+            ),
+        )
+        self.assertFalse(value.empty_role_boundary_is_sufficient)
+
+    def test_current_track_target_inventory(self) -> None:
+        value = policy.load_product_role_policy()
+        track = value.track("current-ssn-sosa")
+
+        self.assertEqual(
+            track.formal_product_order,
+            (
+                "integrated",
+                "alignment_core",
+                "strict_bfo_mapping",
+                "cco_extension",
+            ),
+        )
+        self.assertEqual(
+            track.omitted_product_roles,
+            ("bfo_projection",),
+        )
+
+    def test_sosa_source_version_target_inventory(self) -> None:
+        value = policy.load_product_role_policy()
+        source = source_version.load_source_version_authority()
+        track = value.track(source.source_identity)
+
+        self.assertEqual(
+            track.formal_product_order,
+            (
+                "integrated",
+                "strict_bfo_mapping",
+                "cco_extension",
+            ),
+        )
+        self.assertEqual(
+            track.omitted_product_roles,
+            (
+                "alignment_core",
+                "bfo_projection",
+            ),
+        )
+
+    def test_empty_boundary_cannot_be_approved(self) -> None:
+        original = policy.CONFIG_PATH.read_text(encoding="utf-8")
+        altered = original.replace(
+            "empty_role_boundary_is_sufficient = false",
+            "empty_role_boundary_is_sufficient = true",
+            1,
+        )
+        self.assertNotEqual(original, altered)
+
+        with tempfile.TemporaryDirectory(
+            prefix="product-role-policy-test-"
+        ) as directory:
+            config_path = Path(directory) / "policy.toml"
+            config_path.write_text(altered, encoding="utf-8")
+
+            with self.assertRaisesRegex(
+                RuntimeError,
+                "empty role boundaries",
+            ):
+                policy.load_product_role_policy(config_path)
+
+    def test_materialized_order_must_follow_role_status(self) -> None:
+        original = policy.CONFIG_PATH.read_text(encoding="utf-8")
+        altered = original.replace(
+            'formal_product_order = ["integrated", "strict_bfo_mapping", "cco_extension"]',
+            'formal_product_order = ["integrated", "alignment_core", "strict_bfo_mapping", "cco_extension"]',
+            1,
+        )
+        self.assertNotEqual(original, altered)
+
+        with tempfile.TemporaryDirectory(
+            prefix="product-role-policy-test-"
+        ) as directory:
+            config_path = Path(directory) / "policy.toml"
+            config_path.write_text(altered, encoding="utf-8")
+
+            with self.assertRaisesRegex(
+                RuntimeError,
+                "does not match materialization statuses",
+            ):
+                policy.load_product_role_policy(config_path)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_sosa_release_scope.py
+++ b/tests/test_sosa_release_scope.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Focused tests for the SOSA formal-package scope authority."""
+"""Focused tests for the SOSA formal package-scope authority."""
 
 from __future__ import annotations
 
@@ -12,72 +12,66 @@ import sys
 REPO_ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(REPO_ROOT / "tools"))
 
-import check_sosa_release_scope as checker  # noqa: E402
-import sosa_release_scope as release_scope  # noqa: E402
+import sosa_release_scope as scope  # noqa: E402
 import sosa_source_version as source_version  # noqa: E402
 
 
 class SosaReleaseScopeTests(unittest.TestCase):
-    def test_approved_scope_is_separate_three_product_package(
-        self,
-    ) -> None:
-        scope = release_scope.load_release_scope()
+    def test_scope_uses_uniform_product_role_policy(self) -> None:
+        value = scope.load_release_scope()
         source = source_version.load_source_version_authority()
 
-        self.assertEqual(scope.schema_version, 1)
-        self.assertEqual(scope.status, "approved")
+        self.assertEqual(value.schema_version, 2)
+        self.assertEqual(value.status, "approved")
+        self.assertEqual(value.source_identity, source.source_identity)
+        self.assertEqual(value.publication_model, "separate_package")
         self.assertEqual(
-            scope.source_identity,
-            source.source_identity,
+            value.product_role_policy,
+            "config/product-role-policy.toml",
         )
         self.assertEqual(
-            scope.development_alias,
-            "sosa-next",
-        )
-        self.assertEqual(
-            scope.publication_model,
-            "separate_package",
-        )
-        self.assertEqual(
-            scope.formal_track_component,
-            source.source_identity,
-        )
-        self.assertEqual(
-            scope.product_order,
+            value.formal_product_order,
             (
-                "alignment_core",
+                "integrated",
                 "strict_bfo_mapping",
                 "cco_extension",
             ),
         )
-        self.assertFalse(scope.integrated_product)
-        self.assertFalse(scope.bfo_projection_product)
         self.assertEqual(
-            scope.current_track_formal_release,
-            "unchanged",
-        )
-
-    def test_checker_reports_approved_scope(self) -> None:
-        summary = checker.run_check()
-
-        self.assertTrue(summary["passed"])
-        self.assertEqual(
-            summary["publication_model"],
-            "separate_package",
-        )
-        self.assertEqual(
-            summary["product_order"],
+            value.omitted_product_roles,
             (
                 "alignment_core",
-                "strict_bfo_mapping",
-                "cco_extension",
+                "bfo_projection",
             ),
         )
-
-    def test_combined_package_is_rejected(self) -> None:
-        original = release_scope.CONFIG_PATH.read_text(
-            encoding="utf-8"
+        self.assertEqual(
+            value.current_track_formal_release,
+            "pending_product_role_policy_migration",
         )
+
+    def test_old_three_product_inventory_is_rejected(self) -> None:
+        original = scope.CONFIG_PATH.read_text(encoding="utf-8")
+        altered = original.replace(
+            'formal_product_order = ["integrated", "strict_bfo_mapping", "cco_extension"]',
+            'formal_product_order = ["alignment_core", "strict_bfo_mapping", "cco_extension"]',
+            1,
+        )
+        self.assertNotEqual(original, altered)
+
+        with tempfile.TemporaryDirectory(
+            prefix="sosa-release-scope-test-"
+        ) as directory:
+            config_path = Path(directory) / "scope.toml"
+            config_path.write_text(altered, encoding="utf-8")
+
+            with self.assertRaisesRegex(
+                RuntimeError,
+                "must equal product-role policy",
+            ):
+                scope.load_release_scope(config_path)
+
+    def test_combined_package_remains_rejected(self) -> None:
+        original = scope.CONFIG_PATH.read_text(encoding="utf-8")
         altered = original.replace(
             'publication_model = "separate_package"',
             'publication_model = "combined_package"',
@@ -93,78 +87,9 @@ class SosaReleaseScopeTests(unittest.TestCase):
 
             with self.assertRaisesRegex(
                 RuntimeError,
-                "approved model",
+                "separate package decision remains approved",
             ):
-                release_scope.load_release_scope(config_path)
-
-    def test_public_label_key_is_rejected(self) -> None:
-        original = release_scope.CONFIG_PATH.read_text(
-            encoding="utf-8"
-        )
-        altered = original.replace(
-            '"strict_bfo_mapping"',
-            '"bfo_mapping"',
-            1,
-        )
-        self.assertNotEqual(original, altered)
-
-        with tempfile.TemporaryDirectory(
-            prefix="sosa-release-scope-test-"
-        ) as directory:
-            config_path = Path(directory) / "scope.toml"
-            config_path.write_text(altered, encoding="utf-8")
-
-            with self.assertRaisesRegex(
-                RuntimeError,
-                "approved order",
-            ):
-                release_scope.load_release_scope(config_path)
-
-    def test_extra_formal_product_is_rejected(self) -> None:
-        original = release_scope.CONFIG_PATH.read_text(
-            encoding="utf-8"
-        )
-        altered = original.replace(
-            'product_order = ["alignment_core", "strict_bfo_mapping", "cco_extension"]',
-            'product_order = ["alignment_core", "strict_bfo_mapping", "cco_extension", "integrated"]',
-            1,
-        )
-        self.assertNotEqual(original, altered)
-
-        with tempfile.TemporaryDirectory(
-            prefix="sosa-release-scope-test-"
-        ) as directory:
-            config_path = Path(directory) / "scope.toml"
-            config_path.write_text(altered, encoding="utf-8")
-
-            with self.assertRaisesRegex(
-                RuntimeError,
-                "approved order",
-            ):
-                release_scope.load_release_scope(config_path)
-
-    def test_source_identity_mismatch_is_rejected(self) -> None:
-        original = release_scope.CONFIG_PATH.read_text(
-            encoding="utf-8"
-        )
-        altered = original.replace(
-            'source_identity = "sosa-2023-',
-            'source_identity = "wrong-',
-            1,
-        )
-        self.assertNotEqual(original, altered)
-
-        with tempfile.TemporaryDirectory(
-            prefix="sosa-release-scope-test-"
-        ) as directory:
-            config_path = Path(directory) / "scope.toml"
-            config_path.write_text(altered, encoding="utf-8")
-
-            with self.assertRaisesRegex(
-                RuntimeError,
-                "must equal the approved SOSA source-version identity",
-            ):
-                release_scope.load_release_scope(config_path)
+                scope.load_release_scope(config_path)
 
 
 if __name__ == "__main__":

--- a/tools/check_product_role_policy.py
+++ b/tools/check_product_role_policy.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+"""Validate the repository-wide product-role inclusion policy."""
+
+from __future__ import annotations
+
+import product_role_policy
+
+
+def run_check() -> dict[str, object]:
+    policy = product_role_policy.load_product_role_policy()
+
+    return {
+        "schema_version": policy.schema_version,
+        "status": policy.status,
+        "role_order": policy.role_order,
+        "materialization_rule": policy.materialization_rule,
+        "empty_role_boundary_is_sufficient": (
+            policy.empty_role_boundary_is_sufficient
+        ),
+        "tracks": {
+            track.track_key: {
+                "formal_product_order": track.formal_product_order,
+                "omitted_product_roles": track.omitted_product_roles,
+            }
+            for track in policy.tracks
+        },
+        "passed": True,
+    }
+
+
+def main() -> int:
+    try:
+        summary = run_check()
+    except Exception as exc:
+        print(f"Product-role policy: FAIL\n{exc}")
+        return 1
+
+    print(f"Status: {summary['status']}")
+    print(
+        "Role order: "
+        + ", ".join(summary["role_order"])
+    )
+    print(
+        "Materialization rule: "
+        f"{summary['materialization_rule']}"
+    )
+    print(
+        "Empty role boundary sufficient: "
+        f"{summary['empty_role_boundary_is_sufficient']}"
+    )
+
+    for track_key, track in summary["tracks"].items():
+        print(f"{track_key}:")
+        print(
+            "  formal products: "
+            + ", ".join(track["formal_product_order"])
+        )
+        print(
+            "  omitted roles: "
+            + ", ".join(track["omitted_product_roles"])
+        )
+
+    print("Summary: PASS")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/check_sosa_release_scope.py
+++ b/tools/check_sosa_release_scope.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Validate the approved SOSA formal-package scope authority."""
+"""Validate the governed SOSA formal package-scope authority."""
 
 from __future__ import annotations
 
@@ -16,9 +16,9 @@ def run_check() -> dict[str, object]:
         "development_alias": scope.development_alias,
         "publication_model": scope.publication_model,
         "formal_track_component": scope.formal_track_component,
-        "product_order": scope.product_order,
-        "integrated_product": scope.integrated_product,
-        "bfo_projection_product": scope.bfo_projection_product,
+        "product_role_policy": scope.product_role_policy,
+        "formal_product_order": scope.formal_product_order,
+        "omitted_product_roles": scope.omitted_product_roles,
         "current_track_formal_release": (
             scope.current_track_formal_release
         ),
@@ -42,16 +42,16 @@ def main() -> int:
         f"{summary['formal_track_component']}"
     )
     print(
-        "Product order: "
-        + ", ".join(summary["product_order"])
+        "Product-role policy: "
+        f"{summary['product_role_policy']}"
     )
     print(
-        "Integrated product: "
-        f"{summary['integrated_product']}"
+        "Formal product order: "
+        + ", ".join(summary["formal_product_order"])
     )
     print(
-        "BFO projection product: "
-        f"{summary['bfo_projection_product']}"
+        "Omitted product roles: "
+        + ", ".join(summary["omitted_product_roles"])
     )
     print(
         "Current-track formal release: "

--- a/tools/product_role_policy.py
+++ b/tools/product_role_policy.py
@@ -1,0 +1,333 @@
+#!/usr/bin/env python3
+"""Load and validate the repository-wide ontology product-role policy."""
+
+from __future__ import annotations
+
+import tomllib
+from dataclasses import dataclass
+from pathlib import Path
+
+import sosa_source_version
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+CONFIG_PATH = REPO_ROOT / "config/product-role-policy.toml"
+
+ROLE_ORDER = (
+    "integrated",
+    "alignment_core",
+    "strict_bfo_mapping",
+    "bfo_projection",
+    "cco_extension",
+)
+
+MATERIALIZE_STATUSES = frozenset(
+    {
+        "materialize_consumer_function",
+        "materialize_direct_content",
+    }
+)
+
+OMIT_STATUS = "omit_no_substantive_content_or_distinct_function"
+
+EXPECTED_RULE = "direct_logical_content_or_distinct_consumer_function"
+
+ROLE_INCLUSION_BASES = {
+    "integrated": "distinct_consumer_function",
+    "alignment_core": "direct_product_specific_logical_content",
+    "strict_bfo_mapping": "direct_product_specific_logical_content",
+    "bfo_projection": "direct_product_specific_logical_content",
+    "cco_extension": "direct_product_specific_logical_content",
+}
+
+
+@dataclass(frozen=True)
+class ProductRole:
+    key: str
+    human_label: str
+    inclusion_basis: str
+
+
+@dataclass(frozen=True)
+class TrackPolicy:
+    track_key: str
+    formal_product_order: tuple[str, ...]
+    omitted_product_roles: tuple[str, ...]
+    role_status: tuple[tuple[str, str], ...]
+
+    def status_map(self) -> dict[str, str]:
+        return dict(self.role_status)
+
+
+@dataclass(frozen=True)
+class ProductRolePolicy:
+    schema_version: int
+    status: str
+    role_order: tuple[str, ...]
+    materialization_rule: str
+    empty_role_boundary_is_sufficient: bool
+    roles: tuple[ProductRole, ...]
+    tracks: tuple[TrackPolicy, ...]
+
+    def track(self, track_key: str) -> TrackPolicy:
+        matches = [
+            value
+            for value in self.tracks
+            if value.track_key == track_key
+        ]
+        if len(matches) != 1:
+            raise RuntimeError(
+                f"track {track_key!r}: expected exactly one policy record"
+            )
+        return matches[0]
+
+
+def _require_exact_keys(
+    value: dict[str, object],
+    expected: set[str],
+    label: str,
+) -> None:
+    actual = set(value)
+    if actual != expected:
+        raise RuntimeError(
+            f"{label}: noncanonical keys; "
+            f"missing={sorted(expected - actual)}; "
+            f"extra={sorted(actual - expected)}"
+        )
+
+
+def _require_string(value: object, label: str) -> str:
+    if not isinstance(value, str) or not value:
+        raise RuntimeError(f"{label}: expected nonempty string")
+    return value
+
+
+def _require_string_list(
+    value: object,
+    label: str,
+) -> tuple[str, ...]:
+    if not isinstance(value, list):
+        raise RuntimeError(f"{label}: expected array")
+    if not all(isinstance(item, str) and item for item in value):
+        raise RuntimeError(f"{label}: expected nonempty strings")
+    return tuple(value)
+
+
+def load_product_role_policy(
+    config_path: Path = CONFIG_PATH,
+) -> ProductRolePolicy:
+    with config_path.open("rb") as handle:
+        document = tomllib.load(handle)
+
+    _require_exact_keys(
+        document,
+        {
+            "schema_version",
+            "status",
+            "role_order",
+            "materialization_rule",
+            "empty_role_boundary_is_sufficient",
+            "roles",
+            "tracks",
+        },
+        "document",
+    )
+
+    schema_version = document["schema_version"]
+    if isinstance(schema_version, bool) or schema_version != 1:
+        raise RuntimeError("schema_version: expected integer 1")
+
+    status = _require_string(document["status"], "status")
+    if status != "approved":
+        raise RuntimeError("status: expected 'approved'")
+
+    role_order = _require_string_list(
+        document["role_order"],
+        "role_order",
+    )
+    if role_order != ROLE_ORDER:
+        raise RuntimeError(
+            f"role_order: expected canonical order {ROLE_ORDER!r}"
+        )
+
+    materialization_rule = _require_string(
+        document["materialization_rule"],
+        "materialization_rule",
+    )
+    if materialization_rule != EXPECTED_RULE:
+        raise RuntimeError(
+            f"materialization_rule: expected {EXPECTED_RULE!r}"
+        )
+
+    empty_boundary = document["empty_role_boundary_is_sufficient"]
+    if not isinstance(empty_boundary, bool):
+        raise RuntimeError(
+            "empty_role_boundary_is_sufficient: expected boolean"
+        )
+    if empty_boundary:
+        raise RuntimeError(
+            "empty_role_boundary_is_sufficient: empty role boundaries "
+            "are not sufficient for materialization"
+        )
+
+    raw_roles = document["roles"]
+    if not isinstance(raw_roles, dict):
+        raise RuntimeError("roles: expected table")
+
+    if set(raw_roles) != set(ROLE_ORDER):
+        raise RuntimeError(
+            "roles: expected exactly the canonical five product roles"
+        )
+
+    roles: list[ProductRole] = []
+    for key in ROLE_ORDER:
+        raw_role = raw_roles[key]
+        if not isinstance(raw_role, dict):
+            raise RuntimeError(f"roles.{key}: expected table")
+
+        _require_exact_keys(
+            raw_role,
+            {"human_label", "inclusion_basis"},
+            f"roles.{key}",
+        )
+
+        human_label = _require_string(
+            raw_role["human_label"],
+            f"roles.{key}.human_label",
+        )
+        inclusion_basis = _require_string(
+            raw_role["inclusion_basis"],
+            f"roles.{key}.inclusion_basis",
+        )
+
+        if inclusion_basis != ROLE_INCLUSION_BASES[key]:
+            raise RuntimeError(
+                f"roles.{key}.inclusion_basis: expected "
+                f"{ROLE_INCLUSION_BASES[key]!r}"
+            )
+
+        roles.append(
+            ProductRole(
+                key=key,
+                human_label=human_label,
+                inclusion_basis=inclusion_basis,
+            )
+        )
+
+    raw_tracks = document["tracks"]
+    if not isinstance(raw_tracks, list) or len(raw_tracks) != 2:
+        raise RuntimeError("tracks: expected exactly two track records")
+
+    source = sosa_source_version.load_source_version_authority()
+    expected_track_keys = (
+        "current-ssn-sosa",
+        source.source_identity,
+    )
+
+    tracks: list[TrackPolicy] = []
+
+    for index, raw_track in enumerate(raw_tracks):
+        label = f"tracks[{index}]"
+        if not isinstance(raw_track, dict):
+            raise RuntimeError(f"{label}: expected table")
+
+        _require_exact_keys(
+            raw_track,
+            {
+                "track_key",
+                "formal_product_order",
+                "omitted_product_roles",
+                "role_status",
+            },
+            label,
+        )
+
+        track_key = _require_string(
+            raw_track["track_key"],
+            f"{label}.track_key",
+        )
+
+        if track_key != expected_track_keys[index]:
+            raise RuntimeError(
+                f"{label}.track_key: expected "
+                f"{expected_track_keys[index]!r}"
+            )
+
+        formal_product_order = _require_string_list(
+            raw_track["formal_product_order"],
+            f"{label}.formal_product_order",
+        )
+        omitted_product_roles = _require_string_list(
+            raw_track["omitted_product_roles"],
+            f"{label}.omitted_product_roles",
+        )
+
+        raw_status = raw_track["role_status"]
+        if not isinstance(raw_status, dict):
+            raise RuntimeError(f"{label}.role_status: expected table")
+
+        if set(raw_status) != set(ROLE_ORDER):
+            raise RuntimeError(
+                f"{label}.role_status: expected all five roles"
+            )
+
+        status_map: dict[str, str] = {}
+        for role_key in ROLE_ORDER:
+            role_status = _require_string(
+                raw_status[role_key],
+                f"{label}.role_status.{role_key}",
+            )
+            if (
+                role_status not in MATERIALIZE_STATUSES
+                and role_status != OMIT_STATUS
+            ):
+                raise RuntimeError(
+                    f"{label}.role_status.{role_key}: "
+                    "unapproved materialization status"
+                )
+            status_map[role_key] = role_status
+
+        derived_materialized = tuple(
+            role_key
+            for role_key in ROLE_ORDER
+            if status_map[role_key] in MATERIALIZE_STATUSES
+        )
+        derived_omitted = tuple(
+            role_key
+            for role_key in ROLE_ORDER
+            if status_map[role_key] == OMIT_STATUS
+        )
+
+        if formal_product_order != derived_materialized:
+            raise RuntimeError(
+                f"{label}.formal_product_order: does not match "
+                "materialization statuses"
+            )
+
+        if omitted_product_roles != derived_omitted:
+            raise RuntimeError(
+                f"{label}.omitted_product_roles: does not match "
+                "materialization statuses"
+            )
+
+        tracks.append(
+            TrackPolicy(
+                track_key=track_key,
+                formal_product_order=formal_product_order,
+                omitted_product_roles=omitted_product_roles,
+                role_status=tuple(
+                    (key, status_map[key])
+                    for key in ROLE_ORDER
+                ),
+            )
+        )
+
+    return ProductRolePolicy(
+        schema_version=1,
+        status=status,
+        role_order=role_order,
+        materialization_rule=materialization_rule,
+        empty_role_boundary_is_sufficient=empty_boundary,
+        roles=tuple(roles),
+        tracks=tuple(tracks),
+    )

--- a/tools/run_validation_suite.py
+++ b/tools/run_validation_suite.py
@@ -408,6 +408,8 @@ def compile_check() -> StepResult:
             "tools/check_coms_mapping.py",
             "tools/sosa_source_version.py",
             "tools/check_sosa_source_version.py",
+            "tools/product_role_policy.py",
+            "tools/check_product_role_policy.py",
             "tools/sosa_release_scope.py",
             "tools/check_sosa_release_scope.py",
             "tools/check_sosa_next_mapping.py",
@@ -424,6 +426,7 @@ def compile_check() -> StepResult:
             "tools/rehearse_release.py",
             "tests/test_generate_mapping_from_coms.py",
             "tests/test_sosa_source_version.py",
+            "tests/test_product_role_policy.py",
             "tests/test_sosa_release_scope.py",
             "tests/test_check_sosa_next_mapping.py",
             "tests/test_sosa_next_products.py",
@@ -526,6 +529,22 @@ def run_validation_suite(args: argparse.Namespace) -> int:
                     "tests",
                     "-p",
                     "test_sosa_source_version.py",
+                ],
+            )
+        )
+    if results[-1].passed:
+        results.append(
+            run_command(
+                "Uniform product-role policy focused tests",
+                [
+                    sys.executable,
+                    "-m",
+                    "unittest",
+                    "discover",
+                    "-s",
+                    "tests",
+                    "-p",
+                    "test_product_role_policy.py",
                 ],
             )
         )
@@ -870,6 +889,16 @@ def run_validation_suite(args: argparse.Namespace) -> int:
                 [
                     sys.executable,
                     "tools/check_sosa_source_version.py",
+                ],
+            )
+        )
+    if results[-1].passed:
+        results.append(
+            run_command(
+                "Uniform product-role policy check",
+                [
+                    sys.executable,
+                    "tools/check_product_role_policy.py",
                 ],
             )
         )

--- a/tools/sosa_release_scope.py
+++ b/tools/sosa_release_scope.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Load and validate the approved SOSA formal-package scope decision."""
+"""Load and validate the governed SOSA formal package-scope decision."""
 
 from __future__ import annotations
 
@@ -7,6 +7,7 @@ import tomllib
 from dataclasses import dataclass
 from pathlib import Path
 
+import product_role_policy
 import sosa_source_version
 
 
@@ -14,12 +15,8 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 CONFIG_PATH = REPO_ROOT / "config/sosa-release-scope.toml"
 
 EXPECTED_PUBLICATION_MODEL = "separate_package"
-EXPECTED_PRODUCT_ORDER = (
-    "alignment_core",
-    "strict_bfo_mapping",
-    "cco_extension",
-)
-EXPECTED_CURRENT_TRACK_POLICY = "unchanged"
+EXPECTED_ROLE_POLICY_PATH = "config/product-role-policy.toml"
+EXPECTED_CURRENT_TRACK_STATE = "pending_product_role_policy_migration"
 
 
 @dataclass(frozen=True)
@@ -30,9 +27,9 @@ class SosaReleaseScope:
     development_alias: str
     publication_model: str
     formal_track_component: str
-    product_order: tuple[str, ...]
-    integrated_product: bool
-    bfo_projection_product: bool
+    product_role_policy: str
+    formal_product_order: tuple[str, ...]
+    omitted_product_roles: tuple[str, ...]
     current_track_formal_release: str
 
 
@@ -43,10 +40,10 @@ def _require_exact_keys(
 ) -> None:
     actual = set(value)
     if actual != expected:
-        missing = sorted(expected - actual)
-        extra = sorted(actual - expected)
         raise RuntimeError(
-            f"{label}: noncanonical keys; missing={missing}; extra={extra}"
+            f"{label}: noncanonical keys; "
+            f"missing={sorted(expected - actual)}; "
+            f"extra={sorted(actual - expected)}"
         )
 
 
@@ -56,10 +53,15 @@ def _require_string(value: object, label: str) -> str:
     return value
 
 
-def _require_boolean(value: object, label: str) -> bool:
-    if not isinstance(value, bool):
-        raise RuntimeError(f"{label}: expected boolean")
-    return value
+def _require_string_list(
+    value: object,
+    label: str,
+) -> tuple[str, ...]:
+    if not isinstance(value, list):
+        raise RuntimeError(f"{label}: expected array")
+    if not all(isinstance(item, str) and item for item in value):
+        raise RuntimeError(f"{label}: expected nonempty strings")
+    return tuple(value)
 
 
 def load_release_scope(
@@ -77,47 +79,41 @@ def load_release_scope(
             "development_alias",
             "publication_model",
             "formal_track_component",
-            "product_order",
-            "integrated_product",
-            "bfo_projection_product",
+            "product_role_policy",
+            "formal_product_order",
+            "omitted_product_roles",
             "current_track_formal_release",
         },
         "document",
     )
 
     schema_version = document["schema_version"]
-    if isinstance(schema_version, bool) or schema_version != 1:
-        raise RuntimeError(
-            f"schema_version: expected integer 1, got {schema_version!r}"
-        )
+    if isinstance(schema_version, bool) or schema_version != 2:
+        raise RuntimeError("schema_version: expected integer 2")
 
     status = _require_string(document["status"], "status")
     if status != "approved":
-        raise RuntimeError(
-            f"status: expected 'approved', got {status!r}"
-        )
+        raise RuntimeError("status: expected 'approved'")
 
-    source_authority = (
-        sosa_source_version.load_source_version_authority()
-    )
+    source = sosa_source_version.load_source_version_authority()
+    role_policy = product_role_policy.load_product_role_policy()
 
     source_identity = _require_string(
         document["source_identity"],
         "source_identity",
     )
-    if source_identity != source_authority.source_identity:
+    if source_identity != source.source_identity:
         raise RuntimeError(
-            "source_identity: must equal the approved SOSA source-version "
-            f"identity {source_authority.source_identity!r}"
+            "source_identity: must equal approved source-version identity"
         )
 
     development_alias = _require_string(
         document["development_alias"],
         "development_alias",
     )
-    if development_alias != source_authority.development_alias:
+    if development_alias != source.development_alias:
         raise RuntimeError(
-            "development_alias: must equal the source-version authority"
+            "development_alias: must equal source-version authority"
         )
 
     publication_model = _require_string(
@@ -126,8 +122,7 @@ def load_release_scope(
     )
     if publication_model != EXPECTED_PUBLICATION_MODEL:
         raise RuntimeError(
-            "publication_model: approved model is "
-            f"{EXPECTED_PUBLICATION_MODEL!r}"
+            "publication_model: separate package decision remains approved"
         )
 
     formal_track_component = _require_string(
@@ -136,68 +131,56 @@ def load_release_scope(
     )
     if formal_track_component != source_identity:
         raise RuntimeError(
-            "formal_track_component: must equal the approved source identity"
+            "formal_track_component: must equal source identity"
         )
 
-    raw_product_order = document["product_order"]
-    if not isinstance(raw_product_order, list):
-        raise RuntimeError("product_order: expected array")
-
-    if not all(
-        isinstance(value, str) and value
-        for value in raw_product_order
-    ):
-        raise RuntimeError(
-            "product_order: expected nonempty product strings"
-        )
-
-    product_order = tuple(raw_product_order)
-    if product_order != EXPECTED_PRODUCT_ORDER:
-        raise RuntimeError(
-            "product_order: approved order is "
-            f"{EXPECTED_PRODUCT_ORDER!r}"
-        )
-
-    if len(set(product_order)) != len(product_order):
-        raise RuntimeError("product_order: duplicate product key")
-
-    integrated_product = _require_boolean(
-        document["integrated_product"],
-        "integrated_product",
+    role_policy_path = _require_string(
+        document["product_role_policy"],
+        "product_role_policy",
     )
-    if integrated_product:
+    if role_policy_path != EXPECTED_ROLE_POLICY_PATH:
         raise RuntimeError(
-            "integrated_product: not approved for the formal source-version package"
+            f"product_role_policy: expected {EXPECTED_ROLE_POLICY_PATH!r}"
         )
 
-    bfo_projection_product = _require_boolean(
-        document["bfo_projection_product"],
-        "bfo_projection_product",
+    governed_track = role_policy.track(source_identity)
+
+    formal_product_order = _require_string_list(
+        document["formal_product_order"],
+        "formal_product_order",
     )
-    if bfo_projection_product:
+    if formal_product_order != governed_track.formal_product_order:
         raise RuntimeError(
-            "bfo_projection_product: not approved for the formal source-version package"
+            "formal_product_order: must equal product-role policy"
         )
 
-    current_track_formal_release = _require_string(
+    omitted_product_roles = _require_string_list(
+        document["omitted_product_roles"],
+        "omitted_product_roles",
+    )
+    if omitted_product_roles != governed_track.omitted_product_roles:
+        raise RuntimeError(
+            "omitted_product_roles: must equal product-role policy"
+        )
+
+    current_track_state = _require_string(
         document["current_track_formal_release"],
         "current_track_formal_release",
     )
-    if current_track_formal_release != EXPECTED_CURRENT_TRACK_POLICY:
+    if current_track_state != EXPECTED_CURRENT_TRACK_STATE:
         raise RuntimeError(
-            "current_track_formal_release: current formal package contract "
-            "must remain unchanged"
+            "current_track_formal_release: expected pending role-policy migration"
         )
 
     return SosaReleaseScope(
-        schema_version=1,
+        schema_version=2,
         status=status,
         source_identity=source_identity,
         development_alias=development_alias,
         publication_model=publication_model,
         formal_track_component=formal_track_component,
-        product_order=product_order,
-        integrated_product=integrated_product,
-        bfo_projection_product=bfo_projection_product,
-        current_track_formal_release=current_track_formal_release,
+        product_role_policy=role_policy_path,
+        formal_product_order=formal_product_order,
+        omitted_product_roles=omitted_product_roles,
+        current_track_formal_release=current_track_state,
     )


### PR DESCRIPTION
## Summary

Establish a repository-wide product-role materialization policy before changing ontology-product or formal-release implementation.

The policy defines five uniform product roles:

1. Integrated
2. Alignment Core
3. BFO Mapping
4. BFO Projection
5. CCO Extension

Uniformity applies to role semantics and inclusion criteria rather than requiring every mapping track to publish the same number of ontology files.

A role is materialized only when it has direct product-specific logical content or a distinct documented consumer function. Empty shells used only to reserve an import boundary, namespace, or future slot are not sufficient.

## Approved target inventories

Current SSN/SOSA:

- Integrated
- Alignment Core
- BFO Mapping
- CCO Extension

BFO Projection is omitted from the target formal inventory because no direct weakened projection axiom is currently approved.

SOSA 2023 source-version track:

- Integrated
- BFO Mapping
- CCO Extension

Alignment Core is omitted because the current mapping contains no direct target-neutral axioms. BFO Projection remains omitted because no weakened consequence is approved.

## Package boundary

The existing decision to publish the SOSA source-version track as a separate package remains approved.

This PR supersedes only the earlier fixed three-product inventory and the assumption that the current five-product formal inventory must remain unchanged.

## Scope

This is a governance-only milestone.

It does not change:

- either COMS workbook;
- current SSN/SOSA ontology-product bytes;
- SOSA-2023 maintained ontology-product bytes;
- pinned W3C SOSA source bytes;
- current publication metadata;
- current manifest schema;
- current package/archive construction;
- current release rehearsal.

The maintained import-only current BFO Projection and zero-direct-axiom SOSA-next Alignment Core remain temporarily in place until separate implementation migrations.

## Validation

Full `make check` passes.

The validation suite now includes:

- uniform product-role policy focused tests;
- product-role policy authority check;
- revised SOSA formal package-scope tests and authority check.

Protected current products, SOSA-2023 development products, pinned source files, mapping authorities, and current formal-release implementation were explicitly verified unchanged.
