### PR TITLE
Add SOSA-2023 publication rendering

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: validate validate-write audit-write legacy-audit-write compile check check-coms check-sosa-next check-coms-row-identities check-coms-product-dispositions check-alignment-core check-strict-bfo-mapping check-cco-extension check-publication-metadata check-release-rendering check-release-package check-release-archive check-release-rehearsal check-placeholder-catalog-migration watch-coms coms-status post-merge-check status diffstat generate-sosa-next-products check-sosa-next-products check-sosa-next-consumer-stack check-sosa-source-version check-product-role-policy check-sosa-release-scope
+.PHONY: validate validate-write audit-write legacy-audit-write compile check check-coms check-sosa-next check-coms-row-identities check-coms-product-dispositions check-alignment-core check-strict-bfo-mapping check-cco-extension check-publication-metadata check-release-rendering check-release-package check-release-archive check-release-rehearsal check-placeholder-catalog-migration watch-coms coms-status post-merge-check status diffstat generate-sosa-next-products check-sosa-next-products check-sosa-next-consumer-stack check-sosa-2023-publication-rendering check-sosa-source-version check-product-role-policy check-sosa-release-scope
 
 validate:
 	PYTHONDONTWRITEBYTECODE=1 python tools/run_validation_suite.py
@@ -59,6 +59,8 @@ compile:
 		tests/test_check_sosa_next_mapping.py \
 		tests/test_sosa_next_products.py \
 		tests/test_sosa_next_consumer_stack.py \
+		tests/test_sosa_2023_publication_metadata.py \
+		tests/test_sosa_2023_release_rendering.py \
 		tests/test_robot_diff_pilot.py \
 		tests/test_robot_extract_pilot.py \
 		tests/test_robot_query_equivalence_pilot.py \
@@ -131,6 +133,10 @@ check-sosa-next-products:
 
 check-sosa-next-consumer-stack:
 	PYTHONDONTWRITEBYTECODE=1 python -m unittest discover -s tests -p 'test_sosa_next_consumer_stack.py'
+
+check-sosa-2023-publication-rendering:
+	PYTHONDONTWRITEBYTECODE=1 python -m unittest discover -s tests -p 'test_sosa_2023_publication_metadata.py'
+	PYTHONDONTWRITEBYTECODE=1 python -m unittest discover -s tests -p 'test_sosa_2023_release_rendering.py'
 
 check-coms:
 	PYTHONDONTWRITEBYTECODE=1 python tools/check_coms_mapping.py

--- a/config/sosa-2023-publication-metadata.toml
+++ b/config/sosa-2023-publication-metadata.toml
@@ -1,0 +1,36 @@
+schema_version = 4
+
+[publication]
+project_title = "SSN-to-BFO"
+default_language = "en"
+release_iri_base = "http://www.sks.ai/SSN2BFO/releases"
+license_iri = "https://creativecommons.org/publicdomain/zero/1.0/"
+repository_iri = "https://github.com/BFO-Mappings/SSN-to-BFO"
+generated_warning = "Generated from governed SOSA-2023 COMS and publication metadata; do not edit this ontology directly."
+development_status_property_iri = "http://www.w3.org/ns/adms#status"
+development_status_iri = "http://www.sks.ai/SSN2BFO/authority-status/maintained-authoritative-development"
+formal_release_status_iri = "http://www.sks.ai/SSN2BFO/authority-status/immutable-authoritative-release"
+
+[products.integrated]
+path = "releases/sosa-next/sosa-integrated.ttl"
+stable_ontology_iri = "http://www.sks.ai/SSN2BFO/sosa-2023-af425a0454ec00512a5ebfa2873fe35a077f5fda/integrated"
+release_iri_suffix = "sosa-2023-af425a0454ec00512a5ebfa2873fe35a077f5fda/integrated"
+label = "SOSA 2023 Integrated Mapping"
+description = "Directly asserts the complete governed SOSA 2023 mapping to BFO and CCO and serves as the complete consumer entry point."
+product_type_iri = "http://www.sks.ai/SSN2BFO/product-type/integrated"
+
+[products.strict_bfo_mapping]
+path = "releases/sosa-next/sosa-bfo-mapping.ttl"
+stable_ontology_iri = "http://www.sks.ai/SSN2BFO/sosa-2023-af425a0454ec00512a5ebfa2873fe35a077f5fda/bfo-mapping"
+release_iri_suffix = "sosa-2023-af425a0454ec00512a5ebfa2873fe35a077f5fda/bfo-mapping"
+label = "SOSA 2023 Strict BFO Mapping"
+description = "Directly asserts the governed BFO-bearing SOSA 2023 mapping axioms without weakening and imports no ontology."
+product_type_iri = "http://www.sks.ai/SSN2BFO/product-type/strict-bfo-mapping"
+
+[products.cco_extension]
+path = "releases/sosa-next/sosa-cco-extension.ttl"
+stable_ontology_iri = "http://www.sks.ai/SSN2BFO/sosa-2023-af425a0454ec00512a5ebfa2873fe35a077f5fda/cco-extension"
+release_iri_suffix = "sosa-2023-af425a0454ec00512a5ebfa2873fe35a077f5fda/cco-extension"
+label = "SOSA 2023 CCO Extension"
+description = "Directly asserts the governed CCO-bearing and mixed BFO/CCO SOSA 2023 mapping axioms and imports the strict BFO mapping."
+product_type_iri = "http://www.sks.ai/SSN2BFO/product-type/cco-extension"

--- a/docs/PRODUCT-ARCHITECTURE.md
+++ b/docs/PRODUCT-ARCHITECTURE.md
@@ -204,10 +204,46 @@ The maintained product hashes are:
 | BFO Mapping | `67bb58ea543e654ace41c0d1a393b2a3f92426c693f5100f0aa3ba35f3b005d2` |
 | CCO Extension | `e65e96f15a55e19fc43be8dbda6e56351ef40bbd6e0fa9368a240e83c5d6bb69` |
 
-The source-version track remains a separate future formal package. Formal
-publication must replace the `sosa-next` development alias in track-specific
-formal paths and ontology IRIs with
-`sosa-2023-af425a0454ec00512a5ebfa2873fe35a077f5fda`.
+The source-version track remains a separate future formal package, but its
+publication-metadata and formal-rendering layers are now implemented.
+
+`config/sosa-2023-publication-metadata.toml` governs the three formal product
+identities. Formal stable ontology IRIs and date-based version-IRI suffixes use
+the immutable source identity
+`sosa-2023-af425a0454ec00512a5ebfa2873fe35a077f5fda`; no formal ontology header
+retains the `sosa-next` development alias.
+
+The pure formal renderer preserves the three development logical graphs and
+uses this formal import graph:
+
+```text
+Formal Integrated
+  -> SOSA
+  -> SOSA Systems
+  -> SOSA Sampling
+  -> merged CCO/BFO
+
+Formal CCO Extension
+  -> same-release Formal BFO Mapping
+
+Formal BFO Mapping
+  -> no ontology import
+```
+
+The development-only source-declaration overlay remains governed source and
+validation evidence but is deliberately not a published formal import.
+
+Under the fixed synthetic `2099-01-02` release context, the formal bytes are
+locked at:
+
+| Product | Logical triples | Total triples | SHA-256 |
+| --- | ---: | ---: | --- |
+| Integrated | 273 | 288 | `81694ddfc0a7587c2d83517f0fc69449a25dc31ae68571b0a63f48aa5ca10aae` |
+| BFO Mapping | 157 | 168 | `c88cb347742a15fc003cafe2e167f7f784cc4a70653720c11f1e6247e6a3096c` |
+| CCO Extension | 116 | 128 | `bc356b515e29a21d74865101661fe1d81f2da33f86b31bf4c497109e8f9b202b` |
+
+Package paths, manifest/schema evidence, package catalog, archive, release
+notes, rehearsal, and actual publication remain future formal-package work.
 
 Focused validation:
 
