### PR TITLE
Add SOSA-2023 release manifest authority

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: validate validate-write audit-write legacy-audit-write compile check check-coms check-sosa-next check-coms-row-identities check-coms-product-dispositions check-alignment-core check-strict-bfo-mapping check-cco-extension check-publication-metadata check-release-rendering check-release-package check-release-archive check-release-rehearsal check-placeholder-catalog-migration watch-coms coms-status post-merge-check status diffstat generate-sosa-next-products check-sosa-next-products check-sosa-next-consumer-stack check-sosa-2023-publication-rendering check-sosa-source-version check-product-role-policy check-sosa-release-scope
+.PHONY: validate validate-write audit-write legacy-audit-write compile check check-coms check-sosa-next check-coms-row-identities check-coms-product-dispositions check-alignment-core check-strict-bfo-mapping check-cco-extension check-publication-metadata check-release-rendering check-release-package check-release-archive check-release-rehearsal check-placeholder-catalog-migration watch-coms coms-status post-merge-check status diffstat generate-sosa-next-products check-sosa-next-products check-sosa-next-consumer-stack check-sosa-2023-publication-rendering check-sosa-2023-release-manifest check-sosa-source-version check-product-role-policy check-sosa-release-scope
 
 validate:
 	PYTHONDONTWRITEBYTECODE=1 python tools/run_validation_suite.py
@@ -61,6 +61,7 @@ compile:
 		tests/test_sosa_next_consumer_stack.py \
 		tests/test_sosa_2023_publication_metadata.py \
 		tests/test_sosa_2023_release_rendering.py \
+		tests/test_sosa_2023_release_manifest.py \
 		tests/test_robot_diff_pilot.py \
 		tests/test_robot_extract_pilot.py \
 		tests/test_robot_query_equivalence_pilot.py \
@@ -137,6 +138,9 @@ check-sosa-next-consumer-stack:
 check-sosa-2023-publication-rendering:
 	PYTHONDONTWRITEBYTECODE=1 python -m unittest discover -s tests -p 'test_sosa_2023_publication_metadata.py'
 	PYTHONDONTWRITEBYTECODE=1 python -m unittest discover -s tests -p 'test_sosa_2023_release_rendering.py'
+
+check-sosa-2023-release-manifest:
+	PYTHONDONTWRITEBYTECODE=1 python -m unittest discover -s tests -p 'test_sosa_2023_release_manifest.py'
 
 check-coms:
 	PYTHONDONTWRITEBYTECODE=1 python tools/check_coms_mapping.py

