### PR TITLE
Make retained-example byte checks portable

### DIFF
--- a/tests/test_robot_retained_example_validation_pilot.py
+++ b/tests/test_robot_retained_example_validation_pilot.py
@@ -91,7 +91,22 @@ class RobotRetainedExampleValidationPilotTests(unittest.TestCase):
             )
             self.assertEqual(
                 summary["raw_byte_reproducible_count"],
-                10,
+                sum(
+                    1
+                    for result in summary["examples"]
+                    if result["raw_bytes_equal"]
+                ),
+            )
+            self.assertLessEqual(
+                summary["raw_byte_reproducible_count"],
+                summary["successful_example_count"],
+            )
+            self.assertEqual(
+                summary["disposition"],
+                "ROBOT convert is accepted as a permanent read-only "
+                "retained-example parse gate; normalized graph equivalence "
+                "is authoritative for this gate, while raw converted bytes "
+                "are not",
             )
             self.assertEqual(
                 summary["canonical_reproducible_count"],
@@ -173,11 +188,6 @@ class RobotRetainedExampleValidationPilotTests(unittest.TestCase):
                     ],
                 )
 
-            self.assertFalse(
-                examples[
-                    "sosa-instance-data/ip68.ttl"
-                ]["raw_bytes_equal"]
-            )
             self.assertTrue(
                 examples[
                     "sosa-instance-data/iphone_barometer-sosa.ttl"


### PR DESCRIPTION
## Summary

Remove a platform-sensitive raw-byte reproducibility assumption from the retained-example ROBOT validation regression.

The pilot's governed acceptance criterion is normalized graph equivalence, not exact serializer bytes. The previous test nevertheless required:

- exactly 10 of 11 retained examples to be raw-byte-identical; and
- `ip68.ttl` specifically to differ at the raw-byte level.

That assumption passes with the local macOS/Oracle Java environment but failed on GitHub's Linux/Temurin runner, where all 11 conversions were raw-byte-identical.

## Change

- retain `raw_byte_reproducible_count` as diagnostic evidence
- verify that the reported count matches the per-example `raw_bytes_equal` results
- retain the upper-bound consistency check
- explicitly verify the pilot disposition stating that normalized graph equivalence is authoritative while raw converted bytes are not
- remove the platform-specific `ip68.ttl` raw-byte inequality assertion

All semantic/canonical acceptance checks remain unchanged.

## Validation

Locally:

- exact retained-example test: PASS
- complete 12-test ROBOT focused suite: PASS
- Python compile: PASS
- `git diff --check`: PASS

This PR changes only:

`tests/test_robot_retained_example_validation_pilot.py`