@@ -218,7 +254,8 @@ make check-sosa-release-scope
 make check-sosa-next
 make check-sosa-next-products
 make check-sosa-next-consumer-stack
+make check-sosa-2023-publication-rendering
 ```
 
-For the implemented development contract, see
+For the development and formal-rendering contract, see
 `reports/sosa-next-product-contract.md`.

--- a/docs/VALIDATION-AND-RELEASES.md
+++ b/docs/VALIDATION-AND-RELEASES.md
@@ -12,6 +12,7 @@ It includes:
 - modular-product tests
 - SOSA-next maintained-product tests
 - SOSA-next catalog consumer-stack tests
+- SOSA-2023 publication-metadata and formal-rendering tests
 - publication-metadata validation
 - formal release-context and rendering tests
 - release-package, archive, and rehearsal tests
@@ -84,10 +85,10 @@ artifact. It maps exactly the four immutable current-track same-release version
 IRIs to package-relative products. The SOSA-next development catalog is not
 copied into that package.
 
-## SOSA-next development validation
+## SOSA-2023 validation
 
-The SOSA-2023 workbook and its three maintained development products have
-separate focused gates:
+The SOSA-2023 workbook, maintained development products, and formal-rendering
+contract have separate focused gates:
 
 ```bash
 make check-sosa-source-version
@@ -96,6 +97,7 @@ make check-sosa-release-scope
 make check-sosa-next
 make check-sosa-next-products
 make check-sosa-next-consumer-stack