--- a/config/sosa-2023-release-manifest-schema-v1.json
+++ b/config/sosa-2023-release-manifest-schema-v1.json
@@ -1,0 +1,1524 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/BFO-Mappings/SSN-to-BFO/blob/main/config/sosa-2023-release-manifest-schema-v1.json",
+  "title": "SOSA-2023 Release Manifest Schema v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "release_identifier",
+    "release_date",
+    "git_tag",
+    "source_commit",
+    "repository_iri",
+    "inputs",
+    "product_order",
+    "products",
+    "dependencies",
+    "validation_environment",
+    "validation",
+    "included_files"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": 1
+    },
+    "release_identifier": {
+      "$ref": "#/$defs/releaseDate"
+    },
+    "release_date": {
+      "$ref": "#/$defs/releaseDate"
+    },
+    "git_tag": {
+      "type": "string",
+      "pattern": "^v[0-9]{4}-[0-9]{2}-[0-9]{2}$"
+    },
+    "source_commit": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{40}$"
+    },
+    "repository_iri": {
+      "$ref": "#/$defs/httpIri"
+    },
+    "inputs": {
+      "type": "array",
+      "minItems": 28,
+      "maxItems": 28,
+      "prefixItems": [
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/input"
+            },
+            {
+              "properties": {
+                "key": {
+                  "const": "coms_workbook"
+                },
+                "package_path": {
+                  "const": "sources/SOSA-2023-to-BFO-COMS.xlsx"
+                },
+                "source_path": {
+                  "const": "mappings/SOSA-next-to-BFO-COMS.xlsx"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/input"
+            },
+            {
+              "properties": {
+                "key": {
+                  "const": "publication_metadata"
+                },
+                "package_path": {
+                  "const": "sources/sosa-2023-publication-metadata.toml"
+                },
+                "source_path": {
+                  "const": "config/sosa-2023-publication-metadata.toml"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/input"
+            },
+            {
+              "properties": {
+                "key": {
+                  "const": "source_version"
+                },
+                "package_path": {
+                  "const": "sources/sosa-source-version.toml"
+                },
+                "source_path": {
+                  "const": "config/sosa-source-version.toml"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/input"
+            },
+            {
+              "properties": {
+                "key": {
+                  "const": "release_scope"
+                },
+                "package_path": {
+                  "const": "sources/sosa-release-scope.toml"
+                },
+                "source_path": {
+                  "const": "config/sosa-release-scope.toml"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/input"
+            },
+            {
+              "properties": {
+                "key": {
+                  "const": "product_role_policy"
+                },
+                "package_path": {
+                  "const": "sources/product-role-policy.toml"
+                },
+                "source_path": {
+                  "const": "config/product-role-policy.toml"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/input"
+            },
+            {
+              "properties": {
+                "key": {
+                  "const": "development_integrated"
+                },
+                "package_path": {
+                  "const": null
+                },
+                "source_path": {
+                  "const": "releases/sosa-next/sosa-integrated.ttl"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/input"
+            },
+            {
+              "properties": {
+                "key": {
+                  "const": "development_strict_bfo_mapping"
+                },
+                "package_path": {
+                  "const": null
+                },
+                "source_path": {
+                  "const": "releases/sosa-next/sosa-bfo-mapping.ttl"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/input"
+            },
+            {
+              "properties": {
+                "key": {
+                  "const": "development_cco_extension"
+                },
+                "package_path": {
+                  "const": null
+                },
+                "source_path": {
+                  "const": "releases/sosa-next/sosa-cco-extension.ttl"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/input"
+            },
+            {
+              "properties": {
+                "key": {
+                  "const": "pinned_sosa"
+                },
+                "package_path": {
+                  "const": null
+                },
+                "source_path": {
+                  "const": "src/sosa-next/imports/sosa.ttl"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/input"
+            },
+            {
+              "properties": {
+                "key": {
+                  "const": "pinned_sosa_common"
+                },
+                "package_path": {
+                  "const": null
+                },
+                "source_path": {
+                  "const": "src/sosa-next/imports/sosa-common.ttl"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/input"
+            },
+            {
+              "properties": {
+                "key": {
+                  "const": "pinned_sosa_observation"
+                },
+                "package_path": {
+                  "const": null
+                },
+                "source_path": {
+                  "const": "src/sosa-next/imports/sosa-observation.ttl"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/input"
+            },
+            {
+              "properties": {
+                "key": {
+                  "const": "pinned_sosa_actuation"
+                },
+                "package_path": {
+                  "const": null
+                },
+                "source_path": {
+                  "const": "src/sosa-next/imports/sosa-actuation.ttl"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/input"
+            },
+            {
+              "properties": {
+                "key": {
+                  "const": "pinned_sosa_sampling"
+                },
+                "package_path": {
+                  "const": null
+                },
+                "source_path": {
+                  "const": "src/sosa-next/imports/sosa-sampling.ttl"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/input"
+            },
+            {
+              "properties": {
+                "key": {
+                  "const": "pinned_sosa_deprecated"
+                },
+                "package_path": {
+                  "const": null
+                },
+                "source_path": {
+                  "const": "src/sosa-next/imports/sosa-deprecated.ttl"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/input"
+            },
+            {
+              "properties": {
+                "key": {
+                  "const": "pinned_sosa_system"
+                },
+                "package_path": {
+                  "const": null
+                },
+                "source_path": {
+                  "const": "src/sosa-next/imports/sosa-system.ttl"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/input"
+            },
+            {
+              "properties": {
+                "key": {
+                  "const": "pinned_sample_relations"
+                },
+                "package_path": {
+                  "const": null
+                },
+                "source_path": {
+                  "const": "src/sosa-next/imports/sample-relations.ttl"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/input"
+            },
+            {
+              "properties": {
+                "key": {
+                  "const": "source_declaration_overlay"
+                },
+                "package_path": {
+                  "const": null
+                },
+                "source_path": {
+                  "const": "src/sosa-next/imports/sosa-source-declaration-overlay.ttl"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/input"
+            },
+            {
+              "properties": {
+                "key": {
+                  "const": "release_notes"
+                },
+                "package_path": {
+                  "const": "RELEASE-NOTES.md"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/input"
+            },
+            {
+              "properties": {
+                "key": {
+                  "const": "license"
+                },
+                "package_path": {
+                  "const": "LICENSE"
+                },
+                "source_path": {
+                  "const": "LICENSE"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/input"
+            },
+            {
+              "properties": {
+                "key": {
+                  "const": "module_coms_row_identity"
+                },
+                "package_path": {
+                  "const": null
+                },
+                "source_path": {
+                  "const": "tools/coms_row_identity.py"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/input"
+            },
+            {
+              "properties": {
+                "key": {
+                  "const": "module_product_dispositions"
+                },
+                "package_path": {
+                  "const": null
+                },
+                "source_path": {
+                  "const": "tools/product_dispositions.py"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/input"
+            },
+            {
+              "properties": {
+                "key": {
+                  "const": "module_modular_products"
+                },
+                "package_path": {
+                  "const": null
+                },
+                "source_path": {
+                  "const": "tools/modular_products.py"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/input"
+            },
+            {
+              "properties": {
+                "key": {
+                  "const": "module_publication_metadata"
+                },
+                "package_path": {
+                  "const": null
+                },
+                "source_path": {
+                  "const": "tools/publication_metadata.py"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/input"
+            },
+            {
+              "properties": {
+                "key": {
+                  "const": "module_release_context"
+                },
+                "package_path": {
+                  "const": null
+                },
+                "source_path": {
+                  "const": "tools/release_context.py"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/input"
+            },
+            {
+              "properties": {
+                "key": {
+                  "const": "module_check_sosa_next_mapping"
+                },
+                "package_path": {
+                  "const": null
+                },
+                "source_path": {
+                  "const": "tools/check_sosa_next_mapping.py"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/input"
+            },
+            {
+              "properties": {
+                "key": {
+                  "const": "module_generate_sosa_next_products"
+                },
+                "package_path": {
+                  "const": null
+                },
+                "source_path": {
+                  "const": "tools/generate_sosa_next_products.py"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/input"
+            },
+            {
+              "properties": {
+                "key": {
+                  "const": "manifest_schema"
+                },
+                "package_path": {
+                  "const": null
+                },
+                "source_path": {
+                  "const": "config/sosa-2023-release-manifest-schema-v1.json"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/input"
+            },
+            {
+              "properties": {
+                "key": {
+                  "const": "module_sosa_2023_release_manifest"
+                },
+                "package_path": {
+                  "const": null
+                },
+                "source_path": {
+                  "const": "tools/sosa_2023_release_manifest.py"
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "items": false
+    },
+    "product_order": {
+      "const": [
+        "integrated",
+        "strict_bfo_mapping",
+        "cco_extension"
+      ]
+    },
+    "products": {
+      "type": "array",
+      "minItems": 3,
+      "maxItems": 3,
+      "prefixItems": [
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/product"
+            },
+            {
+              "properties": {
+                "key": {
+                  "const": "integrated"
+                },
+                "path": {
+                  "const": "sosa-2023-af425a0454ec00512a5ebfa2873fe35a077f5fda/sosa-integrated.ttl"
+                },
+                "stable_ontology_iri": {
+                  "const": "http://www.sks.ai/SSN2BFO/sosa-2023-af425a0454ec00512a5ebfa2873fe35a077f5fda/integrated"
+                },
+                "imports": {
+                  "minItems": 4,
+                  "maxItems": 4
+                },
+                "byte_size": {
+                  "const": 40785
+                },
+                "ontology_declaration_count": {
+                  "const": 1
+                },
+                "import_count": {
+                  "const": 4
+                },
+                "static_metadata_count": {
+                  "const": 7
+                },
+                "formal_metadata_count": {
+                  "const": 3
+                },
+                "logical_triple_count": {
+                  "const": 273
+                },
+                "total_triple_count": {
+                  "const": 288
+                },
+                "direct_governed_axiom_count": {
+                  "const": 45
+                },
+                "governed_closure_axiom_count": {
+                  "const": 45
+                },
+                "reasoning_mode": {
+                  "const": "independent"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/product"
+            },
+            {
+              "properties": {
+                "key": {
+                  "const": "strict_bfo_mapping"
+                },
+                "path": {
+                  "const": "sosa-2023-af425a0454ec00512a5ebfa2873fe35a077f5fda/sosa-bfo-mapping.ttl"
+                },
+                "stable_ontology_iri": {
+                  "const": "http://www.sks.ai/SSN2BFO/sosa-2023-af425a0454ec00512a5ebfa2873fe35a077f5fda/bfo-mapping"
+                },
+                "imports": {
+                  "minItems": 0,
+                  "maxItems": 0
+                },
+                "byte_size": {
+                  "const": 24238
+                },
+                "ontology_declaration_count": {
+                  "const": 1
+                },
+                "import_count": {
+                  "const": 0
+                },
+                "static_metadata_count": {
+                  "const": 7
+                },
+                "formal_metadata_count": {
+                  "const": 3
+                },
+                "logical_triple_count": {
+                  "const": 157
+                },
+                "total_triple_count": {
+                  "const": 168
+                },
+                "direct_governed_axiom_count": {
+                  "const": 21
+                },
+                "governed_closure_axiom_count": {
+                  "const": 21
+                },
+                "reasoning_mode": {
+                  "const": "independent"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/product"
+            },
+            {
+              "properties": {
+                "key": {
+                  "const": "cco_extension"
+                },
+                "path": {
+                  "const": "sosa-2023-af425a0454ec00512a5ebfa2873fe35a077f5fda/sosa-cco-extension.ttl"
+                },
+                "stable_ontology_iri": {
+                  "const": "http://www.sks.ai/SSN2BFO/sosa-2023-af425a0454ec00512a5ebfa2873fe35a077f5fda/cco-extension"
+                },
+                "imports": {
+                  "minItems": 1,
+                  "maxItems": 1
+                },
+                "byte_size": {
+                  "const": 18092
+                },
+                "ontology_declaration_count": {
+                  "const": 1
+                },
+                "import_count": {
+                  "const": 1
+                },
+                "static_metadata_count": {
+                  "const": 7
+                },
+                "formal_metadata_count": {
+                  "const": 3
+                },
+                "logical_triple_count": {
+                  "const": 116
+                },
+                "total_triple_count": {
+                  "const": 128
+                },
+                "direct_governed_axiom_count": {
+                  "const": 24
+                },
+                "governed_closure_axiom_count": {
+                  "const": 45
+                },
+                "reasoning_mode": {
+                  "const": "independent"
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "items": false
+    },
+    "dependencies": {
+      "type": "array",
+      "minItems": 4,
+      "maxItems": 4,
+      "prefixItems": [
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/dependency"
+            },
+            {
+              "properties": {
+                "key": {
+                  "const": "sosa"
+                },
+                "role": {
+                  "const": "formal external SOSA source ontology dependency"
+                },
+                "path": {
+                  "const": "src/sosa-next/imports/sosa.ttl"
+                },
+                "ontology_iri": {
+                  "const": "http://www.w3.org/ns/sosa/"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/dependency"
+            },
+            {
+              "properties": {
+                "key": {
+                  "const": "sosa_systems"
+                },
+                "role": {
+                  "const": "formal external SOSA Systems ontology dependency"
+                },
+                "path": {
+                  "const": "src/sosa-next/imports/sosa-system.ttl"
+                },
+                "ontology_iri": {
+                  "const": "http://www.w3.org/ns/sosa/systems/"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/dependency"
+            },
+            {
+              "properties": {
+                "key": {
+                  "const": "sosa_sampling"
+                },
+                "role": {
+                  "const": "formal external SOSA Sampling ontology dependency"
+                },
+                "path": {
+                  "const": "src/sosa-next/imports/sosa-sampling.ttl"
+                },
+                "ontology_iri": {
+                  "const": "http://www.w3.org/ns/sosa/sampling/"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/dependency"
+            },
+            {
+              "properties": {
+                "key": {
+                  "const": "merged_cco_bfo"
+                },
+                "role": {
+                  "const": "formal external merged CCO/BFO target ontology dependency"
+                },
+                "path": {
+                  "const": "imports/cco.ttl"
+                },
+                "ontology_iri": {
+                  "const": "https://www.commoncoreontologies.org/CommonCoreOntologiesMerged"
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "items": false
+    },
+    "validation_environment": {
+      "$ref": "#/$defs/validationEnvironment"
+    },
+    "validation": {
+      "$ref": "#/$defs/validation"
+    },
+    "included_files": {
+      "type": "array",
+      "minItems": 11,
+      "maxItems": 11,
+      "prefixItems": [
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/includedFile"
+            },
+            {
+              "properties": {
+                "path": {
+                  "const": "LICENSE"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/includedFile"
+            },
+            {
+              "properties": {
+                "path": {
+                  "const": "RELEASE-NOTES.md"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/includedFile"
+            },
+            {
+              "properties": {
+                "path": {
+                  "const": "catalog-v001.xml"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/includedFile"
+            },
+            {
+              "properties": {
+                "path": {
+                  "const": "sosa-2023-af425a0454ec00512a5ebfa2873fe35a077f5fda/sosa-bfo-mapping.ttl"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/includedFile"
+            },
+            {
+              "properties": {
+                "path": {
+                  "const": "sosa-2023-af425a0454ec00512a5ebfa2873fe35a077f5fda/sosa-cco-extension.ttl"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/includedFile"
+            },
+            {
+              "properties": {
+                "path": {
+                  "const": "sosa-2023-af425a0454ec00512a5ebfa2873fe35a077f5fda/sosa-integrated.ttl"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/includedFile"
+            },
+            {
+              "properties": {
+                "path": {
+                  "const": "sources/SOSA-2023-to-BFO-COMS.xlsx"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/includedFile"
+            },
+            {
+              "properties": {
+                "path": {
+                  "const": "sources/product-role-policy.toml"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/includedFile"
+            },
+            {
+              "properties": {
+                "path": {
+                  "const": "sources/sosa-2023-publication-metadata.toml"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/includedFile"
+            },
+            {
+              "properties": {
+                "path": {
+                  "const": "sources/sosa-release-scope.toml"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/includedFile"
+            },
+            {
+              "properties": {
+                "path": {
+                  "const": "sources/sosa-source-version.toml"
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "items": false
+    }
+  },
+  "$defs": {
+    "releaseDate": {
+      "type": "string",
+      "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$"
+    },
+    "sha256": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    },
+    "relativePath": {
+      "type": "string",
+      "minLength": 1,
+      "pattern": "^(?!/)(?!.*(?:^|/)\\.{1,2}(?:/|$))(?!.*//)(?!.*\\\\)(?![A-Za-z][A-Za-z0-9+.-]*:)(?!.*[\\u0000-\\u001F\\u007F])(?!.*/$).+$"
+    },
+    "httpIri": {
+      "type": "string",
+      "pattern": "^https?://[^#]+$"
+    },
+    "input": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "key",
+        "source_path",
+        "package_path",
+        "sha256",
+        "byte_size"
+      ],
+      "properties": {
+        "key": {
+          "type": "string",
+          "minLength": 1
+        },
+        "source_path": {
+          "$ref": "#/$defs/relativePath"
+        },
+        "package_path": {
+          "oneOf": [
+            {
+              "$ref": "#/$defs/relativePath"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "sha256": {
+          "$ref": "#/$defs/sha256"
+        },
+        "byte_size": {
+          "type": "integer",
+          "minimum": 0
+        }
+      }
+    },
+    "product": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "key",
+        "path",
+        "stable_ontology_iri",
+        "version_iri",
+        "imports",
+        "sha256",
+        "byte_size",
+        "ontology_declaration_count",
+        "import_count",
+        "static_metadata_count",
+        "formal_metadata_count",
+        "logical_triple_count",
+        "total_triple_count",
+        "direct_governed_axiom_count",
+        "governed_closure_axiom_count",
+        "reasoning_mode"
+      ],
+      "properties": {
+        "key": {
+          "enum": [
+            "integrated",
+            "strict_bfo_mapping",
+            "cco_extension"
+          ]
+        },
+        "path": {
+          "$ref": "#/$defs/relativePath"
+        },
+        "stable_ontology_iri": {
+          "$ref": "#/$defs/httpIri"
+        },
+        "version_iri": {
+          "$ref": "#/$defs/httpIri"
+        },
+        "imports": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/httpIri"
+          },
+          "uniqueItems": true
+        },
+        "sha256": {
+          "$ref": "#/$defs/sha256"
+        },
+        "byte_size": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "ontology_declaration_count": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "import_count": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "static_metadata_count": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "formal_metadata_count": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "logical_triple_count": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "total_triple_count": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "direct_governed_axiom_count": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "governed_closure_axiom_count": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "reasoning_mode": {
+          "const": "independent"
+        }
+      }
+    },
+    "dependency": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "key",
+        "role",
+        "path",
+        "ontology_iri",
+        "version_iri",
+        "sha256",
+        "byte_size"
+      ],
+      "properties": {
+        "key": {
+          "type": "string",
+          "minLength": 1
+        },
+        "role": {
+          "type": "string",
+          "minLength": 1
+        },
+        "path": {
+          "$ref": "#/$defs/relativePath"
+        },
+        "ontology_iri": {
+          "$ref": "#/$defs/httpIri"
+        },
+        "version_iri": {
+          "oneOf": [
+            {
+              "$ref": "#/$defs/httpIri"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "sha256": {
+          "$ref": "#/$defs/sha256"
+        },
+        "byte_size": {
+          "type": "integer",
+          "minimum": 0
+        }
+      }
+    },
+    "validationEnvironment": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "python_implementation",
+        "python_version",
+        "java_vendor",
+        "java_version",
+        "java_vm_name",
+        "robot_artifact",
+        "robot_version",
+        "robot_sha256",
+        "toolchain_path",
+        "toolchain_sha256",
+        "requirements_path",
+        "requirements_sha256"
+      ],
+      "properties": {
+        "python_implementation": {
+          "type": "string",
+          "minLength": 1
+        },
+        "python_version": {
+          "type": "string",
+          "minLength": 1
+        },
+        "java_vendor": {
+          "type": "string",
+          "minLength": 1
+        },
+        "java_version": {
+          "type": "string",
+          "minLength": 1
+        },
+        "java_vm_name": {
+          "type": "string",
+          "minLength": 1
+        },
+        "robot_artifact": {
+          "$ref": "#/$defs/httpIri"
+        },
+        "robot_version": {
+          "type": "string",
+          "minLength": 1
+        },
+        "robot_sha256": {
+          "$ref": "#/$defs/sha256"
+        },
+        "toolchain_path": {
+          "$ref": "#/$defs/relativePath"
+        },
+        "toolchain_sha256": {
+          "$ref": "#/$defs/sha256"
+        },
+        "requirements_path": {
+          "$ref": "#/$defs/relativePath"
+        },
+        "requirements_sha256": {
+          "$ref": "#/$defs/sha256"
+        }
+      }
+    },
+    "hermitResult": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "product_key",
+        "status",
+        "fixed_closure_triple_count",
+        "return_code",
+        "reasoned_output_produced",
+        "named_unsatisfiable_class_count",
+        "owl_nothing_equivalent_named_class_count"
+      ],
+      "properties": {
+        "product_key": {
+          "enum": [
+            "integrated",
+            "strict_bfo_mapping",
+            "cco_extension"
+          ]
+        },
+        "status": {
+          "const": "PASS"
+        },
+        "fixed_closure_triple_count": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "return_code": {
+          "const": 0
+        },
+        "reasoned_output_produced": {
+          "const": true
+        },
+        "named_unsatisfiable_class_count": {
+          "const": 0
+        },
+        "owl_nothing_equivalent_named_class_count": {
+          "const": 0
+        }
+      }
+    },
+    "validation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "strict_turtle_parsing",
+        "formal_metadata_validation",
+        "serialized_header_validation",
+        "governed_axiom_reconciliation",
+        "import_graph_validation",
+        "catalog_validation",
+        "checksum_validation",
+        "development_artifact_nonmutation",
+        "deterministic_package_rebuild",
+        "hermit_results"
+      ],
+      "properties": {
+        "strict_turtle_parsing": {
+          "const": true
+        },
+        "formal_metadata_validation": {
+          "const": true
+        },
+        "serialized_header_validation": {
+          "const": true
+        },
+        "governed_axiom_reconciliation": {
+          "const": true
+        },
+        "import_graph_validation": {
+          "const": true
+        },
+        "catalog_validation": {
+          "const": true
+        },
+        "checksum_validation": {
+          "const": true
+        },
+        "development_artifact_nonmutation": {
+          "const": true
+        },
+        "deterministic_package_rebuild": {
+          "const": true
+        },
+        "hermit_results": {
+          "type": "array",
+          "minItems": 3,
+          "maxItems": 3,
+          "prefixItems": [
+            {
+              "allOf": [
+                {
+                  "$ref": "#/$defs/hermitResult"
+                },
+                {
+                  "properties": {
+                    "product_key": {
+                      "const": "integrated"
+                    },
+                    "status": {
+                      "const": "PASS"
+                    },
+                    "fixed_closure_triple_count": {
+                      "const": 15130
+                    },
+                    "return_code": {
+                      "const": 0
+                    },
+                    "reasoned_output_produced": {
+                      "const": true
+                    },
+                    "named_unsatisfiable_class_count": {
+                      "const": 0
+                    },
+                    "owl_nothing_equivalent_named_class_count": {
+                      "const": 0
+                    }
+                  }
+                }
+              ]
+            },
+            {
+              "allOf": [
+                {
+                  "$ref": "#/$defs/hermitResult"
+                },
+                {
+                  "properties": {
+                    "product_key": {
+                      "const": "strict_bfo_mapping"
+                    },
+                    "status": {
+                      "const": "PASS"
+                    },
+                    "fixed_closure_triple_count": {
+                      "const": 15014
+                    },
+                    "return_code": {
+                      "const": 0
+                    },
+                    "reasoned_output_produced": {
+                      "const": true
+                    },
+                    "named_unsatisfiable_class_count": {
+                      "const": 0
+                    },
+                    "owl_nothing_equivalent_named_class_count": {
+                      "const": 0
+                    }
+                  }
+                }
+              ]
+            },
+            {
+              "allOf": [
+                {
+                  "$ref": "#/$defs/hermitResult"
+                },
+                {
+                  "properties": {
+                    "product_key": {
+                      "const": "cco_extension"
+                    },
+                    "status": {
+                      "const": "PASS"
+                    },
+                    "fixed_closure_triple_count": {
+                      "const": 15141
+                    },
+                    "return_code": {
+                      "const": 0
+                    },
+                    "reasoned_output_produced": {
+                      "const": true
+                    },
+                    "named_unsatisfiable_class_count": {
+                      "const": 0
+                    },
+                    "owl_nothing_equivalent_named_class_count": {
+                      "const": 0
+                    }
+                  }
+                }
+              ]
+            }
+          ],
+          "items": false
+        }
+      }
+    },
+    "includedFile": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "path",
+        "role",
+        "sha256",
+        "byte_size"
+      ],
+      "properties": {
+        "path": {
+          "$ref": "#/$defs/relativePath"
+        },
+        "role": {
+          "type": "string",
+          "minLength": 1
+        },
+        "sha256": {
+          "$ref": "#/$defs/sha256"
+        },
+        "byte_size": {
+          "type": "integer",
+          "minimum": 0
+        }
+      }
+    }
+  },
+  "description": "Canonical manifest schema for the separate immutable SOSA-2023 SSN-to-BFO formal-release track."
+}

--- a/docs/PRODUCT-ARCHITECTURE.md
+++ b/docs/PRODUCT-ARCHITECTURE.md
@@ -205,7 +205,24 @@ The maintained product hashes are:
 | CCO Extension | `e65e96f15a55e19fc43be8dbda6e56351ef40bbd6e0fa9368a240e83c5d6bb69` |
 
 The source-version track remains a separate future formal package, but its
-publication-metadata and formal-rendering layers are now implemented.
+publication-metadata, formal-rendering, and release-manifest evidence layers are now implemented.
+
+The separate manifest authority is
+`config/sosa-2023-release-manifest-schema-v1.json`, implemented by
+`tools/sosa_2023_release_manifest.py`. It deliberately leaves the
+current-track schema-v2 authority unchanged rather than generalizing the two
+release tracks back into one inventory.
+
+Its canonical product inventory is exactly Integrated, Strict BFO Mapping, and
+CCO Extension. Formal HermiT closure evidence is fixed at 15,130, 15,014, and
+15,141 triples respectively. The manifest model also governs source-version
+and pinned-source evidence, development and formal product evidence, exact
+formal imports and prospective package paths, byte-affecting modules,
+validation-environment identity, and the prospective included-file inventory.
+
+The source-declaration overlay remains governed source/validation evidence; it
+is not a formal ontology import. The manifest authority defines what the
+future SOSA-2023 package must prove, but does not yet build that package.
 
 `config/sosa-2023-publication-metadata.toml` governs the three formal product
 identities. Formal stable ontology IRIs and date-based version-IRI suffixes use
@@ -242,8 +259,9 @@ locked at:
 | BFO Mapping | 157 | 168 | `c88cb347742a15fc003cafe2e167f7f784cc4a70653720c11f1e6247e6a3096c` |
 | CCO Extension | 116 | 128 | `bc356b515e29a21d74865101661fe1d81f2da33f86b31bf4c497109e8f9b202b` |
 
-Package paths, manifest/schema evidence, package catalog, archive, release
-notes, rehearsal, and actual publication remain future formal-package work.
+Formal package paths and manifest/schema evidence are now governed. Package
+construction, package catalog, archive, release notes, rehearsal, and actual
+publication remain future formal-package work.
 
 Focused validation:
 

--- a/docs/VALIDATION-AND-RELEASES.md
+++ b/docs/VALIDATION-AND-RELEASES.md
@@ -161,6 +161,35 @@ These checks are included in `make check` and hosted CI. The formal-rendering
 gate operates entirely in memory and does not create a manifest, package,
 archive, tag, GitHub release, or persistent-IRI deployment.
 
+### SOSA-2023 release-manifest evidence validation
+
+`make check-sosa-2023-release-manifest` validates the separate SOSA-2023
+manifest/schema evidence authority without constructing a release package.
+The authority consists of
+`config/sosa-2023-release-manifest-schema-v1.json`,
+`tools/sosa_2023_release_manifest.py`, and its focused regression contract.
+
+The canonical manifest product order is Integrated, Strict BFO Mapping, and
+CCO Extension. Product-specific formal HermiT closure evidence is fixed at
+15,130, 15,014, and 15,141 triples respectively.
+
+The evidence model records 28 governed inputs: the SOSA-2023 COMS workbook,
+publication metadata, source-version and release-scope authorities,
+product-role policy, all three maintained development products, all eight
+pinned W3C source files, the local source-declaration overlay, release inputs,
+and the byte-affecting implementation modules. It also records four formal
+external dependencies and an 11-member prospective included-file inventory.
+
+Formal product/package identities use the immutable
+`sosa-2023-af425a0454ec00512a5ebfa2873fe35a077f5fda` identity. Paths containing
+the `sosa-next` development alias remain permissible only as governed
+development or pinned-source evidence; they are prohibited from formal product
+and included-file identities.
+
+This milestone governs manifest evidence only. Package construction, package
+catalog generation, checksum production, archive construction, release
+rehearsal, and publication remain later milestones.
+
 ## Publication metadata
 
 Publication metadata is track-specific.
@@ -206,7 +235,7 @@ immutable-release authority status, add `owl:versionIRI`, plain
 development logical graph.
 
 The SOSA-2023 renderer is currently a pure in-memory rendering capability. It
-does not yet define or construct the separate formal package.
+now defines the separate SOSA-2023 release-manifest evidence authority, but does not yet construct the formal package.
 
 ## Release package
 

--- a/reports/sosa-next-formal-release-integration-audit.md
+++ b/reports/sosa-next-formal-release-integration-audit.md
@@ -164,8 +164,7 @@ These capabilities do not yet construct a formal package.
 
 ### Manifest and schema
 
-The manifest model and JSON schema must gain a deliberate SOSA-source-version
-product inventory. Required evidence includes:
+The separate SOSA-2023 manifest model and JSON schema now define the deliberate source-version product inventory. Governed evidence includes:
 
 - workbook identity and SHA-256;
 - all pinned source-file identities and SHA-256 values;
@@ -177,7 +176,21 @@ product inventory. Required evidence includes:
 - catalog-consumption validation;
 - toolchain identity.
 
-The current formal-release authority is manifest schema version 2. The SOSA-2023 package should either receive a deliberate schema revision or a separate schema authority rather than being inserted into the current-track inventory implicitly.
+The current-track formal-release authority remains manifest schema version 2 and is unchanged. SOSA-2023 now has the separate authority `config/sosa-2023-release-manifest-schema-v1.json`, implemented by `tools/sosa_2023_release_manifest.py`. This preserves the separate-package publication model rather than inserting SOSA-2023 into the current-track manifest inventory.
+
+Implemented manifest evidence now fixes:
+
+- product order: Integrated, Strict BFO Mapping, CCO Extension;
+- formal fixed-closure HermiT counts: 15,130 / 15,014 / 15,141;
+- 28 governed input-evidence records;
+- four external formal dependency records;
+- an 11-member prospective included-file inventory;
+- immutable source-version formal package paths with no `sosa-next` identity;
+- preservation of the current manifest schema-v2 and current release tooling.
+
+The authority is intentionally pre-package: it validates the canonical
+manifest/evidence contract without constructing a release directory,
+`manifest.json`, package catalog, checksum inventory, or archive.
 
 ### Package layout
 
@@ -249,7 +262,7 @@ context and approved release notes.
 1. **Completed:** define track-specific SOSA-2023 publication metadata.
 2. **Completed:** implement deterministic formal rendering and same-release
    project-import rewriting.
-3. **Next:** add a source-version manifest/schema authority and exact evidence
+3. **Completed:** add a source-version manifest/schema authority and exact evidence
    model.
 4. **Then:** implement separate-package construction and read-only validation.
 5. **Then:** implement the canonical package catalog.

--- a/reports/sosa-next-product-contract.md
+++ b/reports/sosa-next-product-contract.md
@@ -346,9 +346,15 @@ preserving the four retained current products.
 
 Publication metadata and pure formal ontology rendering are implemented.
 
+The SOSA-2023 release-manifest/schema evidence authority is now implemented as
+a separate schema-v1 contract. It governs the exact three-product inventory,
+immutable formal identities and prospective package paths, formal import
+graph, source/development evidence, validation environment, and
+product-specific HermiT closure counts of 15,130 / 15,014 / 15,141. It does
+not yet construct a formal package.
+
 Remaining formal-release integration work is:
 
-- define the SOSA-2023 manifest/schema authority and exact release evidence;
 - define canonical formal package-relative paths that use the immutable source
   identity rather than the `sosa-next` development alias;
 - construct and validate the separate formal package;

--- a/tests/test_sosa_2023_release_manifest.py
+++ b/tests/test_sosa_2023_release_manifest.py
@@ -1,0 +1,730 @@
+#!/usr/bin/env python3
+"""SOSA-2023 release-manifest evidence-model regressions."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import sys
+import unittest
+from dataclasses import replace
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT / "tools"))
+
+import sosa_2023_release_manifest as manifest  # noqa: E402
+
+
+HASH = "a" * 64
+SYNTHETIC_DATE = "2099-01-02"
+SYNTHETIC_COMMIT = "0123456789abcdef0123456789abcdef01234567"
+
+FORMAL_HASHES = {
+    "integrated":
+        "81694ddfc0a7587c2d83517f0fc69449a25dc31ae68571b0a63f48aa5ca10aae",
+    "strict_bfo_mapping":
+        "c88cb347742a15fc003cafe2e167f7f784cc4a70653720c11f1e6247e6a3096c",
+    "cco_extension":
+        "bc356b515e29a21d74865101661fe1d81f2da33f86b31bf4c497109e8f9b202b",
+}
+
+CURRENT_AUTHORITY_HASHES = {
+    "tools/release_manifest.py":
+        "89105d96dac5fb4d79128b85a5becfa3faec6ac9586507286f0c97e18f0259c5",
+    "config/release-manifest-schema-v2.json":
+        "b0162fb89fe2872f47b13cae9ad1a15aa2b225c6a69b4152a9c894183822191c",
+    "tests/test_release_manifest.py":
+        "6f25af9a9760ed644bd2b4edf36fb3110f9368eba9337ad1f310fa281499ce51",
+    "tools/build_release.py":
+        "3969aa59159dc5caf1c3f69b2ccef5ca9c9bd28d317b97dcb332e5a04fa2eb76",
+    "tools/check_release.py":
+        "3b839dbdb31142eba720a25801eb4f2f28c46a7623e60dd868024d661dfe8d6a",
+    "tools/release_archive.py":
+        "8928d921ac7b850f5ff52449c12013fa2c394b6d1acaff83972134b81741c974",
+    "tools/rehearse_release.py":
+        "737f880da62c0b33de00877404469e98b0cc6634340bbd8bab0f128676d3263d",
+}
+
+
+def sha256(value: bytes) -> str:
+    return hashlib.sha256(value).hexdigest()
+
+
+def file_record(
+    key: str,
+    source_path: str,
+    package_path: str | None,
+) -> manifest.ReleaseManifestInput:
+    source = REPO_ROOT / source_path
+    content = source.read_bytes()
+
+    return manifest.ReleaseManifestInput(
+        key=key,
+        source_path=source_path,
+        package_path=package_path,
+        sha256=sha256(content),
+        byte_size=len(content),
+    )
+
+
+def valid_manifest() -> manifest.ReleaseManifest:
+    inputs = []
+
+    for key, source_path, package_path in manifest.INPUT_POLICIES:
+        if key == "release_notes":
+            source_path = "release-notes/SYNTHETIC-2099-01-02.md"
+
+        assert source_path is not None
+
+        inputs.append(
+            file_record(
+                key,
+                source_path,
+                package_path,
+            )
+        )
+
+    products = tuple(
+        manifest.ReleaseManifestProduct(
+            key=key,
+            path=manifest.PRODUCT_PACKAGE_PATHS[key],
+            stable_ontology_iri=(
+                manifest.PRODUCT_STABLE_ONTOLOGY_IRIS[key]
+            ),
+            version_iri=manifest.expected_version_iri(
+                key,
+                SYNTHETIC_DATE,
+            ),
+            imports=manifest.expected_product_imports(
+                key,
+                SYNTHETIC_DATE,
+            ),
+            sha256=FORMAL_HASHES[key],
+            **manifest.PRODUCT_STATIC_EVIDENCE[key],
+        )
+        for key in manifest.PRODUCT_ORDER
+    )
+
+    dependencies = tuple(
+        manifest.ReleaseManifestDependency(
+            key=key,
+            role=role,
+            path=source_path,
+            ontology_iri=ontology_iri,
+            version_iri=None,
+            sha256=sha256(
+                (REPO_ROOT / source_path).read_bytes()
+            ),
+            byte_size=(
+                REPO_ROOT / source_path
+            ).stat().st_size,
+        )
+        for (
+            key,
+            role,
+            source_path,
+            ontology_iri,
+        ) in manifest.DEPENDENCY_POLICIES
+    )
+
+    environment = manifest.ReleaseManifestValidationEnvironment(
+        python_implementation="CPython",
+        python_version="3.12.4",
+        java_vendor="Fixture Java Vendor",
+        java_version="22.0.2",
+        java_vm_name="Fixture Java VM",
+        robot_artifact="https://example.invalid/robot.jar",
+        robot_version="1.9.7",
+        robot_sha256=HASH,
+        toolchain_path="config/validation-toolchain.env",
+        toolchain_sha256=HASH,
+        requirements_path="requirements/validation.txt",
+        requirements_sha256=HASH,
+    )
+
+    validation = manifest.ReleaseManifestValidation(
+        strict_turtle_parsing=True,
+        formal_metadata_validation=True,
+        serialized_header_validation=True,
+        governed_axiom_reconciliation=True,
+        import_graph_validation=True,
+        catalog_validation=True,
+        checksum_validation=True,
+        development_artifact_nonmutation=True,
+        deterministic_package_rebuild=True,
+        hermit_results=tuple(
+            manifest.ReleaseManifestHermitResult(
+                product_key=key,
+                status="PASS",
+                fixed_closure_triple_count=count,
+                return_code=0,
+                reasoned_output_produced=True,
+                named_unsatisfiable_class_count=0,
+                owl_nothing_equivalent_named_class_count=0,
+            )
+            for key, count in (
+                manifest.FORMAL_FIXED_CLOSURE_TRIPLE_COUNTS
+            )
+        ),
+    )
+
+    included_files = tuple(
+        manifest.ReleaseManifestIncludedFile(
+            path=value,
+            role="governed SOSA-2023 formal package member",
+            sha256=HASH,
+            byte_size=1,
+        )
+        for value in manifest.INCLUDED_FILE_PATH_ORDER
+    )
+
+    return manifest.build_release_manifest(
+        release_identifier=SYNTHETIC_DATE,
+        release_date=SYNTHETIC_DATE,
+        git_tag="v" + SYNTHETIC_DATE,
+        source_commit=SYNTHETIC_COMMIT,
+        repository_iri=manifest.REPOSITORY_IRI,
+        inputs=tuple(inputs),
+        product_order=manifest.PRODUCT_ORDER,
+        products=products,
+        dependencies=dependencies,
+        validation_environment=environment,
+        validation=validation,
+        included_files=included_files,
+    )
+
+
+class Sosa2023ReleaseManifestTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.value = valid_manifest()
+        cls.serialized = manifest.canonical_manifest_bytes(
+            cls.value
+        )
+        cls.document = json.loads(cls.serialized)
+        cls.schema = json.loads(
+            (
+                REPO_ROOT
+                / "config/sosa-2023-release-manifest-schema-v1.json"
+            ).read_text(encoding="utf-8")
+        )
+
+    def test_exact_track_inventory_and_closure_authority(self) -> None:
+        self.assertEqual(
+            manifest.PRODUCT_ORDER,
+            (
+                "integrated",
+                "strict_bfo_mapping",
+                "cco_extension",
+            ),
+        )
+        self.assertEqual(
+            manifest.FORMAL_FIXED_CLOSURE_TRIPLE_COUNTS,
+            (
+                ("integrated", 15130),
+                ("strict_bfo_mapping", 15014),
+                ("cco_extension", 15141),
+            ),
+        )
+        self.assertEqual(
+            manifest.PRODUCT_IMPORT_COUNTS,
+            {
+                "integrated": 4,
+                "strict_bfo_mapping": 0,
+                "cco_extension": 1,
+            },
+        )
+
+    def test_schema_and_python_authorities_are_synchronized(self) -> None:
+        self.assertEqual(manifest.SCHEMA_VERSION, 1)
+        self.assertEqual(
+            self.schema["properties"]["schema_version"],
+            {"const": 1},
+        )
+        self.assertEqual(
+            tuple(
+                self.schema["properties"][
+                    "product_order"
+                ]["const"]
+            ),
+            manifest.PRODUCT_ORDER,
+        )
+        self.assertEqual(
+            tuple(
+                self.schema["$defs"]["product"][
+                    "properties"
+                ]["key"]["enum"]
+            ),
+            manifest.PRODUCT_ORDER,
+        )
+        self.assertEqual(
+            tuple(
+                self.schema["$defs"]["hermitResult"][
+                    "properties"
+                ]["product_key"]["enum"]
+            ),
+            manifest.PRODUCT_ORDER,
+        )
+
+        expected_arrays = (
+            (
+                "inputs",
+                manifest.INPUT_KEY_ORDER,
+                "key",
+            ),
+            (
+                "products",
+                manifest.PRODUCT_ORDER,
+                "key",
+            ),
+            (
+                "dependencies",
+                manifest.DEPENDENCY_KEY_ORDER,
+                "key",
+            ),
+            (
+                "included_files",
+                manifest.INCLUDED_FILE_PATH_ORDER,
+                "path",
+            ),
+        )
+
+        for field, expected, identity_field in expected_arrays:
+            value = self.schema["properties"][field]
+
+            with self.subTest(field=field):
+                self.assertEqual(
+                    (
+                        value["minItems"],
+                        value["maxItems"],
+                    ),
+                    (
+                        len(expected),
+                        len(expected),
+                    ),
+                )
+                self.assertFalse(value["items"])
+                self.assertEqual(
+                    tuple(
+                        item["allOf"][1]["properties"][
+                            identity_field
+                        ]["const"]
+                        for item in value["prefixItems"]
+                    ),
+                    expected,
+                )
+
+        hermit = self.schema["$defs"]["validation"][
+            "properties"
+        ]["hermit_results"]
+
+        self.assertEqual(
+            (
+                hermit["minItems"],
+                hermit["maxItems"],
+            ),
+            (3, 3),
+        )
+
+        self.assertEqual(
+            tuple(
+                (
+                    item["allOf"][1]["properties"][
+                        "product_key"
+                    ]["const"],
+                    item["allOf"][1]["properties"][
+                        "fixed_closure_triple_count"
+                    ]["const"],
+                )
+                for item in hermit["prefixItems"]
+            ),
+            manifest.FORMAL_FIXED_CLOSURE_TRIPLE_COUNTS,
+        )
+
+    def test_valid_manifest_round_trips_canonically(self) -> None:
+        self.assertEqual(
+            manifest.validate_release_manifest_document(
+                self.document
+            ),
+            (),
+        )
+        loaded = manifest.load_and_validate_release_manifest(
+            self.serialized
+        )
+        self.assertEqual(loaded, self.value)
+        self.assertEqual(
+            manifest.canonical_manifest_bytes(loaded),
+            self.serialized,
+        )
+        self.assertTrue(
+            self.serialized.endswith(b"\n")
+        )
+        self.assertFalse(
+            self.serialized.endswith(b"\n\n")
+        )
+
+    def test_reordered_models_have_identical_canonical_bytes(self) -> None:
+        reordered = replace(
+            self.value,
+            inputs=tuple(reversed(self.value.inputs)),
+            products=tuple(reversed(self.value.products)),
+            dependencies=tuple(
+                reversed(self.value.dependencies)
+            ),
+            validation=replace(
+                self.value.validation,
+                hermit_results=tuple(
+                    reversed(
+                        self.value.validation.hermit_results
+                    )
+                ),
+            ),
+            included_files=tuple(
+                reversed(self.value.included_files)
+            ),
+        )
+
+        self.assertEqual(
+            manifest.canonical_manifest_bytes(reordered),
+            self.serialized,
+        )
+
+    def test_synthetic_formal_product_evidence_is_exact(self) -> None:
+        observed = {
+            value.key: value
+            for value in self.value.products
+        }
+
+        for key in manifest.PRODUCT_ORDER:
+            product = observed[key]
+
+            self.assertEqual(
+                product.sha256,
+                FORMAL_HASHES[key],
+            )
+            self.assertEqual(
+                product.byte_size,
+                manifest.PRODUCT_STATIC_EVIDENCE[
+                    key
+                ]["byte_size"],
+            )
+            self.assertEqual(
+                product.version_iri,
+                manifest.expected_version_iri(
+                    key,
+                    SYNTHETIC_DATE,
+                ),
+            )
+            self.assertEqual(
+                product.imports,
+                manifest.expected_product_imports(
+                    key,
+                    SYNTHETIC_DATE,
+                ),
+            )
+
+            formal_text = "\n".join(
+                (
+                    product.path,
+                    product.stable_ontology_iri,
+                    product.version_iri,
+                    *product.imports,
+                )
+            )
+
+            self.assertNotIn(
+                "sosa-next",
+                formal_text,
+            )
+            self.assertNotIn(
+                "/development/",
+                formal_text,
+            )
+
+    def test_all_source_and_development_evidence_is_represented(self) -> None:
+        records = {
+            value.key: value
+            for value in self.value.inputs
+        }
+
+        self.assertEqual(
+            tuple(records),
+            manifest.INPUT_KEY_ORDER,
+        )
+
+        for key, source_path, package_path in (
+            manifest.INPUT_POLICIES
+        ):
+            record = records[key]
+
+            if key == "release_notes":
+                source_path = (
+                    "release-notes/"
+                    "SYNTHETIC-2099-01-02.md"
+                )
+
+            assert source_path is not None
+
+            content = (
+                REPO_ROOT / source_path
+            ).read_bytes()
+
+            self.assertEqual(
+                record.source_path,
+                source_path,
+            )
+            self.assertEqual(
+                record.package_path,
+                package_path,
+            )
+            self.assertEqual(
+                record.sha256,
+                sha256(content),
+            )
+            self.assertEqual(
+                record.byte_size,
+                len(content),
+            )
+
+        pinned_keys = {
+            "pinned_sosa",
+            "pinned_sosa_common",
+            "pinned_sosa_observation",
+            "pinned_sosa_actuation",
+            "pinned_sosa_sampling",
+            "pinned_sosa_deprecated",
+            "pinned_sosa_system",
+            "pinned_sample_relations",
+            "source_declaration_overlay",
+        }
+
+        self.assertTrue(
+            pinned_keys <= set(records)
+        )
+
+    def test_exact_policy_mutations_are_rejected(self) -> None:
+        variants = []
+
+        wrong_input = json.loads(self.serialized)
+        wrong_input["inputs"][0]["source_path"] = (
+            "mappings/wrong.xlsx"
+        )
+        variants.append(
+            (
+                "wrong input",
+                wrong_input,
+                "INPUT_SOURCE_POLICY",
+            )
+        )
+
+        wrong_product_path = json.loads(self.serialized)
+        wrong_product_path["products"][0]["path"] = (
+            "sosa-next/sosa-integrated.ttl"
+        )
+        variants.append(
+            (
+                "wrong product path",
+                wrong_product_path,
+                "PRODUCT_PATH_POLICY",
+            )
+        )
+
+        wrong_stable = json.loads(self.serialized)
+        wrong_stable["products"][0][
+            "stable_ontology_iri"
+        ] = "http://www.sks.ai/SSN2BFO/development/sosa-next/integrated"
+        variants.append(
+            (
+                "wrong stable IRI",
+                wrong_stable,
+                "PRODUCT_STABLE_IRI_POLICY",
+            )
+        )
+
+        wrong_version = json.loads(self.serialized)
+        wrong_version["products"][1]["version_iri"] = (
+            "http://www.sks.ai/SSN2BFO/releases/"
+            "2099-01-02/wrong"
+        )
+        variants.append(
+            (
+                "wrong version IRI",
+                wrong_version,
+                "PRODUCT_VERSION_IRI_POLICY",
+            )
+        )
+
+        wrong_import = json.loads(self.serialized)
+        wrong_import["products"][2]["imports"] = []
+        wrong_import["products"][2]["import_count"] = 0
+        variants.append(
+            (
+                "wrong import",
+                wrong_import,
+                "PRODUCT_IMPORT_POLICY",
+            )
+        )
+
+        wrong_count = json.loads(self.serialized)
+        wrong_count["products"][0][
+            "logical_triple_count"
+        ] = 274
+        variants.append(
+            (
+                "wrong evidence",
+                wrong_count,
+                "PRODUCT_EVIDENCE_POLICY",
+            )
+        )
+
+        wrong_dependency = json.loads(self.serialized)
+        wrong_dependency["dependencies"][0]["path"] = (
+            "imports/wrong.ttl"
+        )
+        variants.append(
+            (
+                "wrong dependency",
+                wrong_dependency,
+                "DEPENDENCY_POLICY",
+            )
+        )
+
+        wrong_included = json.loads(self.serialized)
+        wrong_included["included_files"][2]["path"] = (
+            "sosa-next/catalog-v001.xml"
+        )
+        variants.append(
+            (
+                "development package path",
+                wrong_included,
+                "DEVELOPMENT_IDENTITY_LEAK",
+            )
+        )
+
+        for label, document, expected_code in variants:
+            with self.subTest(label=label):
+                codes = {
+                    value.code
+                    for value in (
+                        manifest
+                        .validate_release_manifest_document(
+                            document
+                        )
+                    )
+                }
+                self.assertIn(
+                    expected_code,
+                    codes,
+                )
+
+    def test_reasoning_evidence_is_product_specific_and_fixed(self) -> None:
+        observed = tuple(
+            (
+                value.product_key,
+                value.fixed_closure_triple_count,
+                value.return_code,
+                value.reasoned_output_produced,
+                value.named_unsatisfiable_class_count,
+            )
+            for value in self.value.validation.hermit_results
+        )
+
+        self.assertEqual(
+            observed,
+            (
+                (
+                    "integrated",
+                    15130,
+                    0,
+                    True,
+                    0,
+                ),
+                (
+                    "strict_bfo_mapping",
+                    15014,
+                    0,
+                    True,
+                    0,
+                ),
+                (
+                    "cco_extension",
+                    15141,
+                    0,
+                    True,
+                    0,
+                ),
+            ),
+        )
+
+        changed = json.loads(self.serialized)
+        changed["validation"]["hermit_results"][2][
+            "fixed_closure_triple_count"
+        ] = 15140
+
+        codes = {
+            value.code
+            for value in (
+                manifest.validate_release_manifest_document(
+                    changed
+                )
+            )
+        }
+
+        self.assertIn(
+            "FIXED_CLOSURE_TRIPLE_COUNT_MISMATCH",
+            codes,
+        )
+
+    def test_included_files_are_formal_only_and_anti_circular(self) -> None:
+        self.assertEqual(
+            tuple(sorted(manifest.INCLUDED_FILE_PATH_ORDER)),
+            manifest.INCLUDED_FILE_PATH_ORDER,
+        )
+
+        self.assertNotIn(
+            "manifest.json",
+            manifest.INCLUDED_FILE_PATH_ORDER,
+        )
+        self.assertNotIn(
+            "SHA256SUMS",
+            manifest.INCLUDED_FILE_PATH_ORDER,
+        )
+
+        for value in manifest.INCLUDED_FILE_PATH_ORDER:
+            self.assertNotIn(
+                "sosa-next",
+                value,
+            )
+
+    def test_current_release_authorities_remain_byte_locked(self) -> None:
+        for relative, expected in CURRENT_AUTHORITY_HASHES.items():
+            with self.subTest(relative=relative):
+                observed = sha256(
+                    (REPO_ROOT / relative).read_bytes()
+                )
+                self.assertEqual(
+                    observed,
+                    expected,
+                )
+
+    def test_module_has_no_external_json_schema_dependency(self) -> None:
+        source = (
+            REPO_ROOT
+            / "tools/sosa_2023_release_manifest.py"
+        ).read_text(encoding="utf-8")
+
+        package_name = "json" + "schema"
+
+        self.assertNotIn(
+            f"import {package_name}",
+            source,
+        )
+        self.assertNotIn(
+            f"from {package_name}",
+            source,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/run_validation_suite.py
+++ b/tools/run_validation_suite.py
@@ -433,6 +433,7 @@ def compile_check() -> StepResult:
             "tests/test_sosa_next_consumer_stack.py",
             "tests/test_sosa_2023_publication_metadata.py",
             "tests/test_sosa_2023_release_rendering.py",
+            "tests/test_sosa_2023_release_manifest.py",
             "tests/test_robot_template_generation_pilot.py",
             "tests/test_robot_property_chain_generation_pilot.py",
             "tests/test_robot_diff_pilot.py",
@@ -643,6 +644,22 @@ def run_validation_suite(args: argparse.Namespace) -> int:
                     "tests",
                     "-p",
                     "test_sosa_2023_release_rendering.py",
+                ],
+            )
+        )
+    if results[-1].passed:
+        results.append(
+            run_command(
+                "SOSA-2023 release-manifest focused tests",
+                [
+                    sys.executable,
+                    "-m",
+                    "unittest",
+                    "discover",
+                    "-s",
+                    "tests",
+                    "-p",
+                    "test_sosa_2023_release_manifest.py",
                 ],
             )
         )

--- a/tools/sosa_2023_release_manifest.py
+++ b/tools/sosa_2023_release_manifest.py
@@ -1,0 +1,1374 @@
+#!/usr/bin/env python3
+"""Canonical SOSA-2023 schema-1 release-manifest models and validation."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import unicodedata
+from dataclasses import asdict, dataclass
+from pathlib import Path, PurePosixPath
+from typing import Iterable
+from urllib.parse import urlsplit
+
+from release_context import FormalReleaseContextError, parse_formal_release_context
+
+
+SCHEMA_VERSION = 1
+PRODUCT_ORDER = (
+    "integrated",
+    "strict_bfo_mapping",
+    "cco_extension",
+)
+FORMAL_FIXED_CLOSURE_TRIPLE_COUNTS = (
+    ("integrated", 15130),
+    ("strict_bfo_mapping", 15014),
+    ("cco_extension", 15141),
+)
+if tuple(key for key, _ in FORMAL_FIXED_CLOSURE_TRIPLE_COUNTS) != PRODUCT_ORDER:
+    raise RuntimeError("formal fixed-closure counts and product order differ")
+PRODUCT_IMPORT_COUNTS = {
+    "integrated": 4,
+    "strict_bfo_mapping": 0,
+    "cco_extension": 1,
+}
+INPUT_KEY_ORDER = (
+    "coms_workbook",
+    "publication_metadata",
+    "source_version",
+    "release_scope",
+    "product_role_policy",
+    "development_integrated",
+    "development_strict_bfo_mapping",
+    "development_cco_extension",
+    "pinned_sosa",
+    "pinned_sosa_common",
+    "pinned_sosa_observation",
+    "pinned_sosa_actuation",
+    "pinned_sosa_sampling",
+    "pinned_sosa_deprecated",
+    "pinned_sosa_system",
+    "pinned_sample_relations",
+    "source_declaration_overlay",
+    "release_notes",
+    "license",
+    "module_coms_row_identity",
+    "module_product_dispositions",
+    "module_modular_products",
+    "module_publication_metadata",
+    "module_release_context",
+    "module_check_sosa_next_mapping",
+    "module_generate_sosa_next_products",
+    "manifest_schema",
+    "module_sosa_2023_release_manifest",
+)
+DEPENDENCY_KEY_ORDER = (
+    "sosa",
+    "sosa_systems",
+    "sosa_sampling",
+    "merged_cco_bfo",
+)
+INCLUDED_FILE_PATH_ORDER = (
+    "LICENSE",
+    "RELEASE-NOTES.md",
+    "catalog-v001.xml",
+    "sosa-2023-af425a0454ec00512a5ebfa2873fe35a077f5fda/sosa-bfo-mapping.ttl",
+    "sosa-2023-af425a0454ec00512a5ebfa2873fe35a077f5fda/sosa-cco-extension.ttl",
+    "sosa-2023-af425a0454ec00512a5ebfa2873fe35a077f5fda/sosa-integrated.ttl",
+    "sources/SOSA-2023-to-BFO-COMS.xlsx",
+    "sources/product-role-policy.toml",
+    "sources/sosa-2023-publication-metadata.toml",
+    "sources/sosa-release-scope.toml",
+    "sources/sosa-source-version.toml",
+)
+TOP_LEVEL_FIELDS = (
+    "schema_version",
+    "release_identifier",
+    "release_date",
+    "git_tag",
+    "source_commit",
+    "repository_iri",
+    "inputs",
+    "product_order",
+    "products",
+    "dependencies",
+    "validation_environment",
+    "validation",
+    "included_files",
+)
+INPUT_FIELDS = ("key", "source_path", "package_path", "sha256", "byte_size")
+PRODUCT_FIELDS = (
+    "key",
+    "path",
+    "stable_ontology_iri",
+    "version_iri",
+    "imports",
+    "sha256",
+    "byte_size",
+    "ontology_declaration_count",
+    "import_count",
+    "static_metadata_count",
+    "formal_metadata_count",
+    "logical_triple_count",
+    "total_triple_count",
+    "direct_governed_axiom_count",
+    "governed_closure_axiom_count",
+    "reasoning_mode",
+)
+DEPENDENCY_FIELDS = (
+    "key",
+    "role",
+    "path",
+    "ontology_iri",
+    "version_iri",
+    "sha256",
+    "byte_size",
+)
+VALIDATION_ENVIRONMENT_FIELDS = (
+    "python_implementation",
+    "python_version",
+    "java_vendor",
+    "java_version",
+    "java_vm_name",
+    "robot_artifact",
+    "robot_version",
+    "robot_sha256",
+    "toolchain_path",
+    "toolchain_sha256",
+    "requirements_path",
+    "requirements_sha256",
+)
+HERMIT_FIELDS = (
+    "product_key",
+    "status",
+    "fixed_closure_triple_count",
+    "return_code",
+    "reasoned_output_produced",
+    "named_unsatisfiable_class_count",
+    "owl_nothing_equivalent_named_class_count",
+)
+VALIDATION_FIELDS = (
+    "strict_turtle_parsing",
+    "formal_metadata_validation",
+    "serialized_header_validation",
+    "governed_axiom_reconciliation",
+    "import_graph_validation",
+    "catalog_validation",
+    "checksum_validation",
+    "development_artifact_nonmutation",
+    "deterministic_package_rebuild",
+    "hermit_results",
+)
+INCLUDED_FILE_FIELDS = ("path", "role", "sha256", "byte_size")
+SHA256_RE = re.compile(r"[0-9a-f]{64}\Z")
+
+
+@dataclass(frozen=True)
+class ReleaseManifestInput:
+    key: str
+    source_path: str
+    package_path: str | None
+    sha256: str
+    byte_size: int
+
+
+@dataclass(frozen=True)
+class ReleaseManifestProduct:
+    key: str
+    path: str
+    stable_ontology_iri: str
+    version_iri: str
+    imports: tuple[str, ...]
+    sha256: str
+    byte_size: int
+    ontology_declaration_count: int
+    import_count: int
+    static_metadata_count: int
+    formal_metadata_count: int
+    logical_triple_count: int
+    total_triple_count: int
+    direct_governed_axiom_count: int
+    governed_closure_axiom_count: int
+    reasoning_mode: str
+
+
+@dataclass(frozen=True)
+class ReleaseManifestDependency:
+    key: str
+    role: str
+    path: str
+    ontology_iri: str
+    version_iri: str | None
+    sha256: str
+    byte_size: int
+
+
+@dataclass(frozen=True)
+class ReleaseManifestValidationEnvironment:
+    python_implementation: str
+    python_version: str
+    java_vendor: str
+    java_version: str
+    java_vm_name: str
+    robot_artifact: str
+    robot_version: str
+    robot_sha256: str
+    toolchain_path: str
+    toolchain_sha256: str
+    requirements_path: str
+    requirements_sha256: str
+
+
+@dataclass(frozen=True)
+class ReleaseManifestHermitResult:
+    product_key: str
+    status: str
+    fixed_closure_triple_count: int
+    return_code: int
+    reasoned_output_produced: bool
+    named_unsatisfiable_class_count: int
+    owl_nothing_equivalent_named_class_count: int
+
+
+@dataclass(frozen=True)
+class ReleaseManifestValidation:
+    strict_turtle_parsing: bool
+    formal_metadata_validation: bool
+    serialized_header_validation: bool
+    governed_axiom_reconciliation: bool
+    import_graph_validation: bool
+    catalog_validation: bool
+    checksum_validation: bool
+    development_artifact_nonmutation: bool
+    deterministic_package_rebuild: bool
+    hermit_results: tuple[ReleaseManifestHermitResult, ...]
+
+
+@dataclass(frozen=True)
+class ReleaseManifestIncludedFile:
+    path: str
+    role: str
+    sha256: str
+    byte_size: int
+
+
+@dataclass(frozen=True)
+class ReleaseManifest:
+    schema_version: int
+    release_identifier: str
+    release_date: str
+    git_tag: str
+    source_commit: str
+    repository_iri: str
+    inputs: tuple[ReleaseManifestInput, ...]
+    product_order: tuple[str, ...]
+    products: tuple[ReleaseManifestProduct, ...]
+    dependencies: tuple[ReleaseManifestDependency, ...]
+    validation_environment: ReleaseManifestValidationEnvironment
+    validation: ReleaseManifestValidation
+    included_files: tuple[ReleaseManifestIncludedFile, ...]
+
+
+@dataclass(frozen=True)
+class ReleaseManifestIssue:
+    code: str
+    field: str
+    message: str
+
+    @property
+    def sort_key(self) -> tuple[str, str, str]:
+        return self.field, self.code, self.message
+
+
+class ReleaseManifestError(ValueError):
+    """One or more deterministic manifest failures."""
+
+    def __init__(self, issues: Iterable[ReleaseManifestIssue]):
+        self.issues = tuple(sorted(set(issues), key=lambda value: value.sort_key))
+        super().__init__("; ".join(format_issue(issue) for issue in self.issues))
+
+
+def format_issue(issue: ReleaseManifestIssue) -> str:
+    return f"ERROR [{issue.code}] {issue.field}: {issue.message}"
+
+
+def _issue(code: str, field: str, message: str) -> ReleaseManifestIssue:
+    return ReleaseManifestIssue(code, field, message)
+
+
+def sha256_bytes(value: bytes) -> str:
+    return hashlib.sha256(value).hexdigest()
+
+
+def release_manifest_sha256(value: ReleaseManifest | bytes) -> str:
+    serialized = canonical_manifest_bytes(value) if isinstance(value, ReleaseManifest) else value
+    return sha256_bytes(serialized)
+
+
+def is_safe_relative_posix_path(value: object) -> bool:
+    if not isinstance(value, str) or not value or "\\" in value:
+        return False
+    if any(ord(character) < 32 or ord(character) == 127 for character in value):
+        return False
+    if urlsplit(value).scheme or value.startswith("/") or value.endswith("/"):
+        return False
+    parts = value.split("/")
+    if any(part in {"", ".", ".."} for part in parts):
+        return False
+    return PurePosixPath(value).as_posix() == value
+
+
+def _ordered(record: dict[str, object], fields: tuple[str, ...]) -> dict[str, object]:
+    return {field: record.get(field) for field in fields}
+
+
+def manifest_document(manifest: ReleaseManifest) -> dict[str, object]:
+    environment = _ordered(asdict(manifest.validation_environment), VALIDATION_ENVIRONMENT_FIELDS)
+    validation = asdict(manifest.validation)
+    validation["hermit_results"] = [
+        _ordered(asdict(value), HERMIT_FIELDS)
+        for value in sorted(
+            manifest.validation.hermit_results,
+            key=lambda item: PRODUCT_ORDER.index(item.product_key),
+        )
+    ]
+    document: dict[str, object] = {
+        "schema_version": manifest.schema_version,
+        "release_identifier": manifest.release_identifier,
+        "release_date": manifest.release_date,
+        "git_tag": manifest.git_tag,
+        "source_commit": manifest.source_commit,
+        "repository_iri": manifest.repository_iri,
+        "inputs": [
+            _ordered(asdict(value), INPUT_FIELDS)
+            for value in sorted(
+                manifest.inputs,
+                key=lambda item: INPUT_KEY_ORDER.index(item.key),
+            )
+        ],
+        "product_order": list(manifest.product_order),
+        "products": [
+            _ordered({**asdict(value), "imports": list(value.imports)}, PRODUCT_FIELDS)
+            for value in sorted(
+                manifest.products,
+                key=lambda item: PRODUCT_ORDER.index(item.key),
+            )
+        ],
+        "dependencies": [
+            _ordered(asdict(value), DEPENDENCY_FIELDS)
+            for value in sorted(
+                manifest.dependencies,
+                key=lambda item: DEPENDENCY_KEY_ORDER.index(item.key),
+            )
+        ],
+        "validation_environment": environment,
+        "validation": _ordered(validation, VALIDATION_FIELDS),
+        "included_files": [
+            _ordered(asdict(value), INCLUDED_FILE_FIELDS)
+            for value in sorted(manifest.included_files, key=lambda item: item.path)
+        ],
+    }
+    return _ordered(document, TOP_LEVEL_FIELDS)
+
+
+def canonical_manifest_bytes(value: ReleaseManifest | dict[str, object]) -> bytes:
+    if isinstance(value, ReleaseManifest):
+        document = manifest_document(value)
+    else:
+        document = _canonicalize_document(value)
+    return (json.dumps(document, ensure_ascii=False, indent=2) + "\n").encode("utf-8")
+
+
+def _canonicalize_document(document: dict[str, object]) -> dict[str, object]:
+    result = _ordered(document, TOP_LEVEL_FIELDS)
+    result["inputs"] = [
+        _ordered(value, INPUT_FIELDS)
+        for value in sorted(
+            document.get("inputs", []),
+            key=lambda item: INPUT_KEY_ORDER.index(item.get("key"))
+            if isinstance(item, dict) and item.get("key") in INPUT_KEY_ORDER
+            else len(INPUT_KEY_ORDER),
+        )
+        if isinstance(value, dict)
+    ] if isinstance(document.get("inputs"), list) else document.get("inputs")
+    result["products"] = [
+        _ordered(value, PRODUCT_FIELDS)
+        for value in sorted(
+            document.get("products", []),
+            key=lambda item: PRODUCT_ORDER.index(item.get("key"))
+            if isinstance(item, dict) and item.get("key") in PRODUCT_ORDER
+            else len(PRODUCT_ORDER),
+        )
+        if isinstance(value, dict)
+    ] if isinstance(document.get("products"), list) else document.get("products")
+    result["dependencies"] = [
+        _ordered(value, DEPENDENCY_FIELDS)
+        for value in sorted(
+            document.get("dependencies", []),
+            key=lambda item: DEPENDENCY_KEY_ORDER.index(item.get("key"))
+            if isinstance(item, dict) and item.get("key") in DEPENDENCY_KEY_ORDER
+            else len(DEPENDENCY_KEY_ORDER),
+        )
+        if isinstance(value, dict)
+    ] if isinstance(document.get("dependencies"), list) else document.get("dependencies")
+    environment = document.get("validation_environment")
+    if isinstance(environment, dict):
+        result["validation_environment"] = _ordered(environment, VALIDATION_ENVIRONMENT_FIELDS)
+    validation = document.get("validation")
+    if isinstance(validation, dict):
+        ordered_validation = _ordered(validation, VALIDATION_FIELDS)
+        hermit = validation.get("hermit_results")
+        if isinstance(hermit, list):
+            ordered_validation["hermit_results"] = [
+                _ordered(value, HERMIT_FIELDS)
+                for value in sorted(
+                    hermit,
+                    key=lambda item: PRODUCT_ORDER.index(item.get("product_key"))
+                    if isinstance(item, dict) and item.get("product_key") in PRODUCT_ORDER
+                    else len(PRODUCT_ORDER),
+                )
+                if isinstance(value, dict)
+            ]
+        result["validation"] = ordered_validation
+    result["included_files"] = [
+        _ordered(value, INCLUDED_FILE_FIELDS)
+        for value in sorted(
+            document.get("included_files", []),
+            key=lambda item: item.get("path", "") if isinstance(item, dict) else "",
+        )
+        if isinstance(value, dict)
+    ] if isinstance(document.get("included_files"), list) else document.get("included_files")
+    return result
+
+
+def _strict_json_loads(value: bytes) -> dict[str, object]:
+    try:
+        text = value.decode("utf-8")
+    except UnicodeDecodeError as exc:
+        raise ReleaseManifestError((_issue("INVALID_UTF8", "manifest", str(exc)),)) from exc
+
+    def pairs(values: list[tuple[str, object]]) -> dict[str, object]:
+        result: dict[str, object] = {}
+        for key, item in values:
+            if key in result:
+                raise ReleaseManifestError(
+                    (_issue("DUPLICATE_FIELD", key, "JSON object field occurs more than once"),)
+                )
+            result[key] = item
+        return result
+
+    try:
+        document = json.loads(
+            text,
+            object_pairs_hook=pairs,
+            parse_float=lambda _: (_ for _ in ()).throw(ValueError("floating-point values are prohibited")),
+        )
+    except ReleaseManifestError:
+        raise
+    except (json.JSONDecodeError, ValueError) as exc:
+        raise ReleaseManifestError((_issue("INVALID_JSON", "manifest", str(exc)),)) from exc
+    if not isinstance(document, dict):
+        raise ReleaseManifestError((_issue("DOCUMENT_TYPE", "manifest", "expected object"),))
+    return document
+
+
+def _check_fields(
+    value: object,
+    fields: tuple[str, ...],
+    path: str,
+    issues: list[ReleaseManifestIssue],
+) -> dict[str, object] | None:
+    if not isinstance(value, dict):
+        issues.append(_issue("OBJECT_TYPE", path, "expected object"))
+        return None
+    missing = [field for field in fields if field not in value]
+    extra = sorted(set(value) - set(fields))
+    for field in missing:
+        issues.append(_issue("MISSING_FIELD", f"{path}.{field}", "required field is absent"))
+    for field in extra:
+        issues.append(_issue("UNKNOWN_FIELD", f"{path}.{field}", "field is not allowed"))
+    return value
+
+
+def _string(value: object, field: str, issues: list[ReleaseManifestIssue]) -> str | None:
+    if not isinstance(value, str) or not value:
+        issues.append(_issue("STRING_VALUE", field, "expected non-empty string"))
+        return None
+    if unicodedata.normalize("NFC", value) != value:
+        issues.append(_issue("NON_NFC_STRING", field, "string must be NFC-normalized"))
+    return value
+
+
+def _integer(value: object, field: str, issues: list[ReleaseManifestIssue]) -> int | None:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        issues.append(_issue("INTEGER_VALUE", field, "expected non-negative integer"))
+        return None
+    return value
+
+
+def _hash(value: object, field: str, issues: list[ReleaseManifestIssue]) -> None:
+    if not isinstance(value, str) or SHA256_RE.fullmatch(value) is None:
+        issues.append(_issue("SHA256_VALUE", field, "expected 64 lowercase hexadecimal characters"))
+
+
+def _path(value: object, field: str, issues: list[ReleaseManifestIssue], *, nullable: bool = False) -> None:
+    if nullable and value is None:
+        return
+    if not is_safe_relative_posix_path(value):
+        issues.append(_issue("UNSAFE_PATH", field, "expected normalized relative POSIX path"))
+    elif isinstance(value, str) and unicodedata.normalize("NFC", value) != value:
+        issues.append(_issue("NON_NFC_STRING", field, "path must be NFC-normalized"))
+
+
+def _iri(value: object, field: str, issues: list[ReleaseManifestIssue], *, nullable: bool = False) -> None:
+    if nullable and value is None:
+        return
+    text = _string(value, field, issues)
+    if text is None:
+        return
+    parsed = urlsplit(text)
+    if parsed.scheme not in {"http", "https"} or not parsed.netloc or parsed.fragment:
+        issues.append(_issue("IRI_VALUE", field, "expected absolute HTTP(S) IRI without fragment"))
+
+
+def validate_release_manifest_document(document: object) -> tuple[ReleaseManifestIssue, ...]:
+    issues: list[ReleaseManifestIssue] = []
+    top = _check_fields(document, TOP_LEVEL_FIELDS, "manifest", issues)
+    if top is None:
+        return tuple(sorted(set(issues), key=lambda value: value.sort_key))
+    if top.get("schema_version") != SCHEMA_VERSION:
+        issues.append(_issue("SCHEMA_VERSION", "schema_version", f"expected {SCHEMA_VERSION}"))
+    try:
+        parse_formal_release_context(
+            top.get("release_identifier"),
+            top.get("release_date"),
+            top.get("git_tag"),
+            top.get("source_commit"),
+        )
+    except FormalReleaseContextError as exc:
+        issues.extend(_issue(value.code, value.field, value.message) for value in exc.issues)
+    _iri(top.get("repository_iri"), "repository_iri", issues)
+
+    product_order = top.get("product_order")
+    if product_order != list(PRODUCT_ORDER):
+        issues.append(_issue("PRODUCT_ORDER", "product_order", f"expected {list(PRODUCT_ORDER)!r}"))
+
+    inputs = top.get("inputs")
+    if not isinstance(inputs, list):
+        issues.append(_issue("ARRAY_TYPE", "inputs", "expected array"))
+    else:
+        keys: list[str] = []
+        for index, value in enumerate(inputs):
+            path = f"inputs[{index}]"
+            record = _check_fields(value, INPUT_FIELDS, path, issues)
+            if record is None:
+                continue
+            key = _string(record.get("key"), f"{path}.key", issues)
+            if key is not None:
+                keys.append(key)
+            _path(record.get("source_path"), f"{path}.source_path", issues)
+            _path(record.get("package_path"), f"{path}.package_path", issues, nullable=True)
+            _hash(record.get("sha256"), f"{path}.sha256", issues)
+            _integer(record.get("byte_size"), f"{path}.byte_size", issues)
+        if len(keys) != len(set(keys)):
+            issues.append(_issue("DUPLICATE_INPUT_KEY", "inputs", "input keys must be unique"))
+        if keys != list(INPUT_KEY_ORDER):
+            issues.append(_issue("INPUT_ORDER", "inputs", f"expected {list(INPUT_KEY_ORDER)!r}"))
+
+    products = top.get("products")
+    if not isinstance(products, list):
+        issues.append(_issue("ARRAY_TYPE", "products", "expected array"))
+    else:
+        observed_keys: list[str] = []
+        for index, value in enumerate(products):
+            path = f"products[{index}]"
+            record = _check_fields(value, PRODUCT_FIELDS, path, issues)
+            if record is None:
+                continue
+            key = _string(record.get("key"), f"{path}.key", issues)
+            if key is not None:
+                observed_keys.append(key)
+            _path(record.get("path"), f"{path}.path", issues)
+            _iri(record.get("stable_ontology_iri"), f"{path}.stable_ontology_iri", issues)
+            _iri(record.get("version_iri"), f"{path}.version_iri", issues)
+            imports = record.get("imports")
+            if not isinstance(imports, list) or not all(isinstance(item, str) for item in imports):
+                issues.append(_issue("IMPORTS_TYPE", f"{path}.imports", "expected string array"))
+            else:
+                for import_index, iri in enumerate(imports):
+                    _iri(iri, f"{path}.imports[{import_index}]", issues)
+                if len(imports) != len(set(imports)):
+                    issues.append(_issue("DUPLICATE_IMPORT", f"{path}.imports", "imports must be unique"))
+                expected_import_count = PRODUCT_IMPORT_COUNTS.get(key)
+                if expected_import_count is not None and len(imports) != expected_import_count:
+                    issues.append(
+                        _issue(
+                            "IMPORT_COUNT",
+                            f"{path}.imports",
+                            f"expected {expected_import_count}, got {len(imports)}",
+                        )
+                    )
+            _hash(record.get("sha256"), f"{path}.sha256", issues)
+            for field in PRODUCT_FIELDS[6:15]:
+                if field != "reasoning_mode":
+                    _integer(record.get(field), f"{path}.{field}", issues)
+            if record.get("reasoning_mode") != "independent":
+                issues.append(_issue("REASONING_MODE", f"{path}.reasoning_mode", "expected independent"))
+        if observed_keys != list(PRODUCT_ORDER):
+            issues.append(_issue("PRODUCT_RECORD_ORDER", "products", f"expected {list(PRODUCT_ORDER)!r}"))
+
+    dependencies = top.get("dependencies")
+    if not isinstance(dependencies, list):
+        issues.append(_issue("ARRAY_TYPE", "dependencies", "expected array"))
+    else:
+        keys: list[str] = []
+        for index, value in enumerate(dependencies):
+            path = f"dependencies[{index}]"
+            record = _check_fields(value, DEPENDENCY_FIELDS, path, issues)
+            if record is None:
+                continue
+            key = _string(record.get("key"), f"{path}.key", issues)
+            if key is not None:
+                keys.append(key)
+            _string(record.get("role"), f"{path}.role", issues)
+            _path(record.get("path"), f"{path}.path", issues)
+            _iri(record.get("ontology_iri"), f"{path}.ontology_iri", issues)
+            _iri(record.get("version_iri"), f"{path}.version_iri", issues, nullable=True)
+            _hash(record.get("sha256"), f"{path}.sha256", issues)
+            _integer(record.get("byte_size"), f"{path}.byte_size", issues)
+        if len(keys) != len(set(keys)):
+            issues.append(_issue("DUPLICATE_DEPENDENCY_KEY", "dependencies", "dependency keys must be unique"))
+        if keys != list(DEPENDENCY_KEY_ORDER):
+            issues.append(_issue("DEPENDENCY_ORDER", "dependencies", f"expected {list(DEPENDENCY_KEY_ORDER)!r}"))
+
+    environment = _check_fields(
+        top.get("validation_environment"),
+        VALIDATION_ENVIRONMENT_FIELDS,
+        "validation_environment",
+        issues,
+    )
+    if environment is not None:
+        for field in VALIDATION_ENVIRONMENT_FIELDS:
+            if field.endswith("_path"):
+                _path(environment.get(field), f"validation_environment.{field}", issues)
+            elif field.endswith("_sha256"):
+                _hash(environment.get(field), f"validation_environment.{field}", issues)
+            elif field == "robot_artifact":
+                _iri(environment.get(field), f"validation_environment.{field}", issues)
+            else:
+                _string(environment.get(field), f"validation_environment.{field}", issues)
+
+    validation = _check_fields(top.get("validation"), VALIDATION_FIELDS, "validation", issues)
+    if validation is not None:
+        for field in VALIDATION_FIELDS[:-1]:
+            if validation.get(field) is not True:
+                issues.append(_issue("VALIDATION_OUTCOME", f"validation.{field}", "expected true"))
+        hermit = validation.get("hermit_results")
+        if not isinstance(hermit, list):
+            issues.append(_issue("ARRAY_TYPE", "validation.hermit_results", "expected array"))
+        else:
+            keys: list[str] = []
+            for index, value in enumerate(hermit):
+                path = f"validation.hermit_results[{index}]"
+                record = _check_fields(value, HERMIT_FIELDS, path, issues)
+                if record is None:
+                    continue
+                key = _string(record.get("product_key"), f"{path}.product_key", issues)
+                if key is not None:
+                    keys.append(key)
+                if record.get("status") != "PASS":
+                    issues.append(_issue("HERMIT_STATUS", f"{path}.status", "expected PASS"))
+                closure_count = _integer(
+                    record.get("fixed_closure_triple_count"),
+                    f"{path}.fixed_closure_triple_count",
+                    issues,
+                )
+                if index < len(FORMAL_FIXED_CLOSURE_TRIPLE_COUNTS):
+                    expected_key, expected_count = FORMAL_FIXED_CLOSURE_TRIPLE_COUNTS[index]
+                    if closure_count is not None and closure_count != expected_count:
+                        issues.append(
+                            _issue(
+                                "FIXED_CLOSURE_TRIPLE_COUNT_MISMATCH",
+                                f"{path}.fixed_closure_triple_count",
+                                f"expected {expected_count} for {expected_key}, got {closure_count}",
+                            )
+                        )
+                if record.get("return_code") != 0:
+                    issues.append(_issue("HERMIT_RETURN_CODE", f"{path}.return_code", "expected zero"))
+                if record.get("reasoned_output_produced") is not True:
+                    issues.append(_issue("HERMIT_OUTPUT", f"{path}.reasoned_output_produced", "expected true"))
+                for field in (
+                    "named_unsatisfiable_class_count",
+                    "owl_nothing_equivalent_named_class_count",
+                ):
+                    if record.get(field) != 0:
+                        issues.append(_issue("HERMIT_UNSAT", f"{path}.{field}", "expected zero"))
+            if keys != list(PRODUCT_ORDER):
+                issues.append(_issue("HERMIT_PRODUCT_ORDER", "validation.hermit_results", f"expected {list(PRODUCT_ORDER)!r}"))
+
+    included = top.get("included_files")
+    if not isinstance(included, list):
+        issues.append(_issue("ARRAY_TYPE", "included_files", "expected array"))
+    else:
+        paths: list[str] = []
+        for index, value in enumerate(included):
+            path = f"included_files[{index}]"
+            record = _check_fields(value, INCLUDED_FILE_FIELDS, path, issues)
+            if record is None:
+                continue
+            file_path = record.get("path")
+            _path(file_path, f"{path}.path", issues)
+            if isinstance(file_path, str):
+                paths.append(file_path)
+            _string(record.get("role"), f"{path}.role", issues)
+            _hash(record.get("sha256"), f"{path}.sha256", issues)
+            _integer(record.get("byte_size"), f"{path}.byte_size", issues)
+        if paths != list(INCLUDED_FILE_PATH_ORDER):
+            issues.append(
+                _issue(
+                    "INCLUDED_FILE_ORDER",
+                    "included_files",
+                    f"expected {list(INCLUDED_FILE_PATH_ORDER)!r}",
+                )
+            )
+        if len(paths) != len(set(paths)):
+            issues.append(_issue("DUPLICATE_INCLUDED_FILE", "included_files", "paths must be unique"))
+        if len(paths) != len(INCLUDED_FILE_PATH_ORDER):
+            issues.append(
+                _issue(
+                    "INCLUDED_FILE_COUNT",
+                    "included_files",
+                    f"expected {len(INCLUDED_FILE_PATH_ORDER)}, got {len(paths)}",
+                )
+            )
+        prohibited = {"manifest.json", "SHA256SUMS"} & set(paths)
+        if prohibited:
+            issues.append(_issue("MANIFEST_SELF_REFERENCE", "included_files", f"prohibited paths: {sorted(prohibited)!r}"))
+    return tuple(sorted(set(issues), key=lambda value: value.sort_key))
+
+
+def _manifest_from_document(document: dict[str, object]) -> ReleaseManifest:
+    return ReleaseManifest(
+        schema_version=document["schema_version"],
+        release_identifier=document["release_identifier"],
+        release_date=document["release_date"],
+        git_tag=document["git_tag"],
+        source_commit=document["source_commit"],
+        repository_iri=document["repository_iri"],
+        inputs=tuple(ReleaseManifestInput(**value) for value in document["inputs"]),
+        product_order=tuple(document["product_order"]),
+        products=tuple(
+            ReleaseManifestProduct(**{**value, "imports": tuple(value["imports"])})
+            for value in document["products"]
+        ),
+        dependencies=tuple(ReleaseManifestDependency(**value) for value in document["dependencies"]),
+        validation_environment=ReleaseManifestValidationEnvironment(**document["validation_environment"]),
+        validation=ReleaseManifestValidation(
+            **{
+                **document["validation"],
+                "hermit_results": tuple(
+                    ReleaseManifestHermitResult(**value)
+                    for value in document["validation"]["hermit_results"]
+                ),
+            }
+        ),
+        included_files=tuple(
+            ReleaseManifestIncludedFile(**value) for value in document["included_files"]
+        ),
+    )
+
+
+def build_release_manifest(**values: object) -> ReleaseManifest:
+    manifest = ReleaseManifest(schema_version=SCHEMA_VERSION, **values)
+    document = manifest_document(manifest)
+    issues = validate_release_manifest_document(document)
+    if issues:
+        raise ReleaseManifestError(issues)
+    return _manifest_from_document(document)
+
+
+def load_and_validate_release_manifest(source: Path | bytes) -> ReleaseManifest:
+    serialized = source.read_bytes() if isinstance(source, Path) else source
+    document = _strict_json_loads(serialized)
+    issues = list(validate_release_manifest_document(document))
+    if canonical_manifest_bytes(document) != serialized:
+        issues.append(
+            _issue(
+                "NONCANONICAL_SERIALIZATION",
+                "manifest",
+                "bytes differ from canonical schema-ordered JSON",
+            )
+        )
+    if issues:
+        raise ReleaseManifestError(issues)
+    return _manifest_from_document(document)
+
+TRACK_ID = "sosa-2023-af425a0454ec00512a5ebfa2873fe35a077f5fda"
+RELEASE_IRI_BASE = "http://www.sks.ai/SSN2BFO/releases"
+REPOSITORY_IRI = "https://github.com/BFO-Mappings/SSN-to-BFO"
+
+PRODUCT_PACKAGE_PATHS = {
+    "integrated":
+        TRACK_ID + "/sosa-integrated.ttl",
+    "strict_bfo_mapping":
+        TRACK_ID + "/sosa-bfo-mapping.ttl",
+    "cco_extension":
+        TRACK_ID + "/sosa-cco-extension.ttl",
+}
+
+PRODUCT_STABLE_ONTOLOGY_IRIS = {
+    "integrated":
+        "http://www.sks.ai/SSN2BFO/" + TRACK_ID + "/integrated",
+    "strict_bfo_mapping":
+        "http://www.sks.ai/SSN2BFO/" + TRACK_ID + "/bfo-mapping",
+    "cco_extension":
+        "http://www.sks.ai/SSN2BFO/" + TRACK_ID + "/cco-extension",
+}
+
+PRODUCT_RELEASE_IRI_SUFFIXES = {
+    "integrated":
+        TRACK_ID + "/integrated",
+    "strict_bfo_mapping":
+        TRACK_ID + "/bfo-mapping",
+    "cco_extension":
+        TRACK_ID + "/cco-extension",
+}
+
+FORMAL_INTEGRATED_EXTERNAL_IMPORTS = (
+    "http://www.w3.org/ns/sosa/",
+    "http://www.w3.org/ns/sosa/systems/",
+    "http://www.w3.org/ns/sosa/sampling/",
+    "https://www.commoncoreontologies.org/CommonCoreOntologiesMerged",
+)
+
+PRODUCT_STATIC_EVIDENCE = {
+    "integrated": {
+        "byte_size": 40785,
+        "ontology_declaration_count": 1,
+        "import_count": 4,
+        "static_metadata_count": 7,
+        "formal_metadata_count": 3,
+        "logical_triple_count": 273,
+        "total_triple_count": 288,
+        "direct_governed_axiom_count": 45,
+        "governed_closure_axiom_count": 45,
+        "reasoning_mode": "independent",
+    },
+    "strict_bfo_mapping": {
+        "byte_size": 24238,
+        "ontology_declaration_count": 1,
+        "import_count": 0,
+        "static_metadata_count": 7,
+        "formal_metadata_count": 3,
+        "logical_triple_count": 157,
+        "total_triple_count": 168,
+        "direct_governed_axiom_count": 21,
+        "governed_closure_axiom_count": 21,
+        "reasoning_mode": "independent",
+    },
+    "cco_extension": {
+        "byte_size": 18092,
+        "ontology_declaration_count": 1,
+        "import_count": 1,
+        "static_metadata_count": 7,
+        "formal_metadata_count": 3,
+        "logical_triple_count": 116,
+        "total_triple_count": 128,
+        "direct_governed_axiom_count": 24,
+        "governed_closure_axiom_count": 45,
+        "reasoning_mode": "independent",
+    },
+}
+
+INPUT_POLICIES = (
+    (
+        "coms_workbook",
+        "mappings/SOSA-next-to-BFO-COMS.xlsx",
+        "sources/SOSA-2023-to-BFO-COMS.xlsx",
+    ),
+    (
+        "publication_metadata",
+        "config/sosa-2023-publication-metadata.toml",
+        "sources/sosa-2023-publication-metadata.toml",
+    ),
+    (
+        "source_version",
+        "config/sosa-source-version.toml",
+        "sources/sosa-source-version.toml",
+    ),
+    (
+        "release_scope",
+        "config/sosa-release-scope.toml",
+        "sources/sosa-release-scope.toml",
+    ),
+    (
+        "product_role_policy",
+        "config/product-role-policy.toml",
+        "sources/product-role-policy.toml",
+    ),
+    (
+        "development_integrated",
+        "releases/sosa-next/sosa-integrated.ttl",
+        None,
+    ),
+    (
+        "development_strict_bfo_mapping",
+        "releases/sosa-next/sosa-bfo-mapping.ttl",
+        None,
+    ),
+    (
+        "development_cco_extension",
+        "releases/sosa-next/sosa-cco-extension.ttl",
+        None,
+    ),
+    (
+        "pinned_sosa",
+        "src/sosa-next/imports/sosa.ttl",
+        None,
+    ),
+    (
+        "pinned_sosa_common",
+        "src/sosa-next/imports/sosa-common.ttl",
+        None,
+    ),
+    (
+        "pinned_sosa_observation",
+        "src/sosa-next/imports/sosa-observation.ttl",
+        None,
+    ),
+    (
+        "pinned_sosa_actuation",
+        "src/sosa-next/imports/sosa-actuation.ttl",
+        None,
+    ),
+    (
+        "pinned_sosa_sampling",
+        "src/sosa-next/imports/sosa-sampling.ttl",
+        None,
+    ),
+    (
+        "pinned_sosa_deprecated",
+        "src/sosa-next/imports/sosa-deprecated.ttl",
+        None,
+    ),
+    (
+        "pinned_sosa_system",
+        "src/sosa-next/imports/sosa-system.ttl",
+        None,
+    ),
+    (
+        "pinned_sample_relations",
+        "src/sosa-next/imports/sample-relations.ttl",
+        None,
+    ),
+    (
+        "source_declaration_overlay",
+        "src/sosa-next/imports/sosa-source-declaration-overlay.ttl",
+        None,
+    ),
+    (
+        "release_notes",
+        None,
+        "RELEASE-NOTES.md",
+    ),
+    (
+        "license",
+        "LICENSE",
+        "LICENSE",
+    ),
+    (
+        "module_coms_row_identity",
+        "tools/coms_row_identity.py",
+        None,
+    ),
+    (
+        "module_product_dispositions",
+        "tools/product_dispositions.py",
+        None,
+    ),
+    (
+        "module_modular_products",
+        "tools/modular_products.py",
+        None,
+    ),
+    (
+        "module_publication_metadata",
+        "tools/publication_metadata.py",
+        None,
+    ),
+    (
+        "module_release_context",
+        "tools/release_context.py",
+        None,
+    ),
+    (
+        "module_check_sosa_next_mapping",
+        "tools/check_sosa_next_mapping.py",
+        None,
+    ),
+    (
+        "module_generate_sosa_next_products",
+        "tools/generate_sosa_next_products.py",
+        None,
+    ),
+    (
+        "manifest_schema",
+        "config/sosa-2023-release-manifest-schema-v1.json",
+        None,
+    ),
+    (
+        "module_sosa_2023_release_manifest",
+        "tools/sosa_2023_release_manifest.py",
+        None,
+    ),
+)
+
+DEPENDENCY_POLICIES = (
+    (
+        "sosa",
+        "formal external SOSA source ontology dependency",
+        "src/sosa-next/imports/sosa.ttl",
+        "http://www.w3.org/ns/sosa/",
+    ),
+    (
+        "sosa_systems",
+        "formal external SOSA Systems ontology dependency",
+        "src/sosa-next/imports/sosa-system.ttl",
+        "http://www.w3.org/ns/sosa/systems/",
+    ),
+    (
+        "sosa_sampling",
+        "formal external SOSA Sampling ontology dependency",
+        "src/sosa-next/imports/sosa-sampling.ttl",
+        "http://www.w3.org/ns/sosa/sampling/",
+    ),
+    (
+        "merged_cco_bfo",
+        "formal external merged CCO/BFO target ontology dependency",
+        "imports/cco.ttl",
+        "https://www.commoncoreontologies.org/CommonCoreOntologiesMerged",
+    ),
+)
+
+
+def expected_version_iri(
+    product_key: str,
+    release_date: str,
+) -> str:
+    """Return the exact immutable SOSA-2023 product version IRI."""
+
+    if product_key not in PRODUCT_RELEASE_IRI_SUFFIXES:
+        raise KeyError(product_key)
+
+    return (
+        RELEASE_IRI_BASE
+        + "/"
+        + release_date
+        + "/"
+        + PRODUCT_RELEASE_IRI_SUFFIXES[product_key]
+    )
+
+
+def expected_product_imports(
+    product_key: str,
+    release_date: str,
+) -> tuple[str, ...]:
+    """Return the exact formal import contract for one manifest record."""
+
+    if product_key == "integrated":
+        return FORMAL_INTEGRATED_EXTERNAL_IMPORTS
+
+    if product_key == "strict_bfo_mapping":
+        return ()
+
+    if product_key == "cco_extension":
+        return (
+            expected_version_iri(
+                "strict_bfo_mapping",
+                release_date,
+            ),
+        )
+
+    raise KeyError(product_key)
+
+
+_base_sosa_2023_validate_release_manifest_document = (
+    validate_release_manifest_document
+)
+
+
+def _sosa_2023_policy_issues(
+    document: object,
+) -> tuple[ReleaseManifestIssue, ...]:
+    issues: list[ReleaseManifestIssue] = []
+
+    if not isinstance(document, dict):
+        return ()
+
+    if document.get("repository_iri") != REPOSITORY_IRI:
+        issues.append(
+            _issue(
+                "REPOSITORY_IRI_POLICY",
+                "repository_iri",
+                f"expected {REPOSITORY_IRI!r}",
+            )
+        )
+
+    release_date = document.get("release_date")
+    usable_release_date = (
+        release_date
+        if isinstance(release_date, str)
+        else None
+    )
+
+    inputs = document.get("inputs")
+    if isinstance(inputs, list):
+        for index, policy in enumerate(INPUT_POLICIES):
+            if index >= len(inputs):
+                break
+
+            record = inputs[index]
+            if not isinstance(record, dict):
+                continue
+
+            key, source_path, package_path = policy
+
+            if record.get("key") != key:
+                continue
+
+            observed_source = record.get("source_path")
+
+            if key == "release_notes":
+                valid_notes_source = (
+                    isinstance(observed_source, str)
+                    and observed_source.startswith(
+                        "release-notes/"
+                    )
+                    and observed_source.endswith(".md")
+                    and observed_source
+                    != "release-notes/TEMPLATE.md"
+                )
+
+                if not valid_notes_source:
+                    issues.append(
+                        _issue(
+                            "INPUT_SOURCE_POLICY",
+                            f"inputs[{index}].source_path",
+                            "expected a non-template Markdown file "
+                            "under release-notes/",
+                        )
+                    )
+
+            elif observed_source != source_path:
+                issues.append(
+                    _issue(
+                        "INPUT_SOURCE_POLICY",
+                        f"inputs[{index}].source_path",
+                        f"expected {source_path!r}",
+                    )
+                )
+
+            if record.get("package_path") != package_path:
+                issues.append(
+                    _issue(
+                        "INPUT_PACKAGE_POLICY",
+                        f"inputs[{index}].package_path",
+                        f"expected {package_path!r}",
+                    )
+                )
+
+    products = document.get("products")
+    if isinstance(products, list):
+        for index, product_key in enumerate(PRODUCT_ORDER):
+            if index >= len(products):
+                break
+
+            record = products[index]
+            if not isinstance(record, dict):
+                continue
+
+            if record.get("key") != product_key:
+                continue
+
+            expected_path = PRODUCT_PACKAGE_PATHS[product_key]
+            expected_stable = PRODUCT_STABLE_ONTOLOGY_IRIS[
+                product_key
+            ]
+
+            if record.get("path") != expected_path:
+                issues.append(
+                    _issue(
+                        "PRODUCT_PATH_POLICY",
+                        f"products[{index}].path",
+                        f"expected {expected_path!r}",
+                    )
+                )
+
+            if (
+                record.get("stable_ontology_iri")
+                != expected_stable
+            ):
+                issues.append(
+                    _issue(
+                        "PRODUCT_STABLE_IRI_POLICY",
+                        f"products[{index}].stable_ontology_iri",
+                        f"expected {expected_stable!r}",
+                    )
+                )
+
+            if usable_release_date is not None:
+                expected_version = expected_version_iri(
+                    product_key,
+                    usable_release_date,
+                )
+
+                if record.get("version_iri") != expected_version:
+                    issues.append(
+                        _issue(
+                            "PRODUCT_VERSION_IRI_POLICY",
+                            f"products[{index}].version_iri",
+                            f"expected {expected_version!r}",
+                        )
+                    )
+
+                expected_imports = list(
+                    expected_product_imports(
+                        product_key,
+                        usable_release_date,
+                    )
+                )
+
+                if record.get("imports") != expected_imports:
+                    issues.append(
+                        _issue(
+                            "PRODUCT_IMPORT_POLICY",
+                            f"products[{index}].imports",
+                            f"expected {expected_imports!r}",
+                        )
+                    )
+
+            for field, expected in (
+                PRODUCT_STATIC_EVIDENCE[product_key].items()
+            ):
+                if record.get(field) != expected:
+                    issues.append(
+                        _issue(
+                            "PRODUCT_EVIDENCE_POLICY",
+                            f"products[{index}].{field}",
+                            f"expected {expected!r}",
+                        )
+                    )
+
+            formal_values = (
+                record.get("path"),
+                record.get("stable_ontology_iri"),
+                record.get("version_iri"),
+                *(
+                    record.get("imports")
+                    if isinstance(
+                        record.get("imports"),
+                        list,
+                    )
+                    else ()
+                ),
+            )
+
+            for value in formal_values:
+                if (
+                    isinstance(value, str)
+                    and (
+                        "sosa-next" in value
+                        or "/development/" in value
+                    )
+                ):
+                    issues.append(
+                        _issue(
+                            "DEVELOPMENT_IDENTITY_LEAK",
+                            f"products[{index}]",
+                            "formal product identity contains a "
+                            "development alias or development IRI",
+                        )
+                    )
+                    break
+
+    dependencies = document.get("dependencies")
+    if isinstance(dependencies, list):
+        for index, policy in enumerate(DEPENDENCY_POLICIES):
+            if index >= len(dependencies):
+                break
+
+            record = dependencies[index]
+            if not isinstance(record, dict):
+                continue
+
+            key, role, dependency_path, ontology_iri = policy
+
+            if record.get("key") != key:
+                continue
+
+            exact_fields = (
+                ("role", role),
+                ("path", dependency_path),
+                ("ontology_iri", ontology_iri),
+            )
+
+            for field, expected in exact_fields:
+                if record.get(field) != expected:
+                    issues.append(
+                        _issue(
+                            "DEPENDENCY_POLICY",
+                            f"dependencies[{index}].{field}",
+                            f"expected {expected!r}",
+                        )
+                    )
+
+    included = document.get("included_files")
+    if isinstance(included, list):
+        for index, record in enumerate(included):
+            if not isinstance(record, dict):
+                continue
+
+            value = record.get("path")
+
+            if (
+                isinstance(value, str)
+                and "sosa-next" in value
+            ):
+                issues.append(
+                    _issue(
+                        "DEVELOPMENT_IDENTITY_LEAK",
+                        f"included_files[{index}].path",
+                        "formal package path contains sosa-next",
+                    )
+                )
+
+    return tuple(
+        sorted(
+            set(issues),
+            key=lambda value: value.sort_key,
+        )
+    )
+
+
+def validate_release_manifest_document(
+    document: object,
+) -> tuple[ReleaseManifestIssue, ...]:
+    """Validate generic schema rules plus exact SOSA-2023 policy."""
+
+    issues = list(
+        _base_sosa_2023_validate_release_manifest_document(
+            document
+        )
+    )
+
+    issues.extend(
+        _sosa_2023_policy_issues(document)
+    )
+
+    return tuple(
+        sorted(
+            set(issues),
+            key=lambda value: value.sort_key,
+        )
+    )


### PR DESCRIPTION
## Summary

Add a separate SOSA-2023 release-manifest/schema evidence authority for the immutable source-version track.

- add `config/sosa-2023-release-manifest-schema-v1.json`
- add `tools/sosa_2023_release_manifest.py`
- add focused SOSA-2023 manifest regressions
- keep the current-track manifest schema-v2 and release tooling unchanged
- govern exactly three formal products: Integrated, Strict BFO Mapping, and CCO Extension
- govern immutable SOSA-2023 formal package paths and ontology identities
- record governed development products, pinned W3C sources, the local source-declaration overlay, and byte-affecting modules as release evidence
- add the manifest gate to the authoritative validation suite
- update product architecture, validation documentation, release-integration audit, and product contract

## Manifest evidence contract

Canonical formal product order:

1. Integrated
2. Strict BFO Mapping
3. CCO Extension

Formal fixed-closure HermiT evidence:

- Integrated: 15,130 triples
- Strict BFO Mapping: 15,014 triples
- CCO Extension: 15,141 triples

The manifest authority records:

- 28 governed input-evidence records
- 4 formal external dependency records
- 11 prospective included-file records
- exact formal product paths and import counts
- exact logical and total triple counts
- exact direct and governed-closure axiom counts
- validation-environment identity
- product-specific reasoning evidence

Development paths containing `sosa-next` are retained only as governed development/source evidence. Formal product and package identities use the immutable source identity:

`sosa-2023-af425a0454ec00512a5ebfa2873fe35a077f5fda`

## Validation

`make check` completed successfully with:

- SOSA-2023 publication-metadata focused tests: PASS
- SOSA-2023 formal-rendering focused tests: PASS
- SOSA-2023 release-manifest focused tests: PASS
- full repository validation suite: PASS

Additional preservation checks confirmed that the following remain byte-identical:

- current manifest schema-v2
- current release-manifest implementation/tests
- current release package builder/checker
- archive and rehearsal tooling
- current SSN/SOSA formal products
- maintained SOSA-2023 development products
- pinned source ontologies

## Scope

This PR establishes the manifest/schema evidence authority only.

It does **not** yet implement:

- SOSA-2023 package construction
- package catalog generation
- checksum production
- archive construction
- release notes/rehearsal integration
- publication