+make check-sosa-2023-publication-rendering
 ```
 
 `make check-sosa-source-version` validates the approved immutable source
@@ -123,49 +125,88 @@ transactional rollback; requires the retired Alignment Core artifact to remain
 absent; and requires zero named unsatisfiable classes in all three reasoning
 profiles.
 
-The fixed reasoning closures contain:
+The fixed development reasoning closures contain:
 
 - 15,127 triples for Integrated;
 - 15,011 triples for BFO Mapping;
 - 15,135 triples for CCO Extension.
 
-`make check-sosa-next-consumer-stack` resolves every catalog target locally,
-parses all dependency and project entries, verifies the exact Integrated and
-modular import boundaries, loads the 290-triple editor project closure, and
-confirms that BFO Mapping and CCO Extension remain independently resolvable.
+`make check-sosa-next-consumer-stack` resolves every development catalog target
+locally, parses all dependency and project entries, verifies the exact
+Integrated and modular import boundaries, loads the 290-triple editor project
+closure, and confirms that BFO Mapping and CCO Extension remain independently
+resolvable.
 
-These checks are included in `make check` and hosted CI. They validate
-maintained development artifacts only; they do not create a formal version IRI,
-manifest, package, archive, tag, GitHub release, or persistent-IRI deployment.
+`make check-sosa-2023-publication-rendering` validates the separate
+SOSA-2023 publication-metadata authority and renders all three formal products
+twice under a fixed synthetic release context. It requires exact stable and
+version IRIs, exact formal import boundaries, preservation of the development
+logical graphs, byte-identical independent renders, and the locked synthetic
+formal byte contract:
+
+- Integrated: 273 logical triples, 288 total triples,
+  SHA-256 `81694ddfc0a7587c2d83517f0fc69449a25dc31ae68571b0a63f48aa5ca10aae`;
+- Strict BFO Mapping: 157 logical triples, 168 total triples,
+  SHA-256 `c88cb347742a15fc003cafe2e167f7f784cc4a70653720c11f1e6247e6a3096c`;
+- CCO Extension: 116 logical triples, 128 total triples,
+  SHA-256 `bc356b515e29a21d74865101661fe1d81f2da33f86b31bf4c497109e8f9b202b`.
+
+The formal Integrated product imports the official SOSA root, Systems, and
+Sampling IRIs plus merged CCO/BFO. The local source-declaration overlay remains
+governed source/validation evidence but is not a published ontology import.
+Formal BFO Mapping is import-free. Formal CCO Extension imports the same-release
+formal BFO Mapping version IRI.
+
+These checks are included in `make check` and hosted CI. The formal-rendering
+gate operates entirely in memory and does not create a manifest, package,
+archive, tag, GitHub release, or persistent-IRI deployment.
 
 ## Publication metadata
 
-`config/publication-metadata.toml` is the sole editable publication-metadata source for the current four-product formal-release track. The uniform product-role policy separately governs five conceptual roles; `bfo_projection` is currently non-materialized.
+Publication metadata is track-specific.
 
-Development-mode validation:
+`config/publication-metadata.toml` remains the sole editable metadata authority
+for the current four-product formal-release track.
+
+`config/sosa-2023-publication-metadata.toml` is the separate metadata authority
+for the three-product SOSA-2023 formal target. Its canonical product order is
+Integrated, Strict BFO Mapping, and CCO Extension. Its stable ontology IRIs and
+release-IRI suffixes use the approved immutable source-version identity
+`sosa-2023-af425a0454ec00512a5ebfa2873fe35a077f5fda`; formal ontology headers
+contain no `sosa-next` or `/development/` identity.
+
+The common metadata loader defaults to the current-track product order for
+backward compatibility and accepts an explicit canonical product order for a
+separate governed track. Existing current-track metadata bytes and formal
+rendering remain unchanged.
+
+Current-track development-mode validation remains:
 
 ```bash
 make check-publication-metadata
 python tools/check_publication_metadata.py
 ```
 
-Formal rendering requires:
+SOSA-2023 publication metadata and rendering are validated together by:
 
-- a real `YYYY-MM-DD` release identifier
-- the matching release date
-- a `vYYYY-MM-DD` Git tag
-- a full lowercase 40-hex source commit
+```bash
+make check-sosa-2023-publication-rendering
+```
 
-Formal renderers:
+Formal rendering requires a complete release context:
 
-- preserve stable ontology IRIs
-- use immutable-release authority status
-- add `owl:versionIRI`
-- add plain `owl:versionInfo`
-- add `dcterms:issued` as `xsd:date`
-- rewrite modular imports to same-release version IRIs
+- a real `YYYY-MM-DD` release identifier;
+- the matching release date;
+- a `vYYYY-MM-DD` Git tag;
+- a full lowercase 40-hex source commit.
 
-`make check-release-rendering` validates deterministic bytes, logical-graph preservation, closure counts, and independent HermiT consistency.
+Both formal rendering systems preserve stable ontology IRIs, use the
+immutable-release authority status, add `owl:versionIRI`, plain
+`owl:versionInfo`, and `dcterms:issued` as `xsd:date`, and preserve the
+development logical graph.
+
+The SOSA-2023 renderer is currently a pure in-memory rendering capability. It
+does not yet define or construct the separate formal package.
 
 ## Release package
 

--- a/reports/sosa-next-formal-release-integration-audit.md
+++ b/reports/sosa-next-formal-release-integration-audit.md
@@ -116,30 +116,51 @@ The current-track formal machinery already follows the same role policy. Its
 four materialized products exclude BFO Projection, which remains governed but
 non-materialized.
 
-### Publication metadata
+### Publication metadata — implemented
 
-The current metadata loader requires one exact five-product inventory. Formal
-integration therefore requires one of these governed designs:
+The repository now has a separate governed SOSA-2023 publication-metadata
+authority at `config/sosa-2023-publication-metadata.toml`.
 
-- a track-specific publication-metadata document for the SOSA source version;
-- or a generalized metadata schema with explicit track records and a canonical
-  product order per track.
+The common metadata loader remains backward-compatible with the current
+four-product default inventory and can accept an explicit canonical product
+order for another governed track. The SOSA-2023 authority contains exactly
+Integrated, BFO Mapping, and CCO Extension, with stable ontology IRIs and
+release-IRI suffixes rooted in the approved immutable source identity.
 
-The design must preserve strict rejection of unknown fields, duplicate paths,
-duplicate stable IRIs, unsafe paths, and noncanonical ordering.
+The metadata `path` fields identify the maintained development source products
+used by the renderer; they are not formal package-relative paths. Canonical
+package paths remain part of the separate package-construction milestone.
 
-### Formal rendering
+### Formal rendering — implemented
 
-Formal rendering must:
+`tools/generate_sosa_next_products.py` now provides a pure in-memory
+SOSA-2023 formal renderer. Under an explicit formal release context it:
 
-- preserve each approved stable ontology IRI;
-- add immutable same-release version IRIs;
-- substitute immutable-release authority status;
-- add release date and version information;
-- rewrite only project imports to same-release version IRIs;
-- preserve the development logical graph;
-- prohibit temporary development identities;
-- validate each product independently and as a project stack.
+- preserves the approved immutable stable ontology IRIs;
+- adds date-based same-release version IRIs;
+- substitutes immutable-release authority status;
+- adds release date and version information;
+- preserves each development logical graph;
+- renders deterministic bytes independent of input order;
+- prohibits `sosa-next` and `/development/` identities from formal ontology
+  bytes;
+- keeps formal BFO Mapping import-free;
+- rewrites the CCO Extension project edge to the same-release formal BFO
+  Mapping version IRI;
+- publishes Integrated with the official SOSA root, Systems, Sampling, and
+  merged CCO/BFO imports;
+- keeps the local source-declaration overlay as governed validation/source
+  evidence rather than a published ontology import.
+
+The fixed synthetic `2099-01-02` byte contract is:
+
+| Product | Logical triples | Total triples | SHA-256 |
+| --- | ---: | ---: | --- |
+| Integrated | 273 | 288 | `81694ddfc0a7587c2d83517f0fc69449a25dc31ae68571b0a63f48aa5ca10aae` |
+| BFO Mapping | 157 | 168 | `c88cb347742a15fc003cafe2e167f7f784cc4a70653720c11f1e6247e6a3096c` |
+| CCO Extension | 116 | 128 | `bc356b515e29a21d74865101661fe1d81f2da33f86b31bf4c497109e8f9b202b` |
+
+These capabilities do not yet construct a formal package.
 
 ### Manifest and schema
 
@@ -156,7 +177,7 @@ product inventory. Required evidence includes:
 - catalog-consumption validation;
 - toolchain identity.
 
-A schema revision may be preferable to overloading schema version 1.
+The current formal-release authority is manifest schema version 2. The SOSA-2023 package should either receive a deliberate schema revision or a separate schema authority rather than being inserted into the current-track inventory implicitly.
 
 ### Package layout
 
@@ -225,14 +246,16 @@ context and approved release notes.
 
 ## Recommended implementation sequence
 
-1. **Define track-specific publication metadata for the separate package.**
-2. **Implement formal rendering and same-release import rewriting.**
-3. **Add a source-version manifest/schema authority and exact evidence model.**
-4. **Implement separate-package construction and read-only validation.**
-5. **Implement the canonical package catalog.**
-6. **Implement the separate package's deterministic archive authority.**
-7. **Add release notes, rehearsal, and hosted-CI regressions.**
-8. **Run a synthetic source-version release context before actual publication.**
+1. **Completed:** define track-specific SOSA-2023 publication metadata.
+2. **Completed:** implement deterministic formal rendering and same-release
+   project-import rewriting.
+3. **Next:** add a source-version manifest/schema authority and exact evidence
+   model.
+4. **Then:** implement separate-package construction and read-only validation.
+5. **Then:** implement the canonical package catalog.
+6. **Then:** implement the separate package's deterministic archive authority.
+7. **Then:** add release notes, rehearsal, and hosted-CI regressions.
+8. **Finally:** run a release-context rehearsal before actual publication.
 
 Each stage should preserve current-track release bytes and behavior.
 

--- a/reports/sosa-next-product-contract.md
+++ b/reports/sosa-next-product-contract.md
@@ -204,9 +204,10 @@ target inventory:
 
 Alignment Core and BFO Projection remain governed omitted roles.
 
-Formal publication remains a separate later phase. It must replace the
-`sosa-next` development alias in formal track-specific paths and ontology IRIs
-with the approved immutable source-version identity.
+Formal package publication remains a later phase, but formal publication
+metadata and pure ontology rendering are now implemented. Formal stable
+ontology IRIs and version-IRI suffixes use the approved immutable source-version
+identity and contain no `sosa-next` development alias.
 
 ## Generation architecture
 
@@ -239,6 +240,27 @@ Each maintained product must use deterministic UTF-8 Turtle with:
 Development metadata must use the repository's existing publication vocabulary
 and product-type IRIs. Formal-release-only metadata, including
 `owl:versionIRI`, must not appear in maintained development artifacts.
+
+The separate formal publication authority is
+`config/sosa-2023-publication-metadata.toml`. The pure formal renderer preserves
+the development logical graphs while replacing development ontology identity
+with the approved immutable stable identity and adding formal status,
+`owl:versionIRI`, `owl:versionInfo`, and `dcterms:issued`.
+
+Formal Integrated imports the official SOSA root, Systems, Sampling, and merged
+CCO/BFO IRIs. The source-declaration overlay remains governed source and
+validation evidence but is not a published formal import. Formal BFO Mapping
+is import-free. Formal CCO Extension imports the same-release formal BFO
+Mapping version IRI.
+
+Under the synthetic `2099-01-02` release context, the exact formal hashes are:
+
+- Integrated:
+  `81694ddfc0a7587c2d83517f0fc69449a25dc31ae68571b0a63f48aa5ca10aae`;
+- BFO Mapping:
+  `c88cb347742a15fc003cafe2e167f7f784cc4a70653720c11f1e6247e6a3096c`;
+- CCO Extension:
+  `bc356b515e29a21d74865101661fe1d81f2da33f86b31bf4c497109e8f9b202b`.
 
 ## Validation closures
 
@@ -322,16 +344,23 @@ preserving the four retained current products.
 
 ## Formal-release transition
 
-Formal release integration is a later phase. Before release:
+Publication metadata and pure formal ontology rendering are implemented.
 
-- `sosa-2023-af425a0454ec00512a5ebfa2873fe35a077f5fda` must replace `sosa-next` in formal track-specific package
-  paths and ontology IRIs;
-- release products must receive date-based version IRIs under
-  `http://www.sks.ai/SSN2BFO/releases/<release-id>/`;
-- the package catalog must resolve project and dependency imports offline;
-- release manifests, checksums, archives, and rehearsal must be extended
-  without changing the current-SOSA package contract;
-- no placeholder or development ontology IRI may enter the formal archive.
+Remaining formal-release integration work is:
+
+- define the SOSA-2023 manifest/schema authority and exact release evidence;
+- define canonical formal package-relative paths that use the immutable source
+  identity rather than the `sosa-next` development alias;
+- construct and validate the separate formal package;
+- generate a package catalog resolving the three same-release formal products;
+- add canonical checksums, archive construction, release notes, and isolated
+  release rehearsal;
+- preserve offline dependency governance and prevent accidental network
+  resolution;
+- keep all placeholder and development ontology IRIs out of the formal package.
+
+No formal package, archive, tag, GitHub release, or persistent-IRI deployment is
+created by the current rendering milestone.
 
 ## Non-goals
 

--- a/tests/test_sosa_2023_publication_metadata.py
+++ b/tests/test_sosa_2023_publication_metadata.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python3
+"""Publication-metadata contract for the immutable SOSA-2023 track."""
+
+from __future__ import annotations
+
+import hashlib
+import sys
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT / "tools"))
+
+import publication_metadata as metadata  # noqa: E402
+from release_context import parse_formal_release_context  # noqa: E402
+
+
+TRACK_ID = "sosa-2023-af425a0454ec00512a5ebfa2873fe35a077f5fda"
+
+PRODUCT_ORDER = (
+    "integrated",
+    "strict_bfo_mapping",
+    "cco_extension",
+)
+
+CONFIG = (
+    REPO_ROOT
+    / "config/sosa-2023-publication-metadata.toml"
+)
+
+CURRENT_CONFIG = REPO_ROOT / "config/publication-metadata.toml"
+
+CURRENT_CONFIG_SHA256 = (
+    "bb818ab88d2dbcfd8a11eddcfc846c81609c4e9a9c6819def44f950da423e8f9"
+)
+
+SYNTHETIC_CONTEXT = parse_formal_release_context(
+    "2099-01-02",
+    "2099-01-02",
+    "v2099-01-02",
+    "0123456789abcdef0123456789abcdef01234567",
+)
+
+
+class Sosa2023PublicationMetadataTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.value = metadata.load_metadata(
+            CONFIG,
+            product_order=PRODUCT_ORDER,
+        )
+        cls.by_key = {
+            product.key: product
+            for product in cls.value.products
+        }
+
+    def test_exact_product_inventory(self) -> None:
+        self.assertEqual(
+            tuple(product.key for product in self.value.products),
+            PRODUCT_ORDER,
+        )
+        self.assertEqual(self.value.schema_version, 4)
+
+    def test_exact_product_paths(self) -> None:
+        self.assertEqual(
+            {
+                key: self.by_key[key].path
+                for key in PRODUCT_ORDER
+            },
+            {
+                "integrated":
+                    "releases/sosa-next/sosa-integrated.ttl",
+                "strict_bfo_mapping":
+                    "releases/sosa-next/sosa-bfo-mapping.ttl",
+                "cco_extension":
+                    "releases/sosa-next/sosa-cco-extension.ttl",
+            },
+        )
+
+    def test_stable_ontology_iris_use_immutable_source_identity(self) -> None:
+        expected = {
+            "integrated":
+                f"http://www.sks.ai/SSN2BFO/{TRACK_ID}/integrated",
+            "strict_bfo_mapping":
+                f"http://www.sks.ai/SSN2BFO/{TRACK_ID}/bfo-mapping",
+            "cco_extension":
+                f"http://www.sks.ai/SSN2BFO/{TRACK_ID}/cco-extension",
+        }
+
+        observed = {
+            key: self.by_key[key].stable_ontology_iri
+            for key in PRODUCT_ORDER
+        }
+
+        self.assertEqual(observed, expected)
+
+        for value in observed.values():
+            self.assertNotIn("sosa-next", value)
+            self.assertNotIn("/development/", value)
+
+    def test_release_suffixes_use_immutable_source_identity(self) -> None:
+        expected = {
+            "integrated":
+                f"{TRACK_ID}/integrated",
+            "strict_bfo_mapping":
+                f"{TRACK_ID}/bfo-mapping",
+            "cco_extension":
+                f"{TRACK_ID}/cco-extension",
+        }
+
+        self.assertEqual(
+            {
+                key: self.by_key[key].release_iri_suffix
+                for key in PRODUCT_ORDER
+            },
+            expected,
+        )
+
+    def test_synthetic_version_iris_are_exact(self) -> None:
+        expected = {
+            "integrated":
+                "http://www.sks.ai/SSN2BFO/releases/"
+                f"2099-01-02/{TRACK_ID}/integrated",
+            "strict_bfo_mapping":
+                "http://www.sks.ai/SSN2BFO/releases/"
+                f"2099-01-02/{TRACK_ID}/bfo-mapping",
+            "cco_extension":
+                "http://www.sks.ai/SSN2BFO/releases/"
+                f"2099-01-02/{TRACK_ID}/cco-extension",
+        }
+
+        self.assertEqual(
+            {
+                key: metadata.release_version_iri(
+                    self.value,
+                    key,
+                    SYNTHETIC_CONTEXT,
+                )
+                for key in PRODUCT_ORDER
+            },
+            expected,
+        )
+
+    def test_product_types_are_shared_role_iris(self) -> None:
+        self.assertEqual(
+            {
+                key: self.by_key[key].product_type_iri
+                for key in PRODUCT_ORDER
+            },
+            {
+                "integrated":
+                    "http://www.sks.ai/SSN2BFO/product-type/integrated",
+                "strict_bfo_mapping":
+                    "http://www.sks.ai/SSN2BFO/product-type/strict-bfo-mapping",
+                "cco_extension":
+                    "http://www.sks.ai/SSN2BFO/product-type/cco-extension",
+            },
+        )
+
+    def test_formal_generated_warning_avoids_development_alias(self) -> None:
+        warning = self.value.publication.generated_warning
+        self.assertNotIn("sosa-next", warning)
+        self.assertIn("SOSA-2023", warning)
+
+    def test_explicit_product_order_is_required_for_second_track(self) -> None:
+        with self.assertRaises(metadata.PublicationMetadataError):
+            metadata.load_metadata(CONFIG)
+
+    def test_current_default_product_order_is_unchanged(self) -> None:
+        current = metadata.load_metadata(CURRENT_CONFIG)
+
+        self.assertEqual(
+            tuple(product.key for product in current.products),
+            metadata.PRODUCT_ORDER,
+        )
+
+    def test_current_publication_metadata_bytes_are_unchanged(self) -> None:
+        observed = hashlib.sha256(
+            CURRENT_CONFIG.read_bytes()
+        ).hexdigest()
+
+        self.assertEqual(
+            observed,
+            CURRENT_CONFIG_SHA256,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_sosa_2023_release_rendering.py
+++ b/tests/test_sosa_2023_release_rendering.py
@@ -1,0 +1,352 @@
+#!/usr/bin/env python3
+"""Focused formal-rendering contract for the immutable SOSA-2023 track."""
+
+from __future__ import annotations
+
+import hashlib
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+from rdflib import Graph, OWL
+from rdflib.compare import isomorphic
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT / "tools"))
+
+import generate_sosa_next_products as products  # noqa: E402
+from release_context import parse_formal_release_context  # noqa: E402
+
+
+TRACK_ID = (
+    "sosa-2023-"
+    "af425a0454ec00512a5ebfa2873fe35a077f5fda"
+)
+
+SYNTHETIC_CONTEXT = parse_formal_release_context(
+    "2099-01-02",
+    "2099-01-02",
+    "v2099-01-02",
+    "0123456789abcdef0123456789abcdef01234567",
+)
+
+EXPECTED_TOTAL_TRIPLES = {
+    "integrated": 288,
+    "strict_bfo_mapping": 168,
+    "cco_extension": 128,
+}
+
+EXPECTED_LOGICAL_TRIPLES = {
+    "integrated": 273,
+    "strict_bfo_mapping": 157,
+    "cco_extension": 116,
+}
+
+
+FORMAL_HASHES = {
+    "integrated":
+        "81694ddfc0a7587c2d83517f0fc69449a25dc31ae68571b0a63f48aa5ca10aae",
+    "strict_bfo_mapping":
+        "c88cb347742a15fc003cafe2e167f7f784cc4a70653720c11f1e6247e6a3096c",
+    "cco_extension":
+        "bc356b515e29a21d74865101661fe1d81f2da33f86b31bf4c497109e8f9b202b",
+}
+
+FORMAL_BYTE_SIZES = {
+    "integrated": 40785,
+    "strict_bfo_mapping": 24238,
+    "cco_extension": 18092,
+}
+
+
+def sha256(path: Path) -> str:
+    return hashlib.sha256(
+        path.read_bytes()
+    ).hexdigest()
+
+
+class Sosa2023ReleaseRenderingTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.temporary = tempfile.TemporaryDirectory(
+            prefix="sosa-2023-formal-rendering-"
+        )
+        cls.root = Path(cls.temporary.name)
+
+        (
+            cls.processed,
+            cls.counts,
+            cls.source_graph,
+        ) = products.process_active_rows(
+            cls.root / "source"
+        )
+
+        cls.first = products.render_formal_product_set(
+            cls.processed,
+            SYNTHETIC_CONTEXT,
+        )
+
+        cls.second = products.render_formal_product_set(
+            cls.processed,
+            SYNTHETIC_CONTEXT,
+            reverse_input=True,
+        )
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        cls.temporary.cleanup()
+
+    def test_exact_formal_product_inventory(self) -> None:
+        self.assertEqual(
+            tuple(self.first["products"]),
+            products.PRODUCT_ORDER,
+        )
+
+    def test_synthetic_formal_bytes_are_locked(self) -> None:
+        observed_hashes = {
+            key: self.first["products"][key]["sha256"]
+            for key in products.PRODUCT_ORDER
+        }
+
+        observed_sizes = {
+            key: self.first["products"][key]["byte_size"]
+            for key in products.PRODUCT_ORDER
+        }
+
+        self.assertEqual(
+            observed_hashes,
+            FORMAL_HASHES,
+        )
+
+        self.assertEqual(
+            observed_sizes,
+            FORMAL_BYTE_SIZES,
+        )
+
+    def test_exact_formal_graph_partitions(self) -> None:
+        for key in products.PRODUCT_ORDER:
+            with self.subTest(product=key):
+                result = self.first["products"][key]
+
+                self.assertEqual(
+                    result["axiom_count"],
+                    products.PRODUCT_SPECS[key][
+                        "axiom_count"
+                    ],
+                )
+                self.assertEqual(
+                    result["logical_triple_count"],
+                    EXPECTED_LOGICAL_TRIPLES[key],
+                )
+                self.assertEqual(
+                    result["total_triple_count"],
+                    EXPECTED_TOTAL_TRIPLES[key],
+                )
+
+    def test_exact_formal_import_contract(self) -> None:
+        bfo_version = (
+            "http://www.sks.ai/SSN2BFO/releases/"
+            f"2099-01-02/{TRACK_ID}/bfo-mapping"
+        )
+
+        expected = {
+            "integrated": (
+                "http://www.w3.org/ns/sosa/",
+                "http://www.w3.org/ns/sosa/systems/",
+                "http://www.w3.org/ns/sosa/sampling/",
+                (
+                    "https://www.commoncoreontologies.org/"
+                    "CommonCoreOntologiesMerged"
+                ),
+            ),
+            "strict_bfo_mapping": (),
+            "cco_extension": (bfo_version,),
+        }
+
+        observed = {
+            key: self.first["products"][key]["imports"]
+            for key in products.PRODUCT_ORDER
+        }
+
+        self.assertEqual(observed, expected)
+
+    def test_source_declaration_overlay_is_not_published_import(self) -> None:
+        overlay = (
+            "http://www.sks.ai/SSN2BFO/development/"
+            "sosa-next/source-declaration-overlay"
+        )
+
+        for key in products.PRODUCT_ORDER:
+            with self.subTest(product=key):
+                self.assertNotIn(
+                    overlay,
+                    self.first["products"][key][
+                        "imports"
+                    ],
+                )
+
+    def test_no_temporary_development_identity_survives(self) -> None:
+        for key in products.PRODUCT_ORDER:
+            with self.subTest(product=key):
+                serialized = self.first["products"][key][
+                    "serialized_bytes"
+                ]
+
+                self.assertNotIn(
+                    b"sosa-next",
+                    serialized,
+                )
+                self.assertNotIn(
+                    b"/development/",
+                    serialized,
+                )
+
+    def test_stable_and_version_iris_are_exact(self) -> None:
+        expected_stable = {
+            "integrated":
+                f"http://www.sks.ai/SSN2BFO/{TRACK_ID}/integrated",
+            "strict_bfo_mapping":
+                f"http://www.sks.ai/SSN2BFO/{TRACK_ID}/bfo-mapping",
+            "cco_extension":
+                f"http://www.sks.ai/SSN2BFO/{TRACK_ID}/cco-extension",
+        }
+
+        expected_versions = {
+            "integrated":
+                "http://www.sks.ai/SSN2BFO/releases/"
+                f"2099-01-02/{TRACK_ID}/integrated",
+            "strict_bfo_mapping":
+                "http://www.sks.ai/SSN2BFO/releases/"
+                f"2099-01-02/{TRACK_ID}/bfo-mapping",
+            "cco_extension":
+                "http://www.sks.ai/SSN2BFO/releases/"
+                f"2099-01-02/{TRACK_ID}/cco-extension",
+        }
+
+        self.assertEqual(
+            {
+                key: self.first["products"][key][
+                    "stable_ontology_iri"
+                ]
+                for key in products.PRODUCT_ORDER
+            },
+            expected_stable,
+        )
+
+        self.assertEqual(
+            {
+                key: self.first["products"][key][
+                    "version_iri"
+                ]
+                for key in products.PRODUCT_ORDER
+            },
+            expected_versions,
+        )
+
+    def test_formal_logical_graphs_match_development_products(self) -> None:
+        for key in products.PRODUCT_ORDER:
+            with self.subTest(product=key):
+                development = Graph().parse(
+                    products.MAINTAINED_PRODUCTS[key],
+                    format="turtle",
+                )
+
+                development_logical = (
+                    products.logical_graph(
+                        development,
+                        products.PRODUCT_SPECS[key][
+                            "ontology_iri"
+                        ],
+                    )
+                )
+
+                formal_logical = self.first["products"][
+                    key
+                ]["logical_graph"]
+
+                self.assertTrue(
+                    isomorphic(
+                        development_logical,
+                        formal_logical,
+                    )
+                )
+
+    def test_formal_modular_union_is_integrated(self) -> None:
+        self.assertEqual(
+            self.first[
+                "combined_logical_triple_count"
+            ],
+            273,
+        )
+        self.assertTrue(
+            self.first["logical_union_isomorphic"]
+        )
+
+    def test_formal_import_triples_match_contract(self) -> None:
+        for key in products.PRODUCT_ORDER:
+            with self.subTest(product=key):
+                result = self.first["products"][key]
+
+                graph = Graph().parse(
+                    data=result["serialized_bytes"],
+                    format="turtle",
+                )
+
+                observed = {
+                    str(value)
+                    for value in graph.objects(
+                        None,
+                        OWL.imports,
+                    )
+                }
+
+                self.assertEqual(
+                    observed,
+                    set(result["imports"]),
+                )
+
+    def test_independent_renders_are_byte_identical(self) -> None:
+        for key in products.PRODUCT_ORDER:
+            with self.subTest(product=key):
+                self.assertEqual(
+                    self.first["products"][key][
+                        "serialized_bytes"
+                    ],
+                    self.second["products"][key][
+                        "serialized_bytes"
+                    ],
+                )
+
+                self.assertEqual(
+                    self.first["products"][key][
+                        "sha256"
+                    ],
+                    self.second["products"][key][
+                        "sha256"
+                    ],
+                )
+
+    def test_renderer_does_not_change_maintained_products(self) -> None:
+        expected = {
+            "integrated":
+                "7ce45659e4d84ac089ae90c3279fa46d169d763ec487c34cb3c533eb0e6c197c",
+            "strict_bfo_mapping":
+                "67bb58ea543e654ace41c0d1a393b2a3f92426c693f5100f0aa3ba35f3b005d2",
+            "cco_extension":
+                "e65e96f15a55e19fc43be8dbda6e56351ef40bbd6e0fa9368a240e83c5d6bb69",
+        }
+
+        self.assertEqual(
+            {
+                key: sha256(
+                    products.MAINTAINED_PRODUCTS[key]
+                )
+                for key in products.PRODUCT_ORDER
+            },
+            expected,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/generate_sosa_next_products.py
+++ b/tools/generate_sosa_next_products.py
@@ -21,6 +21,10 @@ import check_sosa_next_mapping as mapping_checker
 import generate_mapping_from_coms as coms
 import modular_products
 import publication_metadata
+from release_context import (
+    FormalReleaseContext,
+    validate_formal_release_context,
+)
 from product_dispositions import (
     axiom_input_from_canonical_row,
     classify_target_category,
@@ -30,6 +34,26 @@ from product_dispositions import (
 REPO_ROOT = Path(__file__).resolve().parents[1]
 WORKBOOK = REPO_ROOT / "mappings/SOSA-next-to-BFO-COMS.xlsx"
 METADATA_PATH = REPO_ROOT / "config/publication-metadata.toml"
+
+SOSA_2023_PUBLICATION_METADATA_PATH = (
+    REPO_ROOT
+    / "config/sosa-2023-publication-metadata.toml"
+)
+
+FORMAL_GENERATED_NOTICE = (
+    "# Generated from the governed SOSA 2023 COMS mapping and "
+    "publication metadata. Do not edit this ontology directly."
+)
+
+FORMAL_INTEGRATED_EXTERNAL_IMPORTS = (
+    "http://www.w3.org/ns/sosa/",
+    "http://www.w3.org/ns/sosa/systems/",
+    "http://www.w3.org/ns/sosa/sampling/",
+    (
+        "https://www.commoncoreontologies.org/"
+        "CommonCoreOntologiesMerged"
+    ),
+)
 
 GENERATED_NOTICE = (
     "# Generated from mappings/SOSA-next-to-BFO-COMS.xlsx. "
@@ -877,6 +901,312 @@ def serialize_product(
     }
 
     return serialized, logical, result
+
+
+
+def load_sosa_2023_publication_metadata() -> Any:
+    """Load the governed SOSA-2023 formal-publication authority."""
+
+    return publication_metadata.load_metadata(
+        SOSA_2023_PUBLICATION_METADATA_PATH,
+        product_order=PRODUCT_ORDER,
+    )
+
+
+def formal_product_imports(
+    metadata: Any,
+    product_key: str,
+    context: FormalReleaseContext,
+) -> tuple[str, ...]:
+    """Return the exact SOSA-2023 formal ontology import contract."""
+
+    validated_context = validate_formal_release_context(
+        context
+    )
+
+    if product_key == "integrated":
+        return FORMAL_INTEGRATED_EXTERNAL_IMPORTS
+
+    if product_key == "strict_bfo_mapping":
+        return ()
+
+    if product_key == "cco_extension":
+        return (
+            publication_metadata.release_version_iri(
+                metadata,
+                "strict_bfo_mapping",
+                validated_context,
+            ),
+        )
+
+    raise RuntimeError(
+        f"Unsupported SOSA-2023 formal product: {product_key}"
+    )
+
+
+def serialize_formal_product(
+    metadata: Any,
+    context: FormalReleaseContext,
+    product_key: str,
+    records: list[dict[str, Any]],
+) -> tuple[bytes, Graph, dict[str, Any]]:
+    """Render one immutable-context SOSA-2023 product in memory."""
+
+    validated_context = validate_formal_release_context(
+        context
+    )
+
+    spec = PRODUCT_SPECS[product_key]
+
+    observed_categories = {
+        record["category"]
+        for record in records
+    }
+
+    if not observed_categories <= spec["categories"]:
+        raise RuntimeError(
+            f"{product_key}: prohibited formal categories "
+            f"{sorted(observed_categories - spec['categories'])}"
+        )
+
+    if len(records) != spec["axiom_count"]:
+        raise RuntimeError(
+            f"{product_key}: expected "
+            f"{spec['axiom_count']} formal axioms; "
+            f"found {len(records)}"
+        )
+
+    body = body_bytes(records)
+    body_hash = sha256_bytes(body)
+
+    if body_hash != spec["body_sha256"]:
+        raise RuntimeError(
+            f"{product_key}: formal axiom-body hash mismatch\n"
+            f"Expected: {spec['body_sha256']}\n"
+            f"Actual:   {body_hash}"
+        )
+
+    imports = formal_product_imports(
+        metadata,
+        product_key,
+        validated_context,
+    )
+
+    header = (
+        publication_metadata
+        .render_ontology_header_bytes(
+            metadata,
+            product_key,
+            imports,
+            generated_notice=FORMAL_GENERATED_NOTICE,
+            prefixes=spec["prefixes"],
+            context=validated_context,
+        )
+    )
+
+    serialized = (
+        header
+        if not body
+        else header + b"\n" + body
+    )
+
+    issues = (
+        publication_metadata
+        .validate_serialized_ontology_header(
+            serialized,
+            metadata,
+            product_key,
+            imports,
+            generated_notice=FORMAL_GENERATED_NOTICE,
+            prefixes=spec["prefixes"],
+            mode="release",
+            context=validated_context,
+        )
+    )
+
+    if issues:
+        rendered = "\n".join(
+            (
+                f"{issue.code}: {issue.field}: "
+                f"{issue.message}"
+            )
+            for issue in issues
+        )
+
+        raise RuntimeError(
+            f"{product_key}: formal metadata validation "
+            f"failed:\n{rendered}"
+        )
+
+    graph = Graph()
+    graph.parse(
+        data=serialized.decode("utf-8"),
+        format="turtle",
+    )
+
+    logical = (
+        publication_metadata
+        .strip_emitted_ontology_header(
+            graph,
+            metadata,
+            product_key,
+            imports,
+            validated_context,
+        )
+    )
+
+    if len(logical) != spec["logical_triple_count"]:
+        raise RuntimeError(
+            f"{product_key}: expected "
+            f"{spec['logical_triple_count']} formal logical "
+            f"triples; found {len(logical)}"
+        )
+
+    formal_metadata_count = len(
+        publication_metadata.ontology_metadata_triples(
+            metadata,
+            product_key,
+            validated_context,
+        )
+    )
+
+    if formal_metadata_count != 10:
+        raise RuntimeError(
+            f"{product_key}: expected 10 formal ontology "
+            f"metadata annotations; found {formal_metadata_count}"
+        )
+
+    expected_total = (
+        spec["logical_triple_count"]
+        + 1
+        + len(imports)
+        + formal_metadata_count
+    )
+
+    if len(graph) != expected_total:
+        raise RuntimeError(
+            f"{product_key}: expected {expected_total} formal "
+            f"triples; found {len(graph)}"
+        )
+
+    if b"sosa-next" in serialized:
+        raise RuntimeError(
+            f"{product_key}: formal serialization retains "
+            "the temporary sosa-next development identity"
+        )
+
+    product_hash = sha256_bytes(serialized)
+
+    result = {
+        "product_key": product_key,
+        "stable_ontology_iri": (
+            next(
+                product.stable_ontology_iri
+                for product in metadata.products
+                if product.key == product_key
+            )
+        ),
+        "version_iri": (
+            publication_metadata.release_version_iri(
+                metadata,
+                product_key,
+                validated_context,
+            )
+        ),
+        "imports": imports,
+        "axiom_count": len(records),
+        "logical_triple_count": len(logical),
+        "total_triple_count": len(graph),
+        "body_sha256": body_hash,
+        "sha256": product_hash,
+        "byte_size": len(serialized),
+        "serialized_bytes": serialized,
+        "logical_graph": logical,
+    }
+
+    return serialized, logical, result
+
+
+def render_formal_product_set(
+    processed: list[coms.ProcessedRow],
+    context: FormalReleaseContext,
+    *,
+    reverse_input: bool = False,
+) -> dict[str, Any]:
+    """Render all three SOSA-2023 formal products without writing them."""
+
+    validated_context = validate_formal_release_context(
+        context
+    )
+
+    metadata = load_sosa_2023_publication_metadata()
+
+    records, categories = build_product_records(
+        processed
+    )
+
+    products: dict[str, dict[str, Any]] = {}
+    logical_graphs: dict[str, Graph] = {}
+
+    for product_key in PRODUCT_ORDER:
+        if product_key == "integrated":
+            supplied = [
+                *records["strict_bfo_mapping"],
+                *records["cco_extension"],
+            ]
+        else:
+            supplied = list(records[product_key])
+
+        if reverse_input:
+            supplied = list(reversed(supplied))
+
+        _, logical, result = serialize_formal_product(
+            metadata,
+            validated_context,
+            product_key,
+            supplied,
+        )
+
+        products[product_key] = result
+        logical_graphs[product_key] = logical
+
+    modular_union = Graph()
+
+    for product_key in MODULAR_PRODUCT_ORDER:
+        for triple in logical_graphs[product_key]:
+            modular_union.add(triple)
+
+    modular_sum = sum(
+        len(logical_graphs[product_key])
+        for product_key in MODULAR_PRODUCT_ORDER
+    )
+
+    if modular_sum != 273 or len(modular_union) != 273:
+        raise RuntimeError(
+            "Expected 273 SOSA-2023 formal modular logical "
+            f"triples; sum={modular_sum}, "
+            f"distinct={len(modular_union)}"
+        )
+
+    if not isomorphic(
+        modular_union,
+        logical_graphs["integrated"],
+    ):
+        raise RuntimeError(
+            "The formal BFO+CCO modular union differs from "
+            "the formal Integrated logical graph."
+        )
+
+    return {
+        "context": validated_context,
+        "metadata": metadata,
+        "category_counts": categories,
+        "products": products,
+        "combined_logical_triple_count": len(
+            modular_union
+        ),
+        "logical_union_isomorphic": True,
+    }
 
 
 def build_candidate(

--- a/tools/publication_metadata.py
+++ b/tools/publication_metadata.py
@@ -847,7 +847,11 @@ def _iri_validation(
         issues.append(_issue(code, field, problem))
 
 
-def validate_metadata(metadata: PublicationMetadata) -> tuple[ValidationIssue, ...]:
+def validate_metadata(
+    metadata: PublicationMetadata,
+    *,
+    product_order: tuple[str, ...] = PRODUCT_ORDER,
+) -> tuple[ValidationIssue, ...]:
     """Return semantic issues in deterministic policy order."""
 
     issues: list[ValidationIssue] = []
@@ -950,11 +954,11 @@ def validate_metadata(metadata: PublicationMetadata) -> tuple[ValidationIssue, .
         )
 
     keys = tuple(product.key for product in metadata.products)
-    if set(keys) != set(PRODUCT_ORDER) or len(keys) != len(PRODUCT_ORDER):
+    if set(keys) != set(product_order) or len(keys) != len(product_order):
         issues.append(
-            _issue("PRODUCT_SET", "products", "expected exactly: " + ", ".join(PRODUCT_ORDER))
+            _issue("PRODUCT_SET", "products", "expected exactly: " + ", ".join(product_order))
         )
-    elif keys != PRODUCT_ORDER:
+    elif keys != product_order:
         issues.append(_issue("PRODUCT_ORDER", "products", "products are not in canonical order"))
 
     for product in metadata.products:
@@ -1030,7 +1034,11 @@ def validate_metadata(metadata: PublicationMetadata) -> tuple[ValidationIssue, .
     return tuple(issues)
 
 
-def load_metadata(path: str | Path) -> PublicationMetadata:
+def load_metadata(
+    path: str | Path,
+    *,
+    product_order: tuple[str, ...] = PRODUCT_ORDER,
+) -> PublicationMetadata:
     """Load UTF-8 TOML and return validated schema-4 metadata."""
 
     source = Path(path)
@@ -1067,16 +1075,16 @@ def load_metadata(path: str | Path) -> PublicationMetadata:
     }
 
     products_table = (
-        _table(top["products"], "products", PRODUCT_ORDER, issues)
+        _table(top["products"], "products", product_order, issues)
         if "products" in top
         else {}
     )
-    if set(products_table) == set(PRODUCT_ORDER) and tuple(products_table) != PRODUCT_ORDER:
+    if set(products_table) == set(product_order) and tuple(products_table) != product_order:
         issues.append(_issue("PRODUCT_ORDER", "products", "products are not in canonical order"))
 
     release_base = publication_values.get("release_iri_base")
     products: list[ProductPublicationMetadata] = []
-    for key in PRODUCT_ORDER:
+    for key in product_order:
         if key not in products_table:
             continue
         product_table = _table(
@@ -1115,7 +1123,10 @@ def load_metadata(path: str | Path) -> PublicationMetadata:
         publication=publication,
         products=tuple(products),
     )
-    semantic_issues = validate_metadata(metadata)
+    semantic_issues = validate_metadata(
+        metadata,
+        product_order=product_order,
+    )
     if semantic_issues:
         raise PublicationMetadataError(semantic_issues)
     return metadata

--- a/tools/run_validation_suite.py
+++ b/tools/run_validation_suite.py
@@ -431,6 +431,8 @@ def compile_check() -> StepResult:
             "tests/test_check_sosa_next_mapping.py",
             "tests/test_sosa_next_products.py",
             "tests/test_sosa_next_consumer_stack.py",
+            "tests/test_sosa_2023_publication_metadata.py",
+            "tests/test_sosa_2023_release_rendering.py",
             "tests/test_robot_template_generation_pilot.py",
             "tests/test_robot_property_chain_generation_pilot.py",
             "tests/test_robot_diff_pilot.py",
@@ -609,6 +611,38 @@ def run_validation_suite(args: argparse.Namespace) -> int:
                     "tests",
                     "-p",
                     "test_sosa_next_consumer_stack.py",
+                ],
+            )
+        )
+    if results[-1].passed:
+        results.append(
+            run_command(
+                "SOSA-2023 publication-metadata focused tests",
+                [
+                    sys.executable,
+                    "-m",
+                    "unittest",
+                    "discover",
+                    "-s",
+                    "tests",
+                    "-p",
+                    "test_sosa_2023_publication_metadata.py",
+                ],
+            )
+        )
+    if results[-1].passed:
+        results.append(
+            run_command(
+                "SOSA-2023 formal-rendering focused tests",
+                [
+                    sys.executable,
+                    "-m",
+                    "unittest",
+                    "discover",
+                    "-s",
+                    "tests",
+                    "-p",
+                    "test_sosa_2023_release_rendering.py",
                 ],
             )
         )


### PR DESCRIPTION
## Summary

Add governed publication metadata and deterministic formal ontology rendering for the SOSA-2023 source-version track.

- add a separate three-product SOSA-2023 publication-metadata authority
- generalize the common metadata loader to accept an explicit canonical product order while preserving the current-track default
- add pure in-memory formal rendering for Integrated, Strict BFO Mapping, and CCO Extension
- use immutable SOSA-2023 stable ontology IRIs and date-based version IRIs
- keep formal BFO Mapping import-free
- rewrite CCO Extension to the same-release formal BFO Mapping version IRI
- publish Integrated with the official SOSA root, Systems, Sampling, and merged CCO/BFO imports
- retain the local source-declaration overlay as governed validation/source evidence rather than a published ontology import
- add focused publication-metadata and formal-rendering gates to the authoritative validation suite
- update architecture and formal-integration documentation
- leave manifest, package, catalog, archive, rehearsal, workbook, and pinned-source authorities unchanged

## Synthetic formal byte contract

Using the fixed synthetic `2099-01-02` release context:

- Integrated
  - 45 direct axioms
  - 273 logical triples
  - 288 total triples
  - SHA-256 `81694ddfc0a7587c2d83517f0fc69449a25dc31ae68571b0a63f48aa5ca10aae`
- Strict BFO Mapping
  - 21 direct axioms
  - 157 logical triples
  - 168 total triples
  - SHA-256 `c88cb347742a15fc003cafe2e167f7f784cc4a70653720c11f1e6247e6a3096c`
- CCO Extension
  - 24 direct axioms
  - 116 logical triples
  - 128 total triples
  - SHA-256 `bc356b515e29a21d74865101661fe1d81f2da33f86b31bf4c497109e8f9b202b`

Independent renders are byte-identical, and each formal logical graph is isomorphic to its maintained development product.

## Validation

`make check` completed successfully.

The full validation suite includes the new:

- SOSA-2023 publication-metadata focused tests
- SOSA-2023 formal-rendering focused tests

Additional preservation gates confirmed:

- current publication metadata unchanged
- current SSN/SOSA ontology products unchanged
- maintained SOSA-2023 development products unchanged
- manifest/package/archive code unchanged
- workbook and pinned source files unchanged
- full validation preserved the working-tree boundary

## Next milestone

Define the SOSA-2023 manifest/schema authority and exact formal-release evidence model. Package construction, package catalog, archive, release notes, rehearsal, and publication remain deferred.
