### PR TITLE
Add SOSA-2023 package construction

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: validate validate-write audit-write legacy-audit-write compile check check-coms check-sosa-next check-coms-row-identities check-coms-product-dispositions check-alignment-core check-strict-bfo-mapping check-cco-extension check-publication-metadata check-release-rendering check-release-package check-release-archive check-release-rehearsal check-placeholder-catalog-migration watch-coms coms-status post-merge-check status diffstat generate-sosa-next-products check-sosa-next-products check-sosa-next-consumer-stack check-sosa-2023-publication-rendering check-sosa-2023-release-manifest check-sosa-source-version check-product-role-policy check-sosa-release-scope
+.PHONY: validate validate-write audit-write legacy-audit-write compile check check-coms check-sosa-next check-coms-row-identities check-coms-product-dispositions check-alignment-core check-strict-bfo-mapping check-cco-extension check-publication-metadata check-release-rendering check-release-package check-release-archive check-release-rehearsal check-placeholder-catalog-migration watch-coms coms-status post-merge-check status diffstat generate-sosa-next-products check-sosa-next-products check-sosa-next-consumer-stack check-sosa-2023-publication-rendering check-sosa-2023-release-manifest check-sosa-2023-package check-sosa-source-version check-product-role-policy check-sosa-release-scope
 
 validate:
 	PYTHONDONTWRITEBYTECODE=1 python tools/run_validation_suite.py
@@ -48,6 +48,10 @@ compile:
 		tools/check_publication_metadata.py \
 		tools/release_context.py \
 		tools/release_manifest.py \
+		tools/sosa_2023_release_manifest.py \
+		tools/sosa_2023_release_runtime.py \
+		tools/sosa_2023_build_release.py \
+		tools/sosa_2023_check_release.py \
 		tools/build_release.py \
 		tools/check_release.py \
 		tools/release_archive.py \
@@ -62,6 +66,8 @@ compile:
 		tests/test_sosa_2023_publication_metadata.py \
 		tests/test_sosa_2023_release_rendering.py \
 		tests/test_sosa_2023_release_manifest.py \
+		tests/test_sosa_2023_release_runtime.py \
+		tests/test_sosa_2023_build_release.py \
 		tests/test_robot_diff_pilot.py \
 		tests/test_robot_extract_pilot.py \
 		tests/test_robot_query_equivalence_pilot.py \
@@ -141,6 +147,9 @@ check-sosa-2023-publication-rendering:
 
 check-sosa-2023-release-manifest:
 	PYTHONDONTWRITEBYTECODE=1 python -m unittest discover -s tests -p 'test_sosa_2023_release_manifest.py'
+
+check-sosa-2023-package:
+	PYTHONDONTWRITEBYTECODE=1 python -m unittest tests.test_sosa_2023_release_runtime tests.test_sosa_2023_build_release
 
 check-coms:
 	PYTHONDONTWRITEBYTECODE=1 python tools/check_coms_mapping.py

--- a/config/sosa-2023-release-manifest-schema-v1.json
+++ b/config/sosa-2023-release-manifest-schema-v1.json
@@ -42,8 +42,8 @@
     },
     "inputs": {
       "type": "array",
-      "minItems": 28,
-      "maxItems": 28,
+      "minItems": 31,
+      "maxItems": 31,
       "prefixItems": [
         {
           "allOf": [
@@ -601,6 +601,66 @@
               }
             }
           ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/input"
+            },
+            {
+              "properties": {
+                "key": {
+                  "const": "module_sosa_2023_release_runtime"
+                },
+                "package_path": {
+                  "const": null
+                },
+                "source_path": {
+                  "const": "tools/sosa_2023_release_runtime.py"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/input"
+            },
+            {
+              "properties": {
+                "key": {
+                  "const": "module_sosa_2023_build_release"
+                },
+                "package_path": {
+                  "const": null
+                },
+                "source_path": {
+                  "const": "tools/sosa_2023_build_release.py"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "$ref": "#/$defs/input"
+            },
+            {
+              "properties": {
+                "key": {
+                  "const": "module_sosa_2023_check_release"
+                },
+                "package_path": {
+                  "const": null
+                },
+                "source_path": {
+                  "const": "tools/sosa_2023_check_release.py"
+                }
+              }
+            }
+          ]
         }
       ],
       "items": false
@@ -850,7 +910,7 @@
                   "const": "src/sosa-next/imports/sosa-sampling.ttl"
                 },
                 "ontology_iri": {
-                  "const": "http://www.w3.org/ns/sosa/sampling/"
+                  "const": "http://www.w3.org/ns/sosa/sam/"
                 }
               }
             }

--- a/docs/PRODUCT-ARCHITECTURE.md
+++ b/docs/PRODUCT-ARCHITECTURE.md
@@ -204,8 +204,10 @@ The maintained product hashes are:
 | BFO Mapping | `67bb58ea543e654ace41c0d1a393b2a3f92426c693f5100f0aa3ba35f3b005d2` |
 | CCO Extension | `e65e96f15a55e19fc43be8dbda6e56351ef40bbd6e0fa9368a240e83c5d6bb69` |
 
-The source-version track remains a separate future formal package, but its
-publication-metadata, formal-rendering, and release-manifest evidence layers are now implemented.
+The source-version track remains a separate formal package. Its
+publication-metadata, formal-rendering, release-manifest, deterministic
+package-construction, canonical package-catalog, checksum, and read-only
+package-validation layers are now implemented.
 
 The separate manifest authority is
 `config/sosa-2023-release-manifest-schema-v1.json`, implemented by
@@ -215,20 +217,23 @@ release tracks back into one inventory.
 
 Its canonical product inventory is exactly Integrated, Strict BFO Mapping, and
 CCO Extension. Formal HermiT closure evidence is fixed at 15,130, 15,014, and
-15,141 triples respectively. The manifest model also governs source-version
-and pinned-source evidence, development and formal product evidence, exact
-formal imports and prospective package paths, byte-affecting modules,
-validation-environment identity, and the prospective included-file inventory.
+15,141 triples respectively. The manifest records 31 governed inputs, including
+the SOSA-2023 package runtime, builder, and checker as byte-affecting
+non-packaged evidence. It also records four external dependency records and an
+11-member included-file evidence inventory.
 
 The source-declaration overlay remains governed source/validation evidence; it
-is not a formal ontology import. The manifest authority defines what the
-future SOSA-2023 package must prove, but does not yet build that package.
+is not a formal ontology import. The pinned Sampling dependency file declares
+`http://www.w3.org/ns/sosa/sam/`; this dependency identity is intentionally
+distinct from the formal Integrated product import
+`http://www.w3.org/ns/sosa/sampling/`.
 
 `config/sosa-2023-publication-metadata.toml` governs the three formal product
 identities. Formal stable ontology IRIs and date-based version-IRI suffixes use
 the immutable source identity
-`sosa-2023-af425a0454ec00512a5ebfa2873fe35a077f5fda`; no formal ontology header
-retains the `sosa-next` development alias.
+`sosa-2023-af425a0454ec00512a5ebfa2873fe35a077f5fda`; no formal ontology header,
+formal package path, or package catalog entry retains the `sosa-next`
+development alias.
 
 The pure formal renderer preserves the three development logical graphs and
 uses this formal import graph:
@@ -259,9 +264,28 @@ locked at:
 | BFO Mapping | 157 | 168 | `c88cb347742a15fc003cafe2e167f7f784cc4a70653720c11f1e6247e6a3096c` |
 | CCO Extension | 116 | 128 | `bc356b515e29a21d74865101661fe1d81f2da33f86b31bf4c497109e8f9b202b` |
 
-Formal package paths and manifest/schema evidence are now governed. Package
-construction, package catalog, archive, release notes, rehearsal, and actual
-publication remain future formal-package work.
+The separate package engine is implemented by
+`tools/sosa_2023_release_runtime.py`, `tools/sosa_2023_build_release.py`, and
+`tools/sosa_2023_check_release.py`. A complete SOSA-2023 package contains 13
+regular files: 11 manifest-evidenced members plus `manifest.json` and
+`SHA256SUMS`. The checksum inventory covers exactly 12 files and excludes only
+`SHA256SUMS` itself.
+
+The canonical package catalog maps exactly the three same-release formal
+version IRIs to their package-relative products. Package construction performs
+two complete independent builds, requires byte identity across all 13 files,
+runs fixed-closure HermiT validation, and publishes the candidate only after a
+read-only package check succeeds. The checker independently reconstructs the
+formal products from the packaged workbook and packaged publication metadata;
+full reconstruction must reproduce all 13 files byte-for-byte without changing
+the retained package.
+
+`release-notes/SOSA-2023-SYNTHETIC-2099-01-02.md` is a deterministic
+package-engineering fixture only. It is not an actual release announcement,
+tag, publication decision, or deployment.
+
+Archive authority, release rehearsal, actual release-context selection, and
+publication remain future formal-release work.
 
 Focused validation:
 
@@ -273,6 +297,8 @@ make check-sosa-next
 make check-sosa-next-products
 make check-sosa-next-consumer-stack
 make check-sosa-2023-publication-rendering
+make check-sosa-2023-release-manifest
+make check-sosa-2023-package
 ```
 
 For the development and formal-rendering contract, see

--- a/docs/VALIDATION-AND-RELEASES.md
+++ b/docs/VALIDATION-AND-RELEASES.md
@@ -12,7 +12,7 @@ It includes:
 - modular-product tests
 - SOSA-next maintained-product tests
 - SOSA-next catalog consumer-stack tests
-- SOSA-2023 publication-metadata and formal-rendering tests
+- SOSA-2023 publication-metadata, formal-rendering, manifest, and package tests
 - publication-metadata validation
 - formal release-context and rendering tests
 - release-package, archive, and rehearsal tests
@@ -87,8 +87,9 @@ copied into that package.
 
 ## SOSA-2023 validation
 
-The SOSA-2023 workbook, maintained development products, and formal-rendering
-contract have separate focused gates:
+The SOSA-2023 workbook, maintained development products, formal rendering,
+manifest authority, and deterministic package engine have separate focused
+gates:
 
 ```bash
 make check-sosa-source-version
@@ -98,6 +99,8 @@ make check-sosa-next
 make check-sosa-next-products
 make check-sosa-next-consumer-stack
 make check-sosa-2023-publication-rendering
+make check-sosa-2023-release-manifest
+make check-sosa-2023-package
 ```
 
 `make check-sosa-source-version` validates the approved immutable source
@@ -137,12 +140,12 @@ Integrated and modular import boundaries, loads the 290-triple editor project
 closure, and confirms that BFO Mapping and CCO Extension remain independently
 resolvable.
 
-`make check-sosa-2023-publication-rendering` validates the separate
-SOSA-2023 publication-metadata authority and renders all three formal products
-twice under a fixed synthetic release context. It requires exact stable and
-version IRIs, exact formal import boundaries, preservation of the development
-logical graphs, byte-identical independent renders, and the locked synthetic
-formal byte contract:
+`make check-sosa-2023-publication-rendering` validates the separate SOSA-2023
+publication-metadata authority and renders all three formal products twice
+under a fixed synthetic release context. It requires exact stable and version
+IRIs, exact formal import boundaries, preservation of the development logical
+graphs, byte-identical independent renders, and the locked synthetic formal
+byte contract:
 
 - Integrated: 273 logical triples, 288 total triples,
   SHA-256 `81694ddfc0a7587c2d83517f0fc69449a25dc31ae68571b0a63f48aa5ca10aae`;
@@ -157,38 +160,66 @@ governed source/validation evidence but is not a published ontology import.
 Formal BFO Mapping is import-free. Formal CCO Extension imports the same-release
 formal BFO Mapping version IRI.
 
-These checks are included in `make check` and hosted CI. The formal-rendering
-gate operates entirely in memory and does not create a manifest, package,
-archive, tag, GitHub release, or persistent-IRI deployment.
-
-### SOSA-2023 release-manifest evidence validation
-
 `make check-sosa-2023-release-manifest` validates the separate SOSA-2023
-manifest/schema evidence authority without constructing a release package.
-The authority consists of
-`config/sosa-2023-release-manifest-schema-v1.json`,
-`tools/sosa_2023_release_manifest.py`, and its focused regression contract.
+schema-v1 manifest authority. The canonical evidence model records 31 governed
+inputs, including the package runtime, builder, and checker as byte-affecting
+non-packaged inputs; four formal external dependencies; the exact three-product
+formal inventory; fixed HermiT closure counts of 15,130 / 15,014 / 15,141; and
+an 11-member included-file evidence inventory.
 
-The canonical manifest product order is Integrated, Strict BFO Mapping, and
-CCO Extension. Product-specific formal HermiT closure evidence is fixed at
-15,130, 15,014, and 15,141 triples respectively.
+The Sampling dependency evidence records the ontology identity actually
+declared by the pinned file, `http://www.w3.org/ns/sosa/sam/`. This is
+deliberately distinct from the formal Integrated import
+`http://www.w3.org/ns/sosa/sampling/`.
 
-The evidence model records 28 governed inputs: the SOSA-2023 COMS workbook,
-publication metadata, source-version and release-scope authorities,
-product-role policy, all three maintained development products, all eight
-pinned W3C source files, the local source-declaration overlay, release inputs,
-and the byte-affecting implementation modules. It also records four formal
-external dependencies and an 11-member prospective included-file inventory.
+`make check-sosa-2023-package` runs the package-runtime and package-construction
+regressions. The production surfaces are
+`tools/sosa_2023_release_runtime.py`, `tools/sosa_2023_build_release.py`, and
+`tools/sosa_2023_check_release.py`; they remain separate from the current-track
+release engine.
 
-Formal product/package identities use the immutable
-`sosa-2023-af425a0454ec00512a5ebfa2873fe35a077f5fda` identity. Paths containing
-the `sosa-next` development alias remain permissible only as governed
-development or pinned-source evidence; they are prohibited from formal product
-and included-file identities.
+A complete synthetic SOSA-2023 package contains exactly 13 regular files:
 
-This milestone governs manifest evidence only. Package construction, package
-catalog generation, checksum production, archive construction, release
-rehearsal, and publication remain later milestones.
+```text
+<release-id>/
+  LICENSE
+  RELEASE-NOTES.md
+  SHA256SUMS
+  catalog-v001.xml
+  manifest.json
+  sosa-2023-af425a0454ec00512a5ebfa2873fe35a077f5fda/
+    sosa-bfo-mapping.ttl
+    sosa-cco-extension.ttl
+    sosa-integrated.ttl
+  sources/
+    SOSA-2023-to-BFO-COMS.xlsx
+    product-role-policy.toml
+    sosa-2023-publication-metadata.toml
+    sosa-release-scope.toml
+    sosa-source-version.toml
+```
+
+The manifest evidences 11 package members. `manifest.json` and `SHA256SUMS`
+are excluded from the manifest's included-file records to avoid circularity.
+`SHA256SUMS` covers the other 12 files and excludes itself.
+
+Package construction renders from the copied package inputs, generates the
+canonical three-entry same-release catalog, performs fixed-closure HermiT
+validation, constructs two independent complete packages, and requires all 13
+files to be byte-identical before retaining a candidate. The read-only checker
+recomputes product, input, dependency, catalog, checksum, validation-environment,
+and included-file evidence and can independently reconstruct a complete package.
+The full reconstruction regression requires 13/13 byte identity while preserving
+the original package bytes and mtimes.
+
+`release-notes/SOSA-2023-SYNTHETIC-2099-01-02.md` is a deterministic test
+fixture only. Package tests create only temporary synthetic packages; they do
+not create a tag, GitHub release, release archive, persistent-IRI deployment,
+or actual publication.
+
+These gates are included in `make check` and hosted CI. SOSA-2023 deterministic
+archive authority, isolated release rehearsal, and actual publication remain
+later milestones.
 
 ## Publication metadata
 
@@ -234,10 +265,12 @@ immutable-release authority status, add `owl:versionIRI`, plain
 `owl:versionInfo`, and `dcterms:issued` as `xsd:date`, and preserve the
 development logical graph.
 
-The SOSA-2023 renderer is currently a pure in-memory rendering capability. It
-now defines the separate SOSA-2023 release-manifest evidence authority, but does not yet construct the formal package.
+The SOSA-2023 renderer remains a pure in-memory rendering capability. The
+separate SOSA-2023 package engine invokes that renderer from copied package
+inputs and is validated independently by `make check-sosa-2023-package`. The
+current-track release machinery remains separate and unchanged.
 
-## Release package
+## Current-track release package
 
 `tools/build_release.py` builds a deterministic current-track candidate package only at an explicit absent output directory.
 

--- a/release-notes/SOSA-2023-SYNTHETIC-2099-01-02.md
+++ b/release-notes/SOSA-2023-SYNTHETIC-2099-01-02.md
@@ -1,0 +1,47 @@
+# Release identity
+
+Synthetic SOSA-2023 identity 2099-01-02 is a deterministic package-engineering fixture. It is not an actual release announcement, tag, GitHub release, upload, deployment, or persistent-IRI publication.
+
+# Included products
+
+The fixture contains the formal SOSA-2023 Integrated, Strict BFO Mapping, and CCO Extension products together with the governed package evidence required by the SOSA-2023 release-manifest authority.
+
+# Product selection guidance
+
+The Integrated product provides the complete governed SOSA-2023 mapping in one ontology. The Strict BFO Mapping provides the BFO-bearing mapping layer without weakening. The CCO Extension provides the governed CCO-bearing and mixed BFO/CCO axioms and imports the same-release Strict BFO Mapping.
+
+# Governed axiom and closure summary
+
+The package records the governed 45-axiom formal mapping set and the fixed HermiT validation closures defined by the SOSA-2023 release-manifest authority.
+
+# Import graph
+
+The Integrated product imports the governed external SOSA source ontologies and merged CCO/BFO target dependency. The Strict BFO Mapping imports no same-release or external ontology. The CCO Extension imports the same-release Strict BFO Mapping version IRI.
+
+# BFO projection notice
+
+No SOSA-2023 BFO Projection product is materialized because no approved weakened but sound BFO consequence currently provides a distinct consumer function.
+
+# Validation summary
+
+This fixture exercises deterministic formal rendering, canonical catalog generation, manifest evidence, checksum generation, independent HermiT validation, development-artifact nonmutation, and complete-package reconstruction.
+
+# Known limitations
+
+This fixture does not establish a real publication date, release tag, GitHub release, archive asset, or persistent-IRI deployment.
+
+# Deferred functionality
+
+Archive construction, release rehearsal, actual release selection, and publication remain outside this synthetic package-construction fixture.
+
+# License scope
+
+The package carries the governed project LICENSE file unchanged.
+
+# Dependencies
+
+External ontology dependencies remain governed by their pinned repository copies and exact hashes; they are validation dependencies and are not redistributed as package members.
+
+# Reproduction
+
+Use the committed repository inputs together with the explicit synthetic 2099-01-02 release context only for deterministic SOSA-2023 package-engineering regression coverage.

--- a/reports/sosa-next-formal-release-integration-audit.md
+++ b/reports/sosa-next-formal-release-integration-audit.md
@@ -129,7 +129,8 @@ release-IRI suffixes rooted in the approved immutable source identity.
 
 The metadata `path` fields identify the maintained development source products
 used by the renderer; they are not formal package-relative paths. Canonical
-package paths remain part of the separate package-construction milestone.
+formal package paths are now governed separately by the SOSA-2023 manifest and
+package-construction authority.
 
 ### Formal rendering — implemented
 
@@ -182,44 +183,62 @@ Implemented manifest evidence now fixes:
 
 - product order: Integrated, Strict BFO Mapping, CCO Extension;
 - formal fixed-closure HermiT counts: 15,130 / 15,014 / 15,141;
-- 28 governed input-evidence records;
+- 31 governed input-evidence records, including the package runtime, builder,
+  and checker as byte-affecting non-packaged inputs;
 - four external formal dependency records;
-- an 11-member prospective included-file inventory;
+- an 11-member included-file evidence inventory;
 - immutable source-version formal package paths with no `sosa-next` identity;
 - preservation of the current manifest schema-v2 and current release tooling.
 
-The authority is intentionally pre-package: it validates the canonical
-manifest/evidence contract without constructing a release directory,
-`manifest.json`, package catalog, checksum inventory, or archive.
+The Sampling dependency record uses the ontology identity declared by the
+pinned file, `http://www.w3.org/ns/sosa/sam/`. The formal Integrated product
+continues to import `http://www.w3.org/ns/sosa/sampling/`; dependency evidence
+and formal import identity are deliberately distinct.
 
-### Package layout
+The package-construction layer is now implemented by
+`tools/sosa_2023_release_runtime.py`, `tools/sosa_2023_build_release.py`, and
+`tools/sosa_2023_check_release.py`. It remains separate from the current-track
+package engine.
 
-A formal package needs an explicit canonical layout. At minimum it requires:
+### Package layout — implemented
+
+The canonical SOSA-2023 package contains exactly 13 regular files:
 
 - license;
-- release notes;
-- checksum inventory;
+- SOSA-2023 synthetic/approved release notes;
+- `SHA256SUMS`;
 - the three formal ontology products;
-- a package-relative project catalog;
-- canonical manifest;
-- governed SOSA-next COMS workbook;
-- governed publication metadata;
-- sufficient pinned-source evidence to identify the mapped source closure.
+- a three-entry package-relative formal catalog;
+- canonical `manifest.json`;
+- the governed SOSA-2023 COMS workbook;
+- product-role policy;
+- SOSA-2023 publication metadata;
+- release-scope policy;
+- immutable source-version evidence.
 
-The project must decide whether pinned external ontology files are recorded
-only by identity and hash, as in the current release, or redistributed when
-their licenses permit. No dependency should be copied implicitly.
+The manifest included-file inventory contains 11 members. `manifest.json` and
+`SHA256SUMS` are excluded from that inventory to avoid circular evidence.
+`SHA256SUMS` covers exactly the other 12 files and excludes itself.
 
-### Package catalog
+External dependencies are recorded by exact identity, path, hash, and byte
+size; they are not redistributed as package members.
 
-The package catalog must map exactly the formal same-release version IRIs to
-the three package-relative products. It must not contain:
+Package construction performs two independent complete builds under the same
+formal release context, runs the three fixed HermiT profiles for each build,
+and requires all 13 package files to be byte-identical before publication of a
+candidate output directory.
 
-- development IRIs;
-- the temporary `sosa-next` identity;
-- remote dependency redirects;
-- the editor shell unless that shell is explicitly approved as a release
-  artifact.
+The read-only checker validates layout, copied inputs, same-input formal
+reconstruction, manifest evidence, dependency evidence, validation environment,
+catalog bytes, checksums, development-artifact nonmutation, and local-path
+leakage. Full reconstruction must reproduce all 13 files byte-for-byte while
+leaving the retained package bytes and mtimes unchanged.
+
+### Package catalog — implemented
+
+The package catalog maps exactly the three formal same-release version IRIs to
+the three package-relative products. It contains no development IRIs,
+`sosa-next` identity, remote dependency redirects, or editor-shell entry.
 
 ### Archive
 
@@ -251,11 +270,16 @@ The release-note template must describe:
 
 ### Release rehearsal and CI
 
-Rehearsal must build and validate two isolated copies of the new formal
-package and archive from the same commit, with network access blocked, then
-compare every retained byte. Hosted CI should validate development products
-continuously but should not create a formal package without explicit release
-context and approved release notes.
+The focused hosted/local package regression now constructs only the fixed
+synthetic SOSA-2023 package in temporary storage, validates its fixed HermiT
+closures, and exercises full read-only reconstruction. It does not retain or
+publish a real release artifact.
+
+Formal release rehearsal remains future work. It must build and validate
+isolated copies of the package and future archive from the exact requested
+commit with network access blocked, then compare every retained byte. A real
+package must not be retained, tagged, uploaded, or deployed without an explicit
+approved release context and approved release notes.
 
 ## Recommended implementation sequence
 
@@ -264,11 +288,11 @@ context and approved release notes.
    project-import rewriting.
 3. **Completed:** add a source-version manifest/schema authority and exact evidence
    model.
-4. **Then:** implement separate-package construction and read-only validation.
-5. **Then:** implement the canonical package catalog.
-6. **Then:** implement the separate package's deterministic archive authority.
-7. **Then:** add release notes, rehearsal, and hosted-CI regressions.
-8. **Finally:** run a release-context rehearsal before actual publication.
+4. **Completed:** implement separate-package construction and read-only validation.
+5. **Completed:** implement the canonical package catalog and checksum inventory.
+6. **Next:** implement the separate package's deterministic archive authority.
+7. **Then:** add isolated release rehearsal and archive regressions.
+8. **Finally:** approve a real release context and release notes, rehearse, and publish.
 
 Each stage should preserve current-track release bytes and behavior.
 

--- a/reports/sosa-next-product-contract.md
+++ b/reports/sosa-next-product-contract.md
@@ -295,8 +295,10 @@ materialize the approved roles:
 - the catalog consumer-stack tests;
 - development and governance documentation.
 
-Release package, release manifest, release archive, and formal publication
-integration remain explicitly deferred.
+The SOSA-2023 release manifest and deterministic package engine are now
+implemented separately from this maintained-development surface. Deterministic
+archive authority, isolated release rehearsal, and actual publication remain
+deferred.
 
 ## Acceptance gates
 
@@ -344,29 +346,47 @@ preserving the four retained current products.
 
 ## Formal-release transition
 
-Publication metadata and pure formal ontology rendering are implemented.
+Publication metadata, pure formal ontology rendering, the separate
+SOSA-2023 release-manifest/schema authority, deterministic package
+construction, canonical package catalog, checksums, and read-only package
+validation are implemented.
 
-The SOSA-2023 release-manifest/schema evidence authority is now implemented as
-a separate schema-v1 contract. It governs the exact three-product inventory,
-immutable formal identities and prospective package paths, formal import
-graph, source/development evidence, validation environment, and
-product-specific HermiT closure counts of 15,130 / 15,014 / 15,141. It does
-not yet construct a formal package.
+The schema-v1 manifest contract governs the exact three-product inventory,
+immutable formal identities and package paths, formal import graph,
+source/development evidence, validation environment, 31 governed inputs, four
+external dependency records, an 11-member included-file evidence inventory,
+and product-specific HermiT closure counts of 15,130 / 15,014 / 15,141.
+
+The package runtime, builder, and checker are themselves governed as
+byte-affecting non-packaged manifest inputs. They remain separate from the
+current-track release engine.
+
+The complete SOSA-2023 package contains 13 regular files and 12 checksum
+entries. Its catalog maps exactly the three same-release formal version IRIs.
+Construction requires two byte-identical complete builds. Read-only validation
+can reconstruct the package from its copied workbook and publication metadata
+and requires 13/13 byte identity without mutating the retained package.
+
+The pinned Sampling dependency declares
+`http://www.w3.org/ns/sosa/sam/`; the formal Integrated product separately
+imports `http://www.w3.org/ns/sosa/sampling/`.
+
+`release-notes/SOSA-2023-SYNTHETIC-2099-01-02.md` is a deterministic
+package-engineering fixture, not a release announcement or publication
+decision.
 
 Remaining formal-release integration work is:
 
-- define canonical formal package-relative paths that use the immutable source
-  identity rather than the `sosa-next` development alias;
-- construct and validate the separate formal package;
-- generate a package catalog resolving the three same-release formal products;
-- add canonical checksums, archive construction, release notes, and isolated
-  release rehearsal;
-- preserve offline dependency governance and prevent accidental network
-  resolution;
-- keep all placeholder and development ontology IRIs out of the formal package.
+- implement the separate package's deterministic archive authority;
+- add isolated release rehearsal and archive equivalence checks;
+- approve actual release notes and an actual release context;
+- perform the final release rehearsal before publication and persistent-IRI
+  deployment.
 
-No formal package, archive, tag, GitHub release, or persistent-IRI deployment is
-created by the current rendering milestone.
+No formal SOSA-2023 package or archive is committed to the repository, and no
+tag, GitHub release, or persistent-IRI deployment is created by this package
+construction milestone. Focused tests create only temporary synthetic package
+outputs.
 
 ## Non-goals
 

--- a/tests/test_sosa_2023_build_release.py
+++ b/tests/test_sosa_2023_build_release.py
@@ -1,0 +1,888 @@
+#!/usr/bin/env python3
+"""Regression coverage for deterministic SOSA-2023 release packaging."""
+
+from __future__ import annotations
+
+import hashlib
+import shutil
+import stat
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT / "tools"))
+
+import publication_metadata as publication  # noqa: E402
+from release_context import parse_formal_release_context  # noqa: E402
+import sosa_2023_build_release as build  # noqa: E402
+import sosa_2023_check_release as check  # noqa: E402
+import sosa_2023_release_manifest as manifest  # noqa: E402
+import sosa_2023_release_runtime as runtime  # noqa: E402
+
+
+SYNTHETIC_CONTEXT = parse_formal_release_context(
+    "2099-01-02",
+    "2099-01-02",
+    "v2099-01-02",
+    "0123456789abcdef0123456789abcdef01234567",
+)
+
+NOTES_PATH = (
+    REPO_ROOT
+    / "release-notes/SOSA-2023-SYNTHETIC-2099-01-02.md"
+)
+
+FORMAL_HASHES = {
+    "integrated":
+        "81694ddfc0a7587c2d83517f0fc69449a25dc31ae68571b0a63f48aa5ca10aae",
+    "strict_bfo_mapping":
+        "c88cb347742a15fc003cafe2e167f7f784cc4a70653720c11f1e6247e6a3096c",
+    "cco_extension":
+        "bc356b515e29a21d74865101661fe1d81f2da33f86b31bf4c497109e8f9b202b",
+}
+
+EXPECTED_CLOSURES = (
+    ("integrated", 15130),
+    ("strict_bfo_mapping", 15014),
+    ("cco_extension", 15141),
+)
+
+PACKAGE_ENGINE_INPUTS = (
+    (
+        "module_sosa_2023_release_runtime",
+        "tools/sosa_2023_release_runtime.py",
+    ),
+    (
+        "module_sosa_2023_build_release",
+        "tools/sosa_2023_build_release.py",
+    ),
+    (
+        "module_sosa_2023_check_release",
+        "tools/sosa_2023_check_release.py",
+    ),
+)
+
+
+def sha256_bytes(value: bytes) -> str:
+    return hashlib.sha256(value).hexdigest()
+
+
+def package_state(
+    root: Path,
+) -> dict[str, tuple[str, int, int]]:
+    return {
+        path.relative_to(root).as_posix(): (
+            sha256_bytes(path.read_bytes()),
+            path.stat().st_size,
+            path.stat().st_mtime_ns,
+        )
+        for path in root.rglob("*")
+        if path.is_file()
+    }
+
+
+def package_hashes(
+    root: Path,
+) -> dict[str, str]:
+    return {
+        relative: sha256_bytes(
+            (root / relative).read_bytes()
+        )
+        for relative in build.PACKAGE_FILE_PATHS
+    }
+
+
+class Sosa2023ReleasePackageTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        status = NOTES_PATH.lstat()
+
+        if (
+            not stat.S_ISREG(status.st_mode)
+            or stat.S_ISLNK(status.st_mode)
+        ):
+            raise AssertionError(
+                "synthetic SOSA-2023 notes fixture "
+                "must be a regular file"
+            )
+
+        note_issues = runtime.validate_release_notes_bytes(
+            NOTES_PATH.read_bytes(),
+            template_bytes=(
+                REPO_ROOT
+                / "release-notes/TEMPLATE.md"
+            ).read_bytes(),
+        )
+
+        if note_issues:
+            raise AssertionError(
+                "\n".join(
+                    runtime.format_issue(issue)
+                    for issue in note_issues
+                )
+            )
+
+        cls.development_before = (
+            build.snapshot_development_outputs(
+                REPO_ROOT
+            )
+        )
+
+        cls.root = Path(
+            tempfile.mkdtemp(
+                prefix="sosa-2023-release-package-tests-"
+            )
+        )
+
+        cls.package = (
+            cls.root
+            / SYNTHETIC_CONTEXT.release_identifier
+        )
+
+        cls.result = build.build_release_package(
+            SYNTHETIC_CONTEXT,
+            NOTES_PATH,
+            cls.package,
+            REPO_ROOT,
+        )
+
+        cls.manifest = (
+            manifest.load_and_validate_release_manifest(
+                cls.package / "manifest.json"
+            )
+        )
+
+        cls.baseline_state = package_state(
+            cls.package
+        )
+
+        cls.baseline_hashes = package_hashes(
+            cls.package
+        )
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        try:
+            issues = build.development_snapshot_issues(
+                REPO_ROOT,
+                cls.development_before,
+            )
+
+            if issues:
+                raise AssertionError(
+                    "\n".join(
+                        runtime.format_issue(issue)
+                        for issue in issues
+                    )
+                )
+        finally:
+            shutil.rmtree(
+                cls.root,
+                ignore_errors=True,
+            )
+
+    def copy_package(self) -> tuple[Path, Path]:
+        parent = Path(
+            tempfile.mkdtemp(
+                prefix="sosa-2023-package-copy-"
+            )
+        )
+
+        destination = (
+            parent
+            / SYNTHETIC_CONTEXT.release_identifier
+        )
+
+        shutil.copytree(
+            self.package,
+            destination,
+        )
+
+        self.addCleanup(
+            shutil.rmtree,
+            parent,
+            True,
+        )
+
+        return parent, destination
+
+    def fast_build(
+        self,
+        output: Path,
+    ):
+        with mock.patch.object(
+            build,
+            "run_independent_reasoning",
+            return_value=(
+                self.manifest.validation.hermit_results
+            ),
+        ), mock.patch.object(
+            check,
+            "validate_release_package",
+            return_value=(),
+        ):
+            return build.build_release_package(
+                SYNTHETIC_CONTEXT,
+                NOTES_PATH,
+                output,
+                REPO_ROOT,
+            )
+
+    def test_exact_package_layout_and_authority_counts(
+        self,
+    ) -> None:
+        observed = tuple(
+            path.relative_to(
+                self.package
+            ).as_posix()
+            for path in sorted(
+                self.package.rglob("*"),
+                key=lambda value: (
+                    value.relative_to(
+                        self.package
+                    ).as_posix()
+                ),
+            )
+            if path.is_file()
+        )
+
+        self.assertEqual(
+            observed,
+            build.PACKAGE_FILE_PATHS,
+        )
+
+        self.assertEqual(
+            len(observed),
+            13,
+        )
+
+        self.assertEqual(
+            len(build.CHECKSUM_PATHS),
+            12,
+        )
+
+        self.assertEqual(
+            len(self.manifest.inputs),
+            31,
+        )
+
+        self.assertEqual(
+            len(self.manifest.dependencies),
+            4,
+        )
+
+        self.assertEqual(
+            len(self.manifest.included_files),
+            11,
+        )
+
+        self.assertEqual(
+            self.manifest.product_order,
+            build.PRODUCT_ORDER,
+        )
+
+    def test_exact_formal_products_and_reasoning_evidence(
+        self,
+    ) -> None:
+        self.assertEqual(
+            {
+                value.key: value.sha256
+                for value in self.manifest.products
+            },
+            FORMAL_HASHES,
+        )
+
+        self.assertEqual(
+            tuple(
+                (
+                    value.product_key,
+                    value.fixed_closure_triple_count,
+                )
+                for value in (
+                    self.manifest
+                    .validation
+                    .hermit_results
+                )
+            ),
+            EXPECTED_CLOSURES,
+        )
+
+        for result in (
+            self.manifest
+            .validation
+            .hermit_results
+        ):
+            with self.subTest(
+                product=result.product_key
+            ):
+                self.assertEqual(
+                    result.status,
+                    "PASS",
+                )
+
+                self.assertEqual(
+                    result.return_code,
+                    0,
+                )
+
+                self.assertTrue(
+                    result.reasoned_output_produced
+                )
+
+                self.assertEqual(
+                    result.named_unsatisfiable_class_count,
+                    0,
+                )
+
+                self.assertEqual(
+                    result.owl_nothing_equivalent_named_class_count,
+                    0,
+                )
+
+    def test_package_engine_modules_are_evidenced_not_packaged(
+        self,
+    ) -> None:
+        records = {
+            value.key: value
+            for value in self.manifest.inputs
+        }
+
+        for key, source_path in PACKAGE_ENGINE_INPUTS:
+            with self.subTest(input=key):
+                record = records[key]
+
+                self.assertEqual(
+                    record.source_path,
+                    source_path,
+                )
+
+                self.assertIsNone(
+                    record.package_path,
+                )
+
+                content = (
+                    REPO_ROOT
+                    / source_path
+                ).read_bytes()
+
+                self.assertEqual(
+                    record.sha256,
+                    sha256_bytes(content),
+                )
+
+                self.assertEqual(
+                    record.byte_size,
+                    len(content),
+                )
+
+                self.assertNotIn(
+                    source_path,
+                    build.PACKAGE_FILE_PATHS,
+                )
+
+                self.assertNotIn(
+                    source_path,
+                    manifest.INCLUDED_FILE_PATH_ORDER,
+                )
+
+    def test_sampling_dependency_identity_is_distinct_from_formal_import(
+        self,
+    ) -> None:
+        dependency = next(
+            value
+            for value in self.manifest.dependencies
+            if value.key == "sosa_sampling"
+        )
+
+        integrated = next(
+            value
+            for value in self.manifest.products
+            if value.key == "integrated"
+        )
+
+        self.assertEqual(
+            dependency.ontology_iri,
+            "http://www.w3.org/ns/sosa/sam/",
+        )
+
+        self.assertIn(
+            "http://www.w3.org/ns/sosa/sampling/",
+            integrated.imports,
+        )
+
+        self.assertNotIn(
+            "http://www.w3.org/ns/sosa/sam/",
+            integrated.imports,
+        )
+
+    def test_catalog_is_exact_and_formal_only(
+        self,
+    ) -> None:
+        metadata = publication.load_metadata(
+            (
+                self.package
+                / (
+                    "sources/"
+                    "sosa-2023-publication-metadata.toml"
+                )
+            ),
+            product_order=build.PRODUCT_ORDER,
+        )
+
+        value = (
+            self.package
+            / "catalog-v001.xml"
+        ).read_bytes()
+
+        self.assertEqual(
+            build.validate_catalog_bytes(
+                value,
+                metadata,
+                SYNTHETIC_CONTEXT,
+            ),
+            (),
+        )
+
+        self.assertEqual(
+            value,
+            build.canonical_catalog_bytes(
+                metadata,
+                SYNTHETIC_CONTEXT,
+            ),
+        )
+
+        self.assertEqual(
+            value.count(b"<uri "),
+            3,
+        )
+
+        self.assertNotIn(
+            b"sosa-next",
+            value,
+        )
+
+        self.assertNotIn(
+            b"/development/",
+            value,
+        )
+
+    def test_checksum_and_manifest_anti_circularity(
+        self,
+    ) -> None:
+        lines = (
+            self.package
+            / "SHA256SUMS"
+        ).read_text(
+            encoding="ascii"
+        ).splitlines()
+
+        paths = tuple(
+            line[66:]
+            for line in lines
+        )
+
+        self.assertEqual(
+            paths,
+            build.CHECKSUM_PATHS,
+        )
+
+        self.assertEqual(
+            len(paths),
+            12,
+        )
+
+        self.assertIn(
+            "manifest.json",
+            paths,
+        )
+
+        self.assertNotIn(
+            "SHA256SUMS",
+            paths,
+        )
+
+        included = {
+            value.path
+            for value in self.manifest.included_files
+        }
+
+        self.assertNotIn(
+            "manifest.json",
+            included,
+        )
+
+        self.assertNotIn(
+            "SHA256SUMS",
+            included,
+        )
+
+        self.assertEqual(
+            build.validate_sha256sums_bytes(
+                self.package,
+                (
+                    self.package
+                    / "SHA256SUMS"
+                ).read_bytes(),
+            ),
+            (),
+        )
+
+    def test_checker_is_read_only_without_reconstruction(
+        self,
+    ) -> None:
+        before = package_state(
+            self.package
+        )
+
+        issues = check.validate_release_package(
+            self.package,
+            repository_root=REPO_ROOT,
+            reconstruct=False,
+        )
+
+        self.assertEqual(
+            issues,
+            (),
+        )
+
+        self.assertEqual(
+            package_state(
+                self.package
+            ),
+            before,
+        )
+
+    def test_full_reconstruction_is_exact_and_read_only(
+        self,
+    ) -> None:
+        before = package_state(
+            self.package
+        )
+
+        issues = check.validate_release_package(
+            self.package,
+            repository_root=REPO_ROOT,
+            reconstruct=True,
+        )
+
+        self.assertEqual(
+            issues,
+            (),
+        )
+
+        self.assertEqual(
+            package_state(
+                self.package
+            ),
+            before,
+        )
+
+    def test_fixed_context_rebuild_is_byte_identical(
+        self,
+    ) -> None:
+        parent = Path(
+            tempfile.mkdtemp(
+                prefix="sosa-2023-repeat-build-"
+            )
+        )
+
+        self.addCleanup(
+            shutil.rmtree,
+            parent,
+            True,
+        )
+
+        output = (
+            parent
+            / SYNTHETIC_CONTEXT.release_identifier
+        )
+
+        self.fast_build(
+            output
+        )
+
+        self.assertEqual(
+            package_hashes(
+                output
+            ),
+            self.baseline_hashes,
+        )
+
+    def test_checker_rejects_tampering_read_only(
+        self,
+    ) -> None:
+        cases = (
+            (
+                "license",
+                lambda root: (
+                    root / "LICENSE"
+                ).write_bytes(
+                    (
+                        root / "LICENSE"
+                    ).read_bytes()
+                    + b"tampered\n"
+                ),
+            ),
+            (
+                "catalog",
+                lambda root: (
+                    root / "catalog-v001.xml"
+                ).write_bytes(
+                    (
+                        root / "catalog-v001.xml"
+                    ).read_bytes().replace(
+                        b"<uri ",
+                        b"<uri  ",
+                        1,
+                    )
+                ),
+            ),
+            (
+                "workbook",
+                lambda root: (
+                    root
+                    / (
+                        "sources/"
+                        "SOSA-2023-to-BFO-COMS.xlsx"
+                    )
+                ).write_bytes(
+                    b"not an xlsx file"
+                ),
+            ),
+            (
+                "formal product",
+                lambda root: (
+                    root
+                    / build.PRODUCT_PACKAGE_PATHS[
+                        "integrated"
+                    ]
+                ).write_bytes(
+                    b"not turtle\n"
+                ),
+            ),
+            (
+                "checksums",
+                lambda root: (
+                    root / "SHA256SUMS"
+                ).write_bytes(
+                    (
+                        root / "SHA256SUMS"
+                    ).read_bytes().replace(
+                        b"  LICENSE",
+                        b" LICENSE",
+                        1,
+                    )
+                ),
+            ),
+        )
+
+        for name, mutate in cases:
+            with self.subTest(case=name):
+                _, package = self.copy_package()
+
+                mutate(
+                    package
+                )
+
+                after_mutation = package_state(
+                    package
+                )
+
+                issues = check.validate_release_package(
+                    package,
+                    repository_root=REPO_ROOT,
+                    reconstruct=False,
+                )
+
+                self.assertTrue(
+                    issues
+                )
+
+                self.assertEqual(
+                    package_state(
+                        package
+                    ),
+                    after_mutation,
+                )
+
+    def test_checker_rejects_package_symlink(
+        self,
+    ) -> None:
+        _, package = self.copy_package()
+
+        target = (
+            package
+            / "LICENSE"
+        )
+
+        target.unlink()
+
+        target.symlink_to(
+            REPO_ROOT / "LICENSE"
+        )
+
+        issues = check.validate_release_package(
+            package,
+            repository_root=REPO_ROOT,
+            reconstruct=False,
+        )
+
+        self.assertIn(
+            "PACKAGE_SYMLINK",
+            {
+                value.code
+                for value in issues
+            },
+        )
+
+    def test_builder_rejects_invalid_release_notes_without_residue(
+        self,
+    ) -> None:
+        parent = Path(
+            tempfile.mkdtemp(
+                prefix="sosa-2023-invalid-notes-"
+            )
+        )
+
+        self.addCleanup(
+            shutil.rmtree,
+            parent,
+            True,
+        )
+
+        repository = (
+            parent
+            / "repository"
+        )
+
+        shutil.copytree(
+            REPO_ROOT,
+            repository,
+            ignore=shutil.ignore_patterns(
+                ".git",
+                "__pycache__",
+                "*.pyc",
+                "*.pyo",
+            ),
+        )
+
+        notes = (
+            repository
+            / "release-notes/INVALID.md"
+        )
+
+        notes.write_bytes(
+            b"invalid\n"
+        )
+
+        output_parent = (
+            parent
+            / "output"
+        )
+
+        output_parent.mkdir()
+
+        output = (
+            output_parent
+            / SYNTHETIC_CONTEXT.release_identifier
+        )
+
+        with self.assertRaises(
+            runtime.ReleasePackageError
+        ):
+            build.build_release_package(
+                SYNTHETIC_CONTEXT,
+                notes,
+                output,
+                repository,
+            )
+
+        self.assertFalse(
+            output.exists()
+        )
+
+        self.assertFalse(
+            any(
+                path.name.startswith(
+                    build.TEMP_PREFIX
+                )
+                for path in output_parent.iterdir()
+            )
+        )
+
+    def test_formal_package_identity_has_no_development_alias(
+        self,
+    ) -> None:
+        rendered = "\n".join(
+            text
+            for product in self.manifest.products
+            for text in (
+                product.path,
+                product.stable_ontology_iri,
+                product.version_iri,
+                *product.imports,
+            )
+        )
+
+        self.assertNotIn(
+            "sosa-next",
+            rendered,
+        )
+
+        self.assertNotIn(
+            "/development/",
+            rendered,
+        )
+
+    def test_sosa_2023_package_engine_is_separate_from_current_engine(
+        self,
+    ) -> None:
+        for relative in (
+            "tools/sosa_2023_release_runtime.py",
+            "tools/sosa_2023_build_release.py",
+            "tools/sosa_2023_check_release.py",
+        ):
+            with self.subTest(module=relative):
+                text = (
+                    REPO_ROOT
+                    / relative
+                ).read_text(
+                    encoding="utf-8"
+                )
+
+                self.assertNotIn(
+                    "import build_release",
+                    text,
+                )
+
+                self.assertNotIn(
+                    "from build_release",
+                    text,
+                )
+
+                self.assertNotIn(
+                    "import check_release",
+                    text,
+                )
+
+                self.assertNotIn(
+                    "from check_release",
+                    text,
+                )
+
+                self.assertNotIn(
+                    "import release_manifest",
+                    text,
+                )
+
+                self.assertNotIn(
+                    "from release_manifest",
+                    text,
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_sosa_2023_release_manifest.py
+++ b/tests/test_sosa_2023_release_manifest.py
@@ -503,6 +503,93 @@ class Sosa2023ReleaseManifestTests(unittest.TestCase):
             pinned_keys <= set(records)
         )
 
+    def test_dependency_ontology_identities_match_pinned_files(self) -> None:
+        from rdflib import Graph, OWL, RDF, URIRef
+
+        for (
+            key,
+            _role,
+            source_path,
+            expected_ontology_iri,
+        ) in manifest.DEPENDENCY_POLICIES:
+            with self.subTest(dependency=key):
+                graph = Graph().parse(
+                    REPO_ROOT / source_path,
+                    format="turtle",
+                )
+
+                observed = tuple(
+                    sorted(
+                        str(value)
+                        for value in graph.subjects(
+                            RDF.type,
+                            OWL.Ontology,
+                        )
+                        if isinstance(value, URIRef)
+                    )
+                )
+
+                self.assertEqual(
+                    observed,
+                    (expected_ontology_iri,),
+                )
+
+
+    def test_package_engine_modules_are_governed_inputs(self) -> None:
+        records = {
+            value.key: value
+            for value in self.value.inputs
+        }
+
+        expected = (
+            (
+                "module_sosa_2023_release_runtime",
+                "tools/sosa_2023_release_runtime.py",
+            ),
+            (
+                "module_sosa_2023_build_release",
+                "tools/sosa_2023_build_release.py",
+            ),
+            (
+                "module_sosa_2023_check_release",
+                "tools/sosa_2023_check_release.py",
+            ),
+        )
+
+        self.assertEqual(
+            len(self.value.inputs),
+            31,
+        )
+
+        for key, source_path in expected:
+            with self.subTest(input=key):
+                record = records[key]
+                content = (
+                    REPO_ROOT / source_path
+                ).read_bytes()
+
+                self.assertEqual(
+                    record.source_path,
+                    source_path,
+                )
+                self.assertIsNone(
+                    record.package_path,
+                )
+                self.assertEqual(
+                    record.sha256,
+                    sha256(content),
+                )
+                self.assertEqual(
+                    record.byte_size,
+                    len(content),
+                )
+
+                self.assertNotIn(
+                    source_path,
+                    manifest.INCLUDED_FILE_PATH_ORDER,
+                )
+
+
     def test_exact_policy_mutations_are_rejected(self) -> None:
         variants = []
 

--- a/tests/test_sosa_2023_release_runtime.py
+++ b/tests/test_sosa_2023_release_runtime.py
@@ -1,0 +1,224 @@
+#!/usr/bin/env python3
+"""Regression contract for the independent SOSA-2023 release runtime."""
+
+from __future__ import annotations
+
+import dataclasses
+import hashlib
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT / "tools"))
+
+import build_release as current  # noqa: E402
+import sosa_2023_release_runtime as runtime  # noqa: E402
+
+
+CURRENT_BUILD_HASH = (
+    "3969aa59159dc5caf1c3f69b2ccef5ca9c9bd28d317b97dcb332e5a04fa2eb76"
+)
+
+
+def issue_signature(values):
+    return tuple(
+        (
+            value.code,
+            value.field,
+            value.message,
+        )
+        for value in values
+    )
+
+
+class Sosa2023ReleaseRuntimeTests(unittest.TestCase):
+    def test_release_note_policy_is_exactly_preserved(self) -> None:
+        template = (
+            REPO_ROOT
+            / "release-notes/TEMPLATE.md"
+        ).read_bytes()
+
+        valid = (
+            REPO_ROOT
+            / "release-notes/SYNTHETIC-2099-01-02.md"
+        ).read_bytes()
+
+        cases = (
+            valid,
+            b"",
+            b"\xff",
+            valid.replace(b"\n", b"\r\n"),
+            valid[:-1],
+            valid + b"\n",
+            valid.replace(b"Synthetic", b"Synthetic\x00", 1),
+            template,
+            valid.replace(b"Synthetic", b"Synthetic TODO", 1),
+            valid.replace(b"# Dependencies", b"## Dependencies"),
+        )
+
+        for index, value in enumerate(cases):
+            with self.subTest(index=index):
+                self.assertEqual(
+                    issue_signature(
+                        runtime.validate_release_notes_bytes(
+                            value,
+                            template_bytes=template,
+                        )
+                    ),
+                    issue_signature(
+                        current.validate_release_notes_bytes(
+                            value,
+                            template_bytes=template,
+                        )
+                    ),
+                )
+
+    def test_required_release_note_headings_are_identical(self) -> None:
+        self.assertEqual(
+            runtime.REQUIRED_RELEASE_NOTE_HEADINGS,
+            current.REQUIRED_RELEASE_NOTE_HEADINGS,
+        )
+
+    def test_offline_environment_is_identical(self) -> None:
+        fixture = {
+            "PATH": "/fixture/bin",
+            "HTTP_PROXY": "http://example.invalid:1",
+            "https_proxy": "http://example.invalid:2",
+            "NO_PROXY": "localhost",
+            "OTHER": "value",
+        }
+
+        self.assertEqual(
+            runtime.offline_subprocess_environment(
+                fixture
+            ),
+            current.offline_subprocess_environment(
+                fixture
+            ),
+        )
+
+    def test_resolved_toolchain_contract_matches_current_reference(self) -> None:
+        expected = current.resolve_validation_toolchain(
+            REPO_ROOT
+        )
+        observed = runtime.resolve_validation_toolchain(
+            REPO_ROOT
+        )
+
+        expected_fields = {
+            field.name
+            for field in dataclasses.fields(expected)
+        }
+
+        observed_fields = {
+            field.name
+            for field in dataclasses.fields(observed)
+        }
+
+        self.assertEqual(
+            observed_fields,
+            expected_fields,
+        )
+
+        for field in sorted(expected_fields):
+            with self.subTest(field=field):
+                self.assertEqual(
+                    getattr(observed, field),
+                    getattr(expected, field),
+                )
+
+        self.assertEqual(
+            observed.java_robot_command(),
+            expected.java_robot_command(),
+        )
+
+    def test_verified_launcher_uses_same_governed_runtime(self) -> None:
+        toolchain = runtime.resolve_validation_toolchain(
+            REPO_ROOT
+        )
+
+        with tempfile.TemporaryDirectory(
+            prefix="sosa-2023-release-runtime-"
+        ) as directory:
+            root = Path(directory)
+
+            with runtime.verified_robot_launcher(
+                toolchain,
+                root,
+            ) as launcher:
+                text = launcher.read_text(
+                    encoding="utf-8"
+                )
+
+                self.assertIn(
+                    str(toolchain.java_executable),
+                    text,
+                )
+                self.assertIn(
+                    str(toolchain.robot_jar),
+                    text,
+                )
+
+                for option in runtime.OFFLINE_JAVA_OPTIONS:
+                    self.assertIn(
+                        option,
+                        text,
+                    )
+
+                completed = subprocess.run(
+                    [
+                        str(launcher),
+                        "--version",
+                    ],
+                    cwd=REPO_ROOT,
+                    env=runtime.offline_subprocess_environment(),
+                    text=True,
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.PIPE,
+                    check=True,
+                )
+
+                self.assertIn(
+                    f"ROBOT version {toolchain.robot_version}",
+                    completed.stdout + completed.stderr,
+                )
+
+    def test_runtime_has_no_current_builder_or_manifest_dependency(self) -> None:
+        text = (
+            REPO_ROOT
+            / "tools/sosa_2023_release_runtime.py"
+        ).read_text(encoding="utf-8")
+
+        self.assertNotIn(
+            "import build_release",
+            text,
+        )
+        self.assertNotIn(
+            "from build_release",
+            text,
+        )
+        self.assertNotIn(
+            "release_manifest",
+            text,
+        )
+
+    def test_current_builder_remains_byte_locked(self) -> None:
+        observed = hashlib.sha256(
+            (
+                REPO_ROOT
+                / "tools/build_release.py"
+            ).read_bytes()
+        ).hexdigest()
+
+        self.assertEqual(
+            observed,
+            CURRENT_BUILD_HASH,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/run_validation_suite.py
+++ b/tools/run_validation_suite.py
@@ -420,6 +420,10 @@ def compile_check() -> StepResult:
             "tools/check_publication_metadata.py",
             "tools/release_context.py",
             "tools/release_manifest.py",
+            "tools/sosa_2023_release_manifest.py",
+            "tools/sosa_2023_release_runtime.py",
+            "tools/sosa_2023_build_release.py",
+            "tools/sosa_2023_check_release.py",
             "tools/build_release.py",
             "tools/check_release.py",
             "tools/release_archive.py",
@@ -434,6 +438,8 @@ def compile_check() -> StepResult:
             "tests/test_sosa_2023_publication_metadata.py",
             "tests/test_sosa_2023_release_rendering.py",
             "tests/test_sosa_2023_release_manifest.py",
+            "tests/test_sosa_2023_release_runtime.py",
+            "tests/test_sosa_2023_build_release.py",
             "tests/test_robot_template_generation_pilot.py",
             "tests/test_robot_property_chain_generation_pilot.py",
             "tests/test_robot_diff_pilot.py",
@@ -660,6 +666,19 @@ def run_validation_suite(args: argparse.Namespace) -> int:
                     "tests",
                     "-p",
                     "test_sosa_2023_release_manifest.py",
+                ],
+            )
+        )
+    if results[-1].passed:
+        results.append(
+            run_command(
+                "SOSA-2023 release-package focused tests",
+                [
+                    sys.executable,
+                    "-m",
+                    "unittest",
+                    "tests.test_sosa_2023_release_runtime",
+                    "tests.test_sosa_2023_build_release",
                 ],
             )
         )

--- a/tools/sosa_2023_build_release.py
+++ b/tools/sosa_2023_build_release.py
@@ -1,0 +1,2194 @@
+#!/usr/bin/env python3
+"""Build one deterministic SOSA-2023 formal-release candidate package."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import platform
+import shutil
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, Mapping
+from xml.etree import ElementTree
+from xml.sax.saxutils import quoteattr
+
+from rdflib import Graph, OWL, RDF, URIRef
+from rdflib.compare import isomorphic
+
+import check_sosa_next_mapping as mapping_checker
+import generate_mapping_from_coms as coms
+import generate_sosa_next_products as products
+import publication_metadata as publication
+from release_context import (
+    FormalReleaseContext,
+    parse_formal_release_context,
+    validate_formal_release_context,
+)
+import sosa_2023_release_manifest as manifest
+import sosa_2023_release_runtime as runtime
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+PRODUCT_ORDER = manifest.PRODUCT_ORDER
+PRODUCT_PACKAGE_PATHS = manifest.PRODUCT_PACKAGE_PATHS
+INCLUDED_FILE_PATHS = manifest.INCLUDED_FILE_PATH_ORDER
+
+PACKAGE_FILE_PATHS = tuple(
+    sorted(
+        (
+            *INCLUDED_FILE_PATHS,
+            "manifest.json",
+            "SHA256SUMS",
+        )
+    )
+)
+
+CHECKSUM_PATHS = tuple(
+    value
+    for value in PACKAGE_FILE_PATHS
+    if value != "SHA256SUMS"
+)
+
+if len(PACKAGE_FILE_PATHS) != 13:
+    raise RuntimeError(
+        "SOSA-2023 complete package must contain 13 files"
+    )
+
+if len(CHECKSUM_PATHS) != 12:
+    raise RuntimeError(
+        "SOSA-2023 checksum inventory must contain 12 files"
+    )
+
+if tuple(
+    value
+    for value in PACKAGE_FILE_PATHS
+    if value not in {"manifest.json", "SHA256SUMS"}
+) != tuple(sorted(INCLUDED_FILE_PATHS)):
+    raise RuntimeError(
+        "complete-package and included-file inventories differ"
+    )
+
+DEVELOPMENT_OUTPUT_PATHS = (
+    "releases/sosa-next/sosa-integrated.ttl",
+    "releases/sosa-next/sosa-bfo-mapping.ttl",
+    "releases/sosa-next/sosa-cco-extension.ttl",
+)
+
+CATALOG_NAMESPACE = (
+    "urn:oasis:names:tc:entity:xmlns:xml:catalog"
+)
+
+TEMP_PREFIX = ".sosa-2023-release-package-build-"
+
+
+ReleasePackageIssue = runtime.ReleasePackageIssue
+ReleasePackageError = runtime.ReleasePackageError
+DevelopmentSnapshot = runtime.DevelopmentSnapshot
+ResolvedValidationToolchain = runtime.ResolvedValidationToolchain
+
+package_issue = runtime.package_issue
+sha256_bytes = runtime.sha256_bytes
+validate_release_notes_bytes = (
+    runtime.validate_release_notes_bytes
+)
+resolve_validation_toolchain = (
+    runtime.resolve_validation_toolchain
+)
+verified_robot_launcher = (
+    runtime.verified_robot_launcher
+)
+
+
+@dataclass(frozen=True)
+class AssembledReleasePackage:
+    manifest: manifest.ReleaseManifest
+    manifest_bytes: bytes
+    catalog_bytes: bytes
+    sha256sums_bytes: bytes
+
+
+def _sha256(path: Path) -> str:
+    return sha256_bytes(
+        path.read_bytes()
+    )
+
+
+def snapshot_development_outputs(
+    repository_root: Path,
+) -> tuple[DevelopmentSnapshot, ...]:
+    values: list[DevelopmentSnapshot] = []
+
+    for relative in DEVELOPMENT_OUTPUT_PATHS:
+        path = repository_root / relative
+        content = path.read_bytes()
+
+        values.append(
+            DevelopmentSnapshot(
+                relative,
+                content,
+                sha256_bytes(content),
+                path.stat().st_mtime_ns,
+            )
+        )
+
+    return tuple(values)
+
+
+def development_snapshot_issues(
+    repository_root: Path,
+    snapshots: Iterable[DevelopmentSnapshot],
+) -> tuple[ReleasePackageIssue, ...]:
+    issues: list[ReleasePackageIssue] = []
+
+    for snapshot in snapshots:
+        path = repository_root / snapshot.path
+
+        if not path.is_file():
+            issues.append(
+                package_issue(
+                    "DEVELOPMENT_OUTPUT_MISSING",
+                    snapshot.path,
+                    "file is absent",
+                )
+            )
+            continue
+
+        content = path.read_bytes()
+
+        if (
+            content != snapshot.content
+            or sha256_bytes(content)
+            != snapshot.sha256
+        ):
+            issues.append(
+                package_issue(
+                    "DEVELOPMENT_OUTPUT_MUTATED",
+                    snapshot.path,
+                    "bytes changed",
+                )
+            )
+
+        if path.stat().st_mtime_ns != snapshot.mtime_ns:
+            issues.append(
+                package_issue(
+                    "DEVELOPMENT_OUTPUT_MTIME",
+                    snapshot.path,
+                    "mtime changed",
+                )
+            )
+
+    return tuple(
+        sorted(
+            set(issues),
+            key=lambda value: value.sort_key,
+        )
+    )
+
+
+def collect_validation_environment(
+    repository_root: Path,
+    toolchain: ResolvedValidationToolchain,
+) -> manifest.ReleaseManifestValidationEnvironment:
+    toolchain_path = (
+        "config/validation-toolchain.env"
+    )
+    requirements_path = (
+        "requirements/validation.txt"
+    )
+
+    return manifest.ReleaseManifestValidationEnvironment(
+        python_implementation=platform.python_implementation(),
+        python_version=platform.python_version(),
+        java_vendor=toolchain.java_vendor,
+        java_version=toolchain.java_version,
+        java_vm_name=toolchain.java_vm_name,
+        robot_artifact=toolchain.robot_artifact,
+        robot_version=toolchain.robot_version,
+        robot_sha256=toolchain.robot_jar_sha256,
+        toolchain_path=toolchain_path,
+        toolchain_sha256=_sha256(
+            repository_root / toolchain_path
+        ),
+        requirements_path=requirements_path,
+        requirements_sha256=_sha256(
+            repository_root / requirements_path
+        ),
+    )
+
+
+def collect_dependencies(
+    repository_root: Path,
+) -> tuple[
+    manifest.ReleaseManifestDependency,
+    ...
+]:
+    values: list[
+        manifest.ReleaseManifestDependency
+    ] = []
+
+    for (
+        key,
+        role,
+        relative,
+        expected_ontology_iri,
+    ) in manifest.DEPENDENCY_POLICIES:
+        path = repository_root / relative
+
+        graph = Graph().parse(
+            path,
+            format="turtle",
+        )
+
+        ontology_iris = sorted(
+            str(value)
+            for value in graph.subjects(
+                RDF.type,
+                OWL.Ontology,
+            )
+            if isinstance(value, URIRef)
+        )
+
+        if ontology_iris != [
+            expected_ontology_iri
+        ]:
+            raise ReleasePackageError(
+                (
+                    package_issue(
+                        "DEPENDENCY_ONTOLOGY_IDENTITY",
+                        relative,
+                        "expected "
+                        f"{[expected_ontology_iri]!r}, "
+                        f"got {ontology_iris!r}",
+                    ),
+                )
+            )
+
+        version_iris = sorted(
+            str(value)
+            for value in graph.objects(
+                URIRef(expected_ontology_iri),
+                OWL.versionIRI,
+            )
+            if isinstance(value, URIRef)
+        )
+
+        if len(version_iris) > 1:
+            raise ReleasePackageError(
+                (
+                    package_issue(
+                        "DEPENDENCY_VERSION_IDENTITY",
+                        relative,
+                        "expected at most one "
+                        "version IRI, got "
+                        f"{version_iris!r}",
+                    ),
+                )
+            )
+
+        values.append(
+            manifest.ReleaseManifestDependency(
+                key=key,
+                role=role,
+                path=relative,
+                ontology_iri=(
+                    expected_ontology_iri
+                ),
+                version_iri=(
+                    version_iris[0]
+                    if version_iris
+                    else None
+                ),
+                sha256=_sha256(path),
+                byte_size=path.stat().st_size,
+            )
+        )
+
+    return tuple(values)
+
+
+def process_workbook(
+    workbook_path: Path,
+    temporary_root: Path,
+) -> tuple[
+    list[coms.ProcessedRow],
+    dict[str, int],
+]:
+    temporary_root.mkdir(
+        parents=True,
+        exist_ok=True,
+    )
+
+    mapping_checker.validate_source_pins()
+
+    merged_source = (
+        temporary_root
+        / "sosa-2023-source-merged.ttl"
+    )
+
+    mapping_checker.build_merged_source(
+        merged_source
+    )
+
+    rows, workbook_stats = (
+        coms.read_workbook(
+            workbook_path
+        )
+    )
+
+    coms.validate_workbook_row_ids(
+        rows,
+        workbook_stats,
+    )
+
+    (
+        active,
+        deferred,
+        explicitly_unmapped,
+    ) = products.classify_workbook_rows(
+        rows
+    )
+
+    counts = {
+        "governed_row_count": len(rows),
+        "unique_row_id_count": (
+            workbook_stats.unique_row_id_count
+        ),
+        "active_mapping_count": len(active),
+        "deferred_mapping_count": len(
+            deferred
+        ),
+        "explicitly_unmapped_row_count": len(
+            explicitly_unmapped
+        ),
+    }
+
+    for (
+        key,
+        expected,
+    ) in products.EXPECTED_WORKBOOK_COUNTS.items():
+        if (
+            key
+            == "canonical_authoritative_axiom_count"
+        ):
+            continue
+
+        actual = counts[key]
+
+        if actual != expected:
+            raise ReleasePackageError(
+                (
+                    package_issue(
+                        "WORKBOOK_COUNT",
+                        key,
+                        f"expected {expected}, "
+                        f"got {actual}",
+                    ),
+                )
+            )
+
+    previous_prefix_files = dict(
+        coms.PREFIX_FILES
+    )
+
+    previous_source_imports = tuple(
+        coms.SOURCE_IMPORTS
+    )
+
+    stats = coms.WorkbookStats(
+        worksheets_read=list(
+            workbook_stats.worksheets_read
+        )
+    )
+
+    mapping_checker.configure_coms_resolver(
+        merged_source
+    )
+
+    try:
+        processed = (
+            coms.validate_and_process_rows(
+                active,
+                coms.Resolver(),
+                stats,
+            )
+        )
+    finally:
+        coms.PREFIX_FILES = (
+            previous_prefix_files
+        )
+        coms.SOURCE_IMPORTS = (
+            previous_source_imports
+        )
+
+    if dict(coms.PREFIX_FILES) != (
+        previous_prefix_files
+    ):
+        raise ReleasePackageError(
+            (
+                package_issue(
+                    "RESOLVER_STATE",
+                    "PREFIX_FILES",
+                    "resolver prefix state "
+                    "was not restored",
+                ),
+            )
+        )
+
+    if tuple(coms.SOURCE_IMPORTS) != (
+        previous_source_imports
+    ):
+        raise ReleasePackageError(
+            (
+                package_issue(
+                    "RESOLVER_STATE",
+                    "SOURCE_IMPORTS",
+                    "resolver source-import "
+                    "state was not restored",
+                ),
+            )
+        )
+
+    expected_active = (
+        products.EXPECTED_WORKBOOK_COUNTS[
+            "canonical_authoritative_axiom_count"
+        ]
+    )
+
+    if len(processed) != expected_active:
+        raise ReleasePackageError(
+            (
+                package_issue(
+                    "PROCESSED_MAPPING_COUNT",
+                    "workbook",
+                    f"expected {expected_active}, "
+                    f"got {len(processed)}",
+                ),
+            )
+        )
+
+    return processed, counts
+
+
+def render_formal_products(
+    context: FormalReleaseContext,
+    workbook_path: Path,
+    metadata_path: Path,
+    temporary_root: Path,
+    *,
+    reverse_input: bool = False,
+) -> tuple[
+    publication.PublicationMetadata,
+    dict[str, dict[str, object]],
+]:
+    validated_context = (
+        validate_formal_release_context(
+            context
+        )
+    )
+
+    metadata = publication.load_metadata(
+        metadata_path,
+        product_order=PRODUCT_ORDER,
+    )
+
+    processed, _ = process_workbook(
+        workbook_path,
+        temporary_root,
+    )
+
+    records, _ = (
+        products.build_product_records(
+            processed
+        )
+    )
+
+    rendered: dict[
+        str,
+        dict[str, object],
+    ] = {}
+
+    logical_graphs: dict[
+        str,
+        Graph,
+    ] = {}
+
+    for key in PRODUCT_ORDER:
+        if key == "integrated":
+            supplied = [
+                *records[
+                    "strict_bfo_mapping"
+                ],
+                *records[
+                    "cco_extension"
+                ],
+            ]
+        else:
+            supplied = list(
+                records[key]
+            )
+
+        if reverse_input:
+            supplied = list(
+                reversed(supplied)
+            )
+
+        (
+            serialized,
+            logical,
+            result,
+        ) = products.serialize_formal_product(
+            metadata,
+            validated_context,
+            key,
+            supplied,
+        )
+
+        rendered[key] = {
+            **result,
+            "serialized_bytes": serialized,
+            "logical_graph": logical,
+        }
+
+        logical_graphs[key] = logical
+
+    modular_union = Graph()
+
+    for key in (
+        "strict_bfo_mapping",
+        "cco_extension",
+    ):
+        for triple in logical_graphs[key]:
+            modular_union.add(triple)
+
+    if len(modular_union) != 273:
+        raise ReleasePackageError(
+            (
+                package_issue(
+                    "FORMAL_LOGICAL_UNION",
+                    "products",
+                    "expected 273 triples, "
+                    f"got {len(modular_union)}",
+                ),
+            )
+        )
+
+    if not isomorphic(
+        modular_union,
+        logical_graphs["integrated"],
+    ):
+        raise ReleasePackageError(
+            (
+                package_issue(
+                    "FORMAL_LOGICAL_UNION",
+                    "products",
+                    "modular logical union "
+                    "differs from Integrated",
+                ),
+            )
+        )
+
+    return metadata, rendered
+
+
+def formal_product_bytes(
+    rendered: Mapping[
+        str,
+        Mapping[str, object],
+    ],
+) -> dict[str, bytes]:
+    return {
+        key: rendered[key][
+            "serialized_bytes"
+        ]
+        for key in PRODUCT_ORDER
+    }
+
+
+def collect_product_records(
+    rendered: Mapping[
+        str,
+        Mapping[str, object],
+    ],
+    metadata: publication.PublicationMetadata,
+    context: FormalReleaseContext,
+) -> tuple[
+    manifest.ReleaseManifestProduct,
+    ...
+]:
+    metadata_by_key = {
+        value.key: value
+        for value in metadata.products
+    }
+
+    values: list[
+        manifest.ReleaseManifestProduct
+    ] = []
+
+    for key in PRODUCT_ORDER:
+        result = rendered[key]
+        static = (
+            manifest.PRODUCT_STATIC_EVIDENCE[
+                key
+            ]
+        )
+
+        if int(result["byte_size"]) != (
+            static["byte_size"]
+        ):
+            raise ReleasePackageError(
+                (
+                    package_issue(
+                        "PRODUCT_BYTE_SIZE",
+                        key,
+                        "expected "
+                        f"{static['byte_size']}, "
+                        f"got "
+                        f"{result['byte_size']}",
+                    ),
+                )
+            )
+
+        if int(
+            result["logical_triple_count"]
+        ) != static[
+            "logical_triple_count"
+        ]:
+            raise ReleasePackageError(
+                (
+                    package_issue(
+                        "PRODUCT_LOGICAL_COUNT",
+                        key,
+                        "formal logical triple "
+                        "count differs from "
+                        "manifest authority",
+                    ),
+                )
+            )
+
+        if int(
+            result["total_triple_count"]
+        ) != static[
+            "total_triple_count"
+        ]:
+            raise ReleasePackageError(
+                (
+                    package_issue(
+                        "PRODUCT_TOTAL_COUNT",
+                        key,
+                        "formal total triple "
+                        "count differs from "
+                        "manifest authority",
+                    ),
+                )
+            )
+
+        imports = tuple(
+            str(value)
+            for value in result["imports"]
+        )
+
+        expected_imports = (
+            manifest.expected_product_imports(
+                key,
+                context.release_date,
+            )
+        )
+
+        if imports != expected_imports:
+            raise ReleasePackageError(
+                (
+                    package_issue(
+                        "PRODUCT_IMPORTS",
+                        key,
+                        "expected "
+                        f"{expected_imports!r}, "
+                        f"got {imports!r}",
+                    ),
+                )
+            )
+
+        values.append(
+            manifest.ReleaseManifestProduct(
+                key=key,
+                path=(
+                    PRODUCT_PACKAGE_PATHS[
+                        key
+                    ]
+                ),
+                stable_ontology_iri=(
+                    metadata_by_key[
+                        key
+                    ].stable_ontology_iri
+                ),
+                version_iri=(
+                    publication
+                    .release_version_iri(
+                        metadata,
+                        key,
+                        context,
+                    )
+                ),
+                imports=imports,
+                sha256=str(
+                    result["sha256"]
+                ),
+                byte_size=int(
+                    result["byte_size"]
+                ),
+                ontology_declaration_count=(
+                    static[
+                        "ontology_declaration_count"
+                    ]
+                ),
+                import_count=static[
+                    "import_count"
+                ],
+                static_metadata_count=(
+                    static[
+                        "static_metadata_count"
+                    ]
+                ),
+                formal_metadata_count=(
+                    static[
+                        "formal_metadata_count"
+                    ]
+                ),
+                logical_triple_count=(
+                    static[
+                        "logical_triple_count"
+                    ]
+                ),
+                total_triple_count=(
+                    static[
+                        "total_triple_count"
+                    ]
+                ),
+                direct_governed_axiom_count=(
+                    static[
+                        "direct_governed_axiom_count"
+                    ]
+                ),
+                governed_closure_axiom_count=(
+                    static[
+                        "governed_closure_axiom_count"
+                    ]
+                ),
+                reasoning_mode=static[
+                    "reasoning_mode"
+                ],
+            )
+        )
+
+    return tuple(values)
+
+
+def collect_inputs(
+    repository_root: Path,
+    notes_relative: str,
+    *,
+    notes_bytes: bytes | None = None,
+) -> tuple[
+    manifest.ReleaseManifestInput,
+    ...
+]:
+    values: list[
+        manifest.ReleaseManifestInput
+    ] = []
+
+    for (
+        key,
+        source,
+        package_path,
+    ) in manifest.INPUT_POLICIES:
+        if key == "release_notes":
+            source = notes_relative
+
+            if notes_bytes is None:
+                content = (
+                    repository_root
+                    / source
+                ).read_bytes()
+            else:
+                content = notes_bytes
+        else:
+            if source is None:
+                raise ReleasePackageError(
+                    (
+                        package_issue(
+                            "INPUT_POLICY",
+                            key,
+                            "non-note input has "
+                            "no source path",
+                        ),
+                    )
+                )
+
+            content = (
+                repository_root
+                / source
+            ).read_bytes()
+
+        values.append(
+            manifest.ReleaseManifestInput(
+                key=key,
+                source_path=source,
+                package_path=package_path,
+                sha256=sha256_bytes(
+                    content
+                ),
+                byte_size=len(content),
+            )
+        )
+
+    return tuple(values)
+
+
+def collect_included_files(
+    package_dir: Path,
+) -> tuple[
+    manifest.ReleaseManifestIncludedFile,
+    ...
+]:
+    roles = {
+        "LICENSE": "project license",
+        "RELEASE-NOTES.md": (
+            "release notes"
+        ),
+        "catalog-v001.xml": (
+            "formal version-IRI catalog"
+        ),
+        PRODUCT_PACKAGE_PATHS[
+            "integrated"
+        ]: (
+            "formal Integrated ontology "
+            "product"
+        ),
+        PRODUCT_PACKAGE_PATHS[
+            "strict_bfo_mapping"
+        ]: (
+            "formal Strict BFO Mapping "
+            "ontology product"
+        ),
+        PRODUCT_PACKAGE_PATHS[
+            "cco_extension"
+        ]: (
+            "formal CCO Extension "
+            "ontology product"
+        ),
+        "sources/SOSA-2023-to-BFO-COMS.xlsx": (
+            "governed SOSA-2023 COMS "
+            "workbook"
+        ),
+        "sources/product-role-policy.toml": (
+            "governed product-role policy"
+        ),
+        "sources/sosa-2023-publication-metadata.toml": (
+            "governed SOSA-2023 "
+            "publication metadata"
+        ),
+        "sources/sosa-release-scope.toml": (
+            "governed SOSA release-scope "
+            "policy"
+        ),
+        "sources/sosa-source-version.toml": (
+            "governed immutable SOSA "
+            "source-version evidence"
+        ),
+    }
+
+    if set(roles) != set(
+        INCLUDED_FILE_PATHS
+    ):
+        raise RuntimeError(
+            "included-file role map differs "
+            "from manifest inventory"
+        )
+
+    return tuple(
+        manifest.ReleaseManifestIncludedFile(
+            path=relative,
+            role=roles[relative],
+            sha256=_sha256(
+                package_dir / relative
+            ),
+            byte_size=(
+                package_dir
+                / relative
+            ).stat().st_size,
+        )
+        for relative in INCLUDED_FILE_PATHS
+    )
+
+
+def _copy_package_inputs(
+    repository_root: Path,
+    notes_bytes: bytes,
+    package_dir: Path,
+) -> None:
+    for (
+        key,
+        source,
+        package_path,
+    ) in manifest.INPUT_POLICIES:
+        if package_path is None:
+            continue
+
+        if key == "release_notes":
+            content = notes_bytes
+        else:
+            if source is None:
+                raise RuntimeError(
+                    f"{key}: copied input "
+                    "has no source"
+                )
+
+            content = (
+                repository_root
+                / source
+            ).read_bytes()
+
+        destination = (
+            package_dir
+            / package_path
+        )
+
+        destination.parent.mkdir(
+            parents=True,
+            exist_ok=True,
+        )
+
+        destination.write_bytes(
+            content
+        )
+
+
+def canonical_catalog_bytes(
+    metadata: publication.PublicationMetadata,
+    context: FormalReleaseContext,
+) -> bytes:
+    lines = [
+        '<?xml version="1.0" encoding="UTF-8"?>',
+        (
+            f'<catalog xmlns="'
+            f'{CATALOG_NAMESPACE}">'
+        ),
+    ]
+
+    for key in PRODUCT_ORDER:
+        version_iri = (
+            publication.release_version_iri(
+                metadata,
+                key,
+                context,
+            )
+        )
+
+        lines.append(
+            "  <uri "
+            f"name={quoteattr(version_iri)} "
+            "uri="
+            f"{quoteattr(PRODUCT_PACKAGE_PATHS[key])}"
+            "/>"
+        )
+
+    lines.append("</catalog>")
+
+    return (
+        "\n".join(lines)
+        + "\n"
+    ).encode("utf-8")
+
+
+def validate_catalog_bytes(
+    value: bytes,
+    metadata: publication.PublicationMetadata,
+    context: FormalReleaseContext,
+) -> tuple[
+    ReleasePackageIssue,
+    ...
+]:
+    if any(
+        token in value
+        for token in (
+            b"<!DOCTYPE",
+            b"<!ENTITY",
+            b"<!--",
+        )
+    ):
+        return (
+            package_issue(
+                "CATALOG_PROHIBITED_XML",
+                "catalog-v001.xml",
+                "DTD, entity, and comments "
+                "are prohibited",
+            ),
+        )
+
+    issues: list[
+        ReleasePackageIssue
+    ] = []
+
+    try:
+        root = ElementTree.fromstring(
+            value
+        )
+    except (
+        ElementTree.ParseError,
+        UnicodeDecodeError,
+    ) as exc:
+        return (
+            package_issue(
+                "CATALOG_XML",
+                "catalog-v001.xml",
+                str(exc),
+            ),
+        )
+
+    if root.tag != (
+        f"{{{CATALOG_NAMESPACE}}}"
+        "catalog"
+    ):
+        issues.append(
+            package_issue(
+                "CATALOG_ROOT",
+                "catalog-v001.xml",
+                "wrong catalog namespace "
+                "or root",
+            )
+        )
+
+    entries = [
+        (
+            child.attrib.get("name"),
+            child.attrib.get("uri"),
+        )
+        for child in root
+    ]
+
+    expected = [
+        (
+            publication.release_version_iri(
+                metadata,
+                key,
+                context,
+            ),
+            PRODUCT_PACKAGE_PATHS[key],
+        )
+        for key in PRODUCT_ORDER
+    ]
+
+    if entries != expected:
+        issues.append(
+            package_issue(
+                "CATALOG_ENTRIES",
+                "catalog-v001.xml",
+                "version-IRI mappings differ",
+            )
+        )
+
+    if value != canonical_catalog_bytes(
+        metadata,
+        context,
+    ):
+        issues.append(
+            package_issue(
+                "NONCANONICAL_CATALOG",
+                "catalog-v001.xml",
+                "bytes differ from "
+                "canonical XML",
+            )
+        )
+
+    return tuple(
+        sorted(
+            set(issues),
+            key=lambda item: item.sort_key,
+        )
+    )
+
+
+def canonical_sha256sums_bytes(
+    package_dir: Path,
+) -> bytes:
+    lines = [
+        f"{_sha256(package_dir / path)}  "
+        f"{path}"
+        for path in CHECKSUM_PATHS
+    ]
+
+    return (
+        "\n".join(lines)
+        + "\n"
+    ).encode("ascii")
+
+
+def validate_sha256sums_bytes(
+    package_dir: Path,
+    value: bytes,
+) -> tuple[
+    ReleasePackageIssue,
+    ...
+]:
+    expected = (
+        canonical_sha256sums_bytes(
+            package_dir
+        )
+    )
+
+    if value == expected:
+        return ()
+
+    return (
+        package_issue(
+            "NONCANONICAL_CHECKSUMS",
+            "SHA256SUMS",
+            "bytes differ from exact "
+            "canonical checksums",
+        ),
+    )
+
+
+def run_independent_reasoning(
+    package_dir: Path,
+    temporary_root: Path,
+    toolchain: ResolvedValidationToolchain,
+) -> tuple[
+    manifest.ReleaseManifestHermitResult,
+    ...
+]:
+    serialized = {
+        key: (
+            package_dir
+            / PRODUCT_PACKAGE_PATHS[key]
+        ).read_bytes()
+        for key in PRODUCT_ORDER
+    }
+
+    profiles = {
+        "integrated": (
+            products.build_reasoning_closure(
+                (
+                    serialized[
+                        "integrated"
+                    ],
+                ),
+                include_target_dependency=True,
+            )
+        ),
+        "strict_bfo_mapping": (
+            products.build_reasoning_closure(
+                (
+                    serialized[
+                        "strict_bfo_mapping"
+                    ],
+                ),
+                include_target_dependency=True,
+            )
+        ),
+        "cco_extension": (
+            products.build_reasoning_closure(
+                (
+                    serialized[
+                        "cco_extension"
+                    ],
+                    serialized[
+                        "strict_bfo_mapping"
+                    ],
+                ),
+                include_target_dependency=True,
+            )
+        ),
+    }
+
+    expected_closures = dict(
+        manifest
+        .FORMAL_FIXED_CLOSURE_TRIPLE_COUNTS
+    )
+
+    evidence: list[
+        manifest.ReleaseManifestHermitResult
+    ] = []
+
+    issues: list[
+        ReleasePackageIssue
+    ] = []
+
+    with verified_robot_launcher(
+        toolchain,
+        temporary_root,
+    ) as launcher:
+        for key in PRODUCT_ORDER:
+            closure = profiles[key]
+
+            if list(
+                closure.triples(
+                    (
+                        None,
+                        OWL.imports,
+                        None,
+                    )
+                )
+            ):
+                issues.append(
+                    package_issue(
+                        "HERMIT_CLOSURE_IMPORTS",
+                        key,
+                        "fixed validation closure "
+                        "retains owl:imports",
+                    )
+                )
+                continue
+
+            expected_count = (
+                expected_closures[key]
+            )
+
+            if len(closure) != (
+                expected_count
+            ):
+                issues.append(
+                    package_issue(
+                        "HERMIT_CLOSURE_COUNT",
+                        key,
+                        f"expected "
+                        f"{expected_count}, "
+                        f"got {len(closure)}",
+                    )
+                )
+
+            root = (
+                temporary_root
+                / key
+            )
+
+            root.mkdir(
+                parents=True,
+                exist_ok=True,
+            )
+
+            closure_path = (
+                root / "closure.ttl"
+            )
+
+            reasoned_path = (
+                root / "reasoned.ttl"
+            )
+
+            unsat_path = (
+                root
+                / "unsatisfiable.ttl"
+            )
+
+            closure.serialize(
+                closure_path,
+                format="turtle",
+            )
+
+            result = (
+                mapping_checker
+                .run_reasoner(
+                    str(launcher),
+                    closure_path,
+                    reasoned_path,
+                    unsat_path,
+                )
+            )
+
+            inferred_unsats = {
+                URIRef(value)
+                for value in result[
+                    "unsatisfiable_classes"
+                ]
+            }
+
+            reasoned_output_produced = bool(
+                result[
+                    "reasoned_output_exists"
+                ]
+                and reasoned_path.is_file()
+                and reasoned_path.stat().st_size
+                > 0
+            )
+
+            if reasoned_output_produced:
+                reasoned_graph = (
+                    Graph().parse(
+                        reasoned_path,
+                        format="turtle",
+                    )
+                )
+
+                inferred_unsats |= set(
+                    coms.unsat_classes(
+                        reasoned_graph
+                    )
+                )
+
+            return_code = (
+                -1
+                if result[
+                    "return_code"
+                ]
+                is None
+                else int(
+                    result[
+                        "return_code"
+                    ]
+                )
+            )
+
+            passed = (
+                return_code == 0
+                and reasoned_output_produced
+                and not inferred_unsats
+                and len(closure)
+                == expected_count
+            )
+
+            if not passed:
+                issues.append(
+                    package_issue(
+                        "HERMIT_FAILED",
+                        key,
+                        str(
+                            result.get(
+                                "robot_output"
+                            )
+                            or result
+                        ),
+                    )
+                )
+
+            evidence.append(
+                manifest
+                .ReleaseManifestHermitResult(
+                    product_key=key,
+                    status=(
+                        "PASS"
+                        if passed
+                        else "FAIL"
+                    ),
+                    fixed_closure_triple_count=(
+                        len(closure)
+                    ),
+                    return_code=return_code,
+                    reasoned_output_produced=(
+                        reasoned_output_produced
+                    ),
+                    named_unsatisfiable_class_count=(
+                        len(
+                            inferred_unsats
+                        )
+                    ),
+                    owl_nothing_equivalent_named_class_count=(
+                        len(
+                            inferred_unsats
+                        )
+                    ),
+                )
+            )
+
+    if issues:
+        raise ReleasePackageError(
+            issues
+        )
+
+    return tuple(evidence)
+
+
+def _validate_paths(
+    context: FormalReleaseContext,
+    notes_source: Path,
+    output_dir: Path,
+    repository_root: Path,
+) -> str:
+    if output_dir.name != (
+        context.release_identifier
+    ):
+        raise ReleasePackageError(
+            (
+                package_issue(
+                    "OUTPUT_BASENAME",
+                    "output_dir",
+                    "expected basename "
+                    f"{context.release_identifier!r}",
+                ),
+            )
+        )
+
+    if os.path.lexists(
+        output_dir
+    ):
+        raise ReleasePackageError(
+            (
+                package_issue(
+                    "OUTPUT_EXISTS",
+                    "output_dir",
+                    "output directory "
+                    "already exists",
+                ),
+            )
+        )
+
+    if not output_dir.parent.is_dir():
+        raise ReleasePackageError(
+            (
+                package_issue(
+                    "OUTPUT_PARENT",
+                    "output_dir",
+                    "parent directory "
+                    "does not exist",
+                ),
+            )
+        )
+
+    resolved_repo = (
+        repository_root.resolve()
+    )
+
+    resolved_notes = (
+        notes_source.resolve()
+    )
+
+    try:
+        relative = (
+            resolved_notes
+            .relative_to(
+                resolved_repo
+            )
+            .as_posix()
+        )
+    except ValueError as exc:
+        raise ReleasePackageError(
+            (
+                package_issue(
+                    "NOTES_OUTSIDE_REPOSITORY",
+                    "notes_source",
+                    "notes must be inside "
+                    "repository",
+                ),
+            )
+        ) from exc
+
+    if relative == (
+        "release-notes/TEMPLATE.md"
+    ):
+        raise ReleasePackageError(
+            (
+                package_issue(
+                    "RELEASE_NOTES_TEMPLATE",
+                    "notes_source",
+                    "template cannot "
+                    "be packaged",
+                ),
+            )
+        )
+
+    if notes_source.is_symlink():
+        raise ReleasePackageError(
+            (
+                package_issue(
+                    "RELEASE_NOTES_SYMLINK",
+                    "notes_source",
+                    "notes must be a regular "
+                    "repository file",
+                ),
+            )
+        )
+
+    if not resolved_notes.is_file():
+        raise ReleasePackageError(
+            (
+                package_issue(
+                    "RELEASE_NOTES_MISSING",
+                    "notes_source",
+                    "notes file is absent",
+                ),
+            )
+        )
+
+    return relative
+
+
+def assemble_release_package(
+    context: FormalReleaseContext,
+    notes_bytes: bytes,
+    notes_relative: str,
+    package_dir: Path,
+    repository_root: Path,
+    toolchain: ResolvedValidationToolchain,
+    snapshots: tuple[
+        DevelopmentSnapshot,
+        ...
+    ],
+    *,
+    reverse_input: bool = False,
+) -> AssembledReleasePackage:
+    package_dir = Path(
+        package_dir
+    )
+
+    repository_root = (
+        repository_root.resolve()
+    )
+
+    if os.path.lexists(
+        package_dir
+    ):
+        raise ReleasePackageError(
+            (
+                package_issue(
+                    "ASSEMBLY_OUTPUT_EXISTS",
+                    "package_dir",
+                    "assembly directory exists",
+                ),
+            )
+        )
+
+    if not package_dir.parent.is_dir():
+        raise ReleasePackageError(
+            (
+                package_issue(
+                    "ASSEMBLY_PARENT",
+                    "package_dir",
+                    "assembly parent "
+                    "does not exist",
+                ),
+            )
+        )
+
+    note_issues = (
+        validate_release_notes_bytes(
+            notes_bytes,
+            template_bytes=(
+                repository_root
+                / "release-notes/TEMPLATE.md"
+            ).read_bytes(),
+        )
+    )
+
+    if note_issues:
+        raise ReleasePackageError(
+            note_issues
+        )
+
+    package_dir.mkdir()
+
+    work_root = (
+        package_dir.parent
+        / (
+            f".{package_dir.name}"
+            "-sosa-2023-build-work"
+        )
+    )
+
+    shutil.rmtree(
+        work_root,
+        ignore_errors=True,
+    )
+
+    work_root.mkdir()
+
+    try:
+        _copy_package_inputs(
+            repository_root,
+            notes_bytes,
+            package_dir,
+        )
+
+        metadata, rendered = (
+            render_formal_products(
+                context,
+                package_dir
+                / (
+                    "sources/"
+                    "SOSA-2023-to-BFO-COMS.xlsx"
+                ),
+                package_dir
+                / (
+                    "sources/"
+                    "sosa-2023-publication-"
+                    "metadata.toml"
+                ),
+                work_root / "render",
+                reverse_input=reverse_input,
+            )
+        )
+
+        for (
+            key,
+            value,
+        ) in formal_product_bytes(
+            rendered
+        ).items():
+            destination = (
+                package_dir
+                / PRODUCT_PACKAGE_PATHS[
+                    key
+                ]
+            )
+
+            destination.parent.mkdir(
+                parents=True,
+                exist_ok=True,
+            )
+
+            destination.write_bytes(
+                value
+            )
+
+        catalog = (
+            canonical_catalog_bytes(
+                metadata,
+                context,
+            )
+        )
+
+        catalog_issues = (
+            validate_catalog_bytes(
+                catalog,
+                metadata,
+                context,
+            )
+        )
+
+        if catalog_issues:
+            raise ReleasePackageError(
+                catalog_issues
+            )
+
+        (
+            package_dir
+            / "catalog-v001.xml"
+        ).write_bytes(
+            catalog
+        )
+
+        hermit = (
+            run_independent_reasoning(
+                package_dir,
+                work_root / "reasoning",
+                toolchain,
+            )
+        )
+
+        snapshot_issues = (
+            development_snapshot_issues(
+                repository_root,
+                snapshots,
+            )
+        )
+
+        if snapshot_issues:
+            raise ReleasePackageError(
+                snapshot_issues
+            )
+
+        validation = (
+            manifest.ReleaseManifestValidation(
+                strict_turtle_parsing=True,
+                formal_metadata_validation=True,
+                serialized_header_validation=True,
+                governed_axiom_reconciliation=True,
+                import_graph_validation=True,
+                catalog_validation=True,
+                checksum_validation=True,
+                development_artifact_nonmutation=True,
+                deterministic_package_rebuild=True,
+                hermit_results=hermit,
+            )
+        )
+
+        release_manifest = (
+            manifest.build_release_manifest(
+                release_identifier=(
+                    context.release_identifier
+                ),
+                release_date=(
+                    context.release_date
+                ),
+                git_tag=context.git_tag,
+                source_commit=(
+                    context.source_commit
+                ),
+                repository_iri=(
+                    metadata.publication
+                    .repository_iri
+                ),
+                inputs=collect_inputs(
+                    repository_root,
+                    notes_relative,
+                    notes_bytes=notes_bytes,
+                ),
+                product_order=(
+                    PRODUCT_ORDER
+                ),
+                products=(
+                    collect_product_records(
+                        rendered,
+                        metadata,
+                        context,
+                    )
+                ),
+                dependencies=(
+                    collect_dependencies(
+                        repository_root
+                    )
+                ),
+                validation_environment=(
+                    collect_validation_environment(
+                        repository_root,
+                        toolchain,
+                    )
+                ),
+                validation=validation,
+                included_files=(
+                    collect_included_files(
+                        package_dir
+                    )
+                ),
+            )
+        )
+
+        manifest_bytes = (
+            manifest
+            .canonical_manifest_bytes(
+                release_manifest
+            )
+        )
+
+        (
+            package_dir
+            / "manifest.json"
+        ).write_bytes(
+            manifest_bytes
+        )
+
+        (
+            manifest
+            .load_and_validate_release_manifest(
+                package_dir
+                / "manifest.json"
+            )
+        )
+
+        sums = (
+            canonical_sha256sums_bytes(
+                package_dir
+            )
+        )
+
+        (
+            package_dir
+            / "SHA256SUMS"
+        ).write_bytes(
+            sums
+        )
+
+        checksum_issues = (
+            validate_sha256sums_bytes(
+                package_dir,
+                sums,
+            )
+        )
+
+        if checksum_issues:
+            raise ReleasePackageError(
+                checksum_issues
+            )
+
+        return AssembledReleasePackage(
+            manifest=release_manifest,
+            manifest_bytes=manifest_bytes,
+            catalog_bytes=catalog,
+            sha256sums_bytes=sums,
+        )
+    except Exception:
+        shutil.rmtree(
+            package_dir,
+            ignore_errors=True,
+        )
+        raise
+    finally:
+        shutil.rmtree(
+            work_root,
+            ignore_errors=True,
+        )
+
+
+def compare_complete_packages(
+    first: Path,
+    second: Path,
+) -> tuple[
+    ReleasePackageIssue,
+    ...
+]:
+    issues: list[
+        ReleasePackageIssue
+    ] = []
+
+    for package_dir in (
+        first,
+        second,
+    ):
+        observed = tuple(
+            path.relative_to(
+                package_dir
+            ).as_posix()
+            for path in sorted(
+                package_dir.rglob("*"),
+                key=lambda value: (
+                    value.relative_to(
+                        package_dir
+                    ).as_posix()
+                ),
+            )
+            if path.is_file()
+        )
+
+        if observed != (
+            PACKAGE_FILE_PATHS
+        ):
+            issues.append(
+                package_issue(
+                    "PACKAGE_INVENTORY",
+                    str(package_dir),
+                    "expected "
+                    f"{PACKAGE_FILE_PATHS!r}, "
+                    f"got {observed!r}",
+                )
+            )
+
+    if issues:
+        return tuple(
+            sorted(
+                set(issues),
+                key=lambda value: (
+                    value.sort_key
+                ),
+            )
+        )
+
+    for relative in (
+        PACKAGE_FILE_PATHS
+    ):
+        if (
+            first / relative
+        ).read_bytes() != (
+            second / relative
+        ).read_bytes():
+            issues.append(
+                package_issue(
+                    "NONDETERMINISTIC_PACKAGE_REBUILD",
+                    relative,
+                    "independent complete "
+                    "package builds differ",
+                )
+            )
+
+    return tuple(
+        sorted(
+            set(issues),
+            key=lambda value: value.sort_key,
+        )
+    )
+
+
+def build_release_package(
+    context: FormalReleaseContext,
+    notes_source: Path,
+    output_dir: Path,
+    repository_root: Path = REPO_ROOT,
+) -> AssembledReleasePackage:
+    context = (
+        validate_formal_release_context(
+            context
+        )
+    )
+
+    repository_root = (
+        Path(repository_root).resolve()
+    )
+
+    notes_source = Path(
+        notes_source
+    )
+
+    output_dir = Path(
+        output_dir
+    )
+
+    notes_relative = _validate_paths(
+        context,
+        notes_source,
+        output_dir,
+        repository_root,
+    )
+
+    notes_bytes = (
+        notes_source.read_bytes()
+    )
+
+    note_issues = (
+        validate_release_notes_bytes(
+            notes_bytes,
+            template_bytes=(
+                repository_root
+                / "release-notes/TEMPLATE.md"
+            ).read_bytes(),
+        )
+    )
+
+    if note_issues:
+        raise ReleasePackageError(
+            note_issues
+        )
+
+    snapshots = (
+        snapshot_development_outputs(
+            repository_root
+        )
+    )
+
+    toolchain = (
+        resolve_validation_toolchain(
+            repository_root
+        )
+    )
+
+    first_root = Path(
+        tempfile.mkdtemp(
+            prefix=TEMP_PREFIX,
+            dir=output_dir.parent,
+        )
+    )
+
+    second_root = Path(
+        tempfile.mkdtemp(
+            prefix=TEMP_PREFIX,
+            dir=output_dir.parent,
+        )
+    )
+
+    first = (
+        first_root
+        / context.release_identifier
+    )
+
+    second = (
+        second_root
+        / context.release_identifier
+    )
+
+    try:
+        assemble_release_package(
+            context,
+            notes_bytes,
+            notes_relative,
+            first,
+            repository_root,
+            toolchain,
+            snapshots,
+        )
+
+        assemble_release_package(
+            context,
+            notes_bytes,
+            notes_relative,
+            second,
+            repository_root,
+            toolchain,
+            snapshots,
+            reverse_input=True,
+        )
+
+        comparison = (
+            compare_complete_packages(
+                first,
+                second,
+            )
+        )
+
+        if comparison:
+            raise ReleasePackageError(
+                comparison
+            )
+
+        snapshot_issues = (
+            development_snapshot_issues(
+                repository_root,
+                snapshots,
+            )
+        )
+
+        if snapshot_issues:
+            raise ReleasePackageError(
+                snapshot_issues
+            )
+
+        import sosa_2023_check_release as checker
+
+        validation_issues = (
+            checker.validate_release_package(
+                first,
+                repository_root=(
+                    repository_root
+                ),
+                toolchain=toolchain,
+                reconstruct=False,
+            )
+        )
+
+        if validation_issues:
+            raise ReleasePackageError(
+                validation_issues
+            )
+
+        os.replace(
+            first,
+            output_dir,
+        )
+
+        return AssembledReleasePackage(
+            manifest=(
+                manifest
+                .load_and_validate_release_manifest(
+                    output_dir
+                    / "manifest.json"
+                )
+            ),
+            manifest_bytes=(
+                output_dir
+                / "manifest.json"
+            ).read_bytes(),
+            catalog_bytes=(
+                output_dir
+                / "catalog-v001.xml"
+            ).read_bytes(),
+            sha256sums_bytes=(
+                output_dir
+                / "SHA256SUMS"
+            ).read_bytes(),
+        )
+    finally:
+        shutil.rmtree(
+            first_root,
+            ignore_errors=True,
+        )
+
+        shutil.rmtree(
+            second_root,
+            ignore_errors=True,
+        )
+
+
+def parse_args(
+    argv: list[str] | None = None,
+) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=__doc__
+    )
+
+    parser.add_argument(
+        "--release-id",
+        required=True,
+    )
+
+    parser.add_argument(
+        "--release-date",
+        required=True,
+    )
+
+    parser.add_argument(
+        "--git-tag",
+        required=True,
+    )
+
+    parser.add_argument(
+        "--source-commit",
+        required=True,
+    )
+
+    parser.add_argument(
+        "--notes",
+        required=True,
+        type=Path,
+    )
+
+    parser.add_argument(
+        "--output-dir",
+        required=True,
+        type=Path,
+    )
+
+    return parser.parse_args(
+        argv
+    )
+
+
+def main(
+    argv: list[str] | None = None,
+) -> int:
+    args = parse_args(
+        argv
+    )
+
+    try:
+        context = (
+            parse_formal_release_context(
+                args.release_id,
+                args.release_date,
+                args.git_tag,
+                args.source_commit,
+            )
+        )
+
+        result = (
+            build_release_package(
+                context,
+                args.notes,
+                args.output_dir,
+                REPO_ROOT,
+            )
+        )
+    except Exception as exc:
+        print(str(exc))
+        return 1
+
+    print(
+        "SOSA-2023 release package "
+        "build: PASS"
+    )
+
+    print(
+        "Release identifier: "
+        f"{result.manifest.release_identifier}"
+    )
+
+    print(
+        "Package files: "
+        f"{len(PACKAGE_FILE_PATHS)}"
+    )
+
+    print(
+        "Checksummed files: "
+        f"{len(CHECKSUM_PATHS)}"
+    )
+
+    print(
+        "Manifest SHA-256: "
+        + manifest.release_manifest_sha256(
+            result.manifest_bytes
+        )
+    )
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(
+        main()
+    )

--- a/tools/sosa_2023_check_release.py
+++ b/tools/sosa_2023_check_release.py
@@ -1,0 +1,967 @@
+#!/usr/bin/env python3
+"""Read-only validation for one SOSA-2023 formal release package."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import tempfile
+from pathlib import Path
+
+import sosa_2023_build_release as build
+import sosa_2023_release_manifest as manifest
+import sosa_2023_release_runtime as runtime
+from release_context import parse_formal_release_context
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+PRODUCT_ORDER = build.PRODUCT_ORDER
+PRODUCT_PACKAGE_PATHS = build.PRODUCT_PACKAGE_PATHS
+INCLUDED_FILE_PATHS = build.INCLUDED_FILE_PATHS
+PACKAGE_FILE_PATHS = build.PACKAGE_FILE_PATHS
+CHECKSUM_PATHS = build.CHECKSUM_PATHS
+DEVELOPMENT_OUTPUT_PATHS = build.DEVELOPMENT_OUTPUT_PATHS
+
+ReleasePackageIssue = runtime.ReleasePackageIssue
+ResolvedValidationToolchain = runtime.ResolvedValidationToolchain
+
+package_issue = runtime.package_issue
+
+
+def _safe_relative_path(
+    value: str,
+    *,
+    field: str,
+) -> Path:
+    path = Path(value)
+
+    if path.is_absolute():
+        raise ValueError(
+            f"{field}: absolute paths are prohibited"
+        )
+
+    if any(
+        part in ("", ".", "..")
+        for part in path.parts
+    ):
+        raise ValueError(
+            f"{field}: non-canonical relative path "
+            f"{value!r}"
+        )
+
+    return path
+
+
+def _expected_directories() -> tuple[str, ...]:
+    values: set[str] = set()
+
+    for relative in PACKAGE_FILE_PATHS:
+        parent = Path(relative).parent
+
+        while parent != Path("."):
+            values.add(
+                parent.as_posix()
+            )
+            parent = parent.parent
+
+    return tuple(sorted(values))
+
+
+EXPECTED_DIRECTORY_PATHS = _expected_directories()
+
+
+def _layout_issues(
+    package_dir: Path,
+) -> tuple[ReleasePackageIssue, ...]:
+    package_dir = Path(package_dir)
+
+    issues: list[ReleasePackageIssue] = []
+
+    if package_dir.is_symlink():
+        return (
+            package_issue(
+                "PACKAGE_SYMLINK",
+                "package_dir",
+                "package root must not be a symlink",
+            ),
+        )
+
+    if not package_dir.is_dir():
+        return (
+            package_issue(
+                "PACKAGE_MISSING",
+                "package_dir",
+                "package directory is absent",
+            ),
+        )
+
+    observed_files: list[str] = []
+    observed_directories: list[str] = []
+
+    for path in sorted(
+        package_dir.rglob("*"),
+        key=lambda item: (
+            item.relative_to(
+                package_dir
+            ).as_posix()
+        ),
+    ):
+        relative = path.relative_to(
+            package_dir
+        ).as_posix()
+
+        if path.is_symlink():
+            issues.append(
+                package_issue(
+                    "PACKAGE_SYMLINK",
+                    relative,
+                    "package entries must not "
+                    "be symlinks",
+                )
+            )
+            continue
+
+        if path.is_file():
+            observed_files.append(
+                relative
+            )
+        elif path.is_dir():
+            observed_directories.append(
+                relative
+            )
+        else:
+            issues.append(
+                package_issue(
+                    "PACKAGE_SPECIAL_FILE",
+                    relative,
+                    "package contains a "
+                    "non-regular entry",
+                )
+            )
+
+    if tuple(observed_files) != (
+        PACKAGE_FILE_PATHS
+    ):
+        issues.append(
+            package_issue(
+                "PACKAGE_FILE_INVENTORY",
+                "package",
+                "expected "
+                f"{PACKAGE_FILE_PATHS!r}, "
+                f"got {tuple(observed_files)!r}",
+            )
+        )
+
+    if tuple(observed_directories) != (
+        EXPECTED_DIRECTORY_PATHS
+    ):
+        issues.append(
+            package_issue(
+                "PACKAGE_DIRECTORY_INVENTORY",
+                "package",
+                "expected "
+                f"{EXPECTED_DIRECTORY_PATHS!r}, "
+                f"got "
+                f"{tuple(observed_directories)!r}",
+            )
+        )
+
+    return tuple(
+        sorted(
+            set(issues),
+            key=lambda value: value.sort_key,
+        )
+    )
+
+
+def _copied_input_issues(
+    package_dir: Path,
+    repository_root: Path,
+    release_manifest: manifest.ReleaseManifest,
+) -> tuple[ReleasePackageIssue, ...]:
+    issues: list[ReleasePackageIssue] = []
+
+    try:
+        notes_record = next(
+            value
+            for value in release_manifest.inputs
+            if value.key == "release_notes"
+        )
+    except StopIteration:
+        return (
+            package_issue(
+                "RELEASE_NOTES_INPUT",
+                "inputs",
+                "release_notes input record is absent",
+            ),
+        )
+
+    try:
+        notes_relative = _safe_relative_path(
+            notes_record.source_path,
+            field="release_notes.source_path",
+        )
+    except ValueError as exc:
+        return (
+            package_issue(
+                "INPUT_SOURCE_PATH",
+                "release_notes",
+                str(exc),
+            ),
+        )
+
+    notes_source = (
+        repository_root
+        / notes_relative
+    )
+
+    if not notes_source.is_file():
+        return (
+            package_issue(
+                "INPUT_SOURCE_MISSING",
+                notes_record.source_path,
+                "release-note source is absent",
+            ),
+        )
+
+    try:
+        expected_inputs = build.collect_inputs(
+            repository_root,
+            notes_record.source_path,
+        )
+    except Exception as exc:
+        return (
+            package_issue(
+                "INPUT_EVIDENCE",
+                "inputs",
+                str(exc),
+            ),
+        )
+
+    if release_manifest.inputs != (
+        expected_inputs
+    ):
+        issues.append(
+            package_issue(
+                "INPUT_EVIDENCE_MISMATCH",
+                "inputs",
+                "manifest input records differ "
+                "from repository authority bytes",
+            )
+        )
+
+    for record in release_manifest.inputs:
+        if record.package_path is None:
+            continue
+
+        try:
+            source_relative = _safe_relative_path(
+                record.source_path,
+                field=(
+                    f"{record.key}.source_path"
+                ),
+            )
+
+            package_relative = _safe_relative_path(
+                record.package_path,
+                field=(
+                    f"{record.key}.package_path"
+                ),
+            )
+        except ValueError as exc:
+            issues.append(
+                package_issue(
+                    "INPUT_PATH",
+                    record.key,
+                    str(exc),
+                )
+            )
+            continue
+
+        source = (
+            repository_root
+            / source_relative
+        )
+
+        packaged = (
+            package_dir
+            / package_relative
+        )
+
+        if not source.is_file():
+            issues.append(
+                package_issue(
+                    "COPIED_INPUT_SOURCE_MISSING",
+                    record.source_path,
+                    "repository source is absent",
+                )
+            )
+            continue
+
+        if not packaged.is_file():
+            issues.append(
+                package_issue(
+                    "COPIED_INPUT_MISSING",
+                    record.package_path,
+                    "package copy is absent",
+                )
+            )
+            continue
+
+        if packaged.read_bytes() != (
+            source.read_bytes()
+        ):
+            issues.append(
+                package_issue(
+                    "COPIED_INPUT_MISMATCH",
+                    record.package_path,
+                    "package copy differs "
+                    "byte-for-byte from source",
+                )
+            )
+
+    return tuple(
+        sorted(
+            set(issues),
+            key=lambda value: value.sort_key,
+        )
+    )
+
+
+def _formal_product_issues(
+    package_dir: Path,
+    context,
+    release_manifest: manifest.ReleaseManifest,
+) -> tuple[ReleasePackageIssue, ...]:
+    issues: list[ReleasePackageIssue] = []
+
+    try:
+        with tempfile.TemporaryDirectory(
+            prefix="sosa-2023-package-render-check-"
+        ) as directory:
+            metadata, rendered = (
+                build.render_formal_products(
+                    context,
+                    package_dir
+                    / (
+                        "sources/"
+                        "SOSA-2023-to-BFO-COMS.xlsx"
+                    ),
+                    package_dir
+                    / (
+                        "sources/"
+                        "sosa-2023-publication-"
+                        "metadata.toml"
+                    ),
+                    Path(directory),
+                )
+            )
+
+            expected_bytes = (
+                build.formal_product_bytes(
+                    rendered
+                )
+            )
+
+            for key in PRODUCT_ORDER:
+                relative = (
+                    PRODUCT_PACKAGE_PATHS[
+                        key
+                    ]
+                )
+
+                observed = (
+                    package_dir
+                    / relative
+                ).read_bytes()
+
+                if observed != (
+                    expected_bytes[key]
+                ):
+                    issues.append(
+                        package_issue(
+                            "FORMAL_PRODUCT_MISMATCH",
+                            relative,
+                            "bytes differ from "
+                            "same-package-input "
+                            "formal rendering",
+                        )
+                    )
+
+            expected_products = (
+                build.collect_product_records(
+                    rendered,
+                    metadata,
+                    context,
+                )
+            )
+
+            if release_manifest.products != (
+                expected_products
+            ):
+                issues.append(
+                    package_issue(
+                        "PRODUCT_EVIDENCE_MISMATCH",
+                        "products",
+                        "manifest product records "
+                        "differ from recomputed "
+                        "formal products",
+                    )
+                )
+
+            catalog = (
+                package_dir
+                / "catalog-v001.xml"
+            ).read_bytes()
+
+            issues.extend(
+                build.validate_catalog_bytes(
+                    catalog,
+                    metadata,
+                    context,
+                )
+            )
+
+    except Exception as exc:
+        issues.append(
+            package_issue(
+                "FORMAL_RENDERING",
+                "products",
+                str(exc),
+            )
+        )
+
+    return tuple(
+        sorted(
+            set(issues),
+            key=lambda value: value.sort_key,
+        )
+    )
+
+
+def _evidence_issues(
+    package_dir: Path,
+    repository_root: Path,
+    release_manifest: manifest.ReleaseManifest,
+    toolchain: ResolvedValidationToolchain,
+) -> tuple[ReleasePackageIssue, ...]:
+    issues: list[ReleasePackageIssue] = []
+
+    try:
+        expected_dependencies = (
+            build.collect_dependencies(
+                repository_root
+            )
+        )
+    except Exception as exc:
+        issues.append(
+            package_issue(
+                "DEPENDENCY_EVIDENCE",
+                "dependencies",
+                str(exc),
+            )
+        )
+    else:
+        if release_manifest.dependencies != (
+            expected_dependencies
+        ):
+            issues.append(
+                package_issue(
+                    "DEPENDENCY_EVIDENCE_MISMATCH",
+                    "dependencies",
+                    "manifest dependency records "
+                    "differ from pinned "
+                    "repository dependencies",
+                )
+            )
+
+    try:
+        expected_environment = (
+            build.collect_validation_environment(
+                repository_root,
+                toolchain,
+            )
+        )
+    except Exception as exc:
+        issues.append(
+            package_issue(
+                "VALIDATION_ENVIRONMENT",
+                "validation_environment",
+                str(exc),
+            )
+        )
+    else:
+        if (
+            release_manifest.validation_environment
+            != expected_environment
+        ):
+            issues.append(
+                package_issue(
+                    "VALIDATION_ENVIRONMENT_MISMATCH",
+                    "validation_environment",
+                    "manifest validation "
+                    "environment differs from "
+                    "declared runtime",
+                )
+            )
+
+    try:
+        expected_included = (
+            build.collect_included_files(
+                package_dir
+            )
+        )
+    except Exception as exc:
+        issues.append(
+            package_issue(
+                "INCLUDED_FILE_EVIDENCE",
+                "included_files",
+                str(exc),
+            )
+        )
+    else:
+        if release_manifest.included_files != (
+            expected_included
+        ):
+            issues.append(
+                package_issue(
+                    "INCLUDED_FILE_EVIDENCE_MISMATCH",
+                    "included_files",
+                    "manifest included-file "
+                    "records differ from "
+                    "package bytes",
+                )
+            )
+
+    return tuple(
+        sorted(
+            set(issues),
+            key=lambda value: value.sort_key,
+        )
+    )
+
+
+def _local_path_leakage_issues(
+    package_dir: Path,
+    repository_root: Path,
+) -> tuple[ReleasePackageIssue, ...]:
+    issues: list[ReleasePackageIssue] = []
+
+    prohibited = (
+        str(
+            repository_root.resolve()
+        ).encode("utf-8"),
+        b"file://",
+        build.TEMP_PREFIX.encode(
+            "utf-8"
+        ),
+        b"-sosa-2023-build-work",
+    )
+
+    for relative in PACKAGE_FILE_PATHS:
+        value = (
+            package_dir
+            / relative
+        ).read_bytes()
+
+        for marker in prohibited:
+            if (
+                marker
+                and marker in value
+            ):
+                issues.append(
+                    package_issue(
+                        "LOCAL_PATH_LEAKAGE",
+                        relative,
+                        "contains prohibited "
+                        "local-build marker "
+                        f"{marker.decode('utf-8', errors='replace')!r}",
+                    )
+                )
+
+    return tuple(
+        sorted(
+            set(issues),
+            key=lambda value: value.sort_key,
+        )
+    )
+
+
+def validate_release_package(
+    package_dir: Path,
+    *,
+    repository_root: Path = REPO_ROOT,
+    toolchain: ResolvedValidationToolchain | None = None,
+    reconstruct: bool = True,
+) -> tuple[ReleasePackageIssue, ...]:
+    """Validate package bytes without modifying the package."""
+
+    package_dir = Path(
+        package_dir
+    )
+
+    repository_root = Path(
+        repository_root
+    ).resolve()
+
+    snapshots = (
+        build.snapshot_development_outputs(
+            repository_root
+        )
+    )
+
+    issues: list[
+        ReleasePackageIssue
+    ] = list(
+        _layout_issues(
+            package_dir
+        )
+    )
+
+    if issues:
+        issues.extend(
+            build.development_snapshot_issues(
+                repository_root,
+                snapshots,
+            )
+        )
+
+        return tuple(
+            sorted(
+                set(issues),
+                key=lambda value: value.sort_key,
+            )
+        )
+
+    try:
+        release_manifest = (
+            manifest
+            .load_and_validate_release_manifest(
+                package_dir
+                / "manifest.json"
+            )
+        )
+    except Exception as exc:
+        issues.append(
+            package_issue(
+                "MANIFEST_VALIDATION",
+                "manifest.json",
+                str(exc),
+            )
+        )
+
+        issues.extend(
+            build.development_snapshot_issues(
+                repository_root,
+                snapshots,
+            )
+        )
+
+        return tuple(
+            sorted(
+                set(issues),
+                key=lambda value: value.sort_key,
+            )
+        )
+
+    if package_dir.name != (
+        release_manifest.release_identifier
+    ):
+        issues.append(
+            package_issue(
+                "PACKAGE_BASENAME",
+                "package_dir",
+                "expected "
+                f"{release_manifest.release_identifier!r}, "
+                f"got {package_dir.name!r}",
+            )
+        )
+
+    try:
+        context = (
+            parse_formal_release_context(
+                release_manifest.release_identifier,
+                release_manifest.release_date,
+                release_manifest.git_tag,
+                release_manifest.source_commit,
+            )
+        )
+    except Exception as exc:
+        issues.append(
+            package_issue(
+                "RELEASE_CONTEXT",
+                "manifest.json",
+                str(exc),
+            )
+        )
+
+        issues.extend(
+            build.development_snapshot_issues(
+                repository_root,
+                snapshots,
+            )
+        )
+
+        return tuple(
+            sorted(
+                set(issues),
+                key=lambda value: value.sort_key,
+            )
+        )
+
+    notes = (
+        package_dir
+        / "RELEASE-NOTES.md"
+    ).read_bytes()
+
+    issues.extend(
+        runtime.validate_release_notes_bytes(
+            notes,
+            template_bytes=(
+                repository_root
+                / "release-notes/TEMPLATE.md"
+            ).read_bytes(),
+        )
+    )
+
+    issues.extend(
+        _copied_input_issues(
+            package_dir,
+            repository_root,
+            release_manifest,
+        )
+    )
+
+    issues.extend(
+        _formal_product_issues(
+            package_dir,
+            context,
+            release_manifest,
+        )
+    )
+
+    sums = (
+        package_dir
+        / "SHA256SUMS"
+    ).read_bytes()
+
+    issues.extend(
+        build.validate_sha256sums_bytes(
+            package_dir,
+            sums,
+        )
+    )
+
+    try:
+        resolved_toolchain = (
+            toolchain
+            or runtime.resolve_validation_toolchain(
+                repository_root
+            )
+        )
+    except Exception as exc:
+        issues.append(
+            package_issue(
+                "VALIDATION_TOOLCHAIN",
+                "validation_environment",
+                str(exc),
+            )
+        )
+
+        issues.extend(
+            build.development_snapshot_issues(
+                repository_root,
+                snapshots,
+            )
+        )
+
+        return tuple(
+            sorted(
+                set(issues),
+                key=lambda value: value.sort_key,
+            )
+        )
+
+    issues.extend(
+        _evidence_issues(
+            package_dir,
+            repository_root,
+            release_manifest,
+            resolved_toolchain,
+        )
+    )
+
+    issues.extend(
+        _local_path_leakage_issues(
+            package_dir,
+            repository_root,
+        )
+    )
+
+    if release_manifest.product_order != (
+        PRODUCT_ORDER
+    ):
+        issues.append(
+            package_issue(
+                "PRODUCT_ORDER",
+                "product_order",
+                "manifest product order differs "
+                "from package authority",
+            )
+        )
+
+    if issues:
+        issues.extend(
+            build.development_snapshot_issues(
+                repository_root,
+                snapshots,
+            )
+        )
+
+        return tuple(
+            sorted(
+                set(issues),
+                key=lambda value: value.sort_key,
+            )
+        )
+
+    if reconstruct:
+        try:
+            notes_record = next(
+                value
+                for value in release_manifest.inputs
+                if value.key == "release_notes"
+            )
+
+            with tempfile.TemporaryDirectory(
+                prefix=(
+                    "sosa-2023-release-package-"
+                    "validation-"
+                )
+            ) as directory:
+                reconstructed = (
+                    Path(directory)
+                    / context.release_identifier
+                )
+
+                build.assemble_release_package(
+                    context,
+                    notes,
+                    notes_record.source_path,
+                    reconstructed,
+                    repository_root,
+                    resolved_toolchain,
+                    snapshots,
+                )
+
+                issues.extend(
+                    build.compare_complete_packages(
+                        package_dir,
+                        reconstructed,
+                    )
+                )
+
+        except Exception as exc:
+            issues.append(
+                package_issue(
+                    "PACKAGE_RECONSTRUCTION",
+                    "package",
+                    str(exc),
+                )
+            )
+
+    issues.extend(
+        build.development_snapshot_issues(
+            repository_root,
+            snapshots,
+        )
+    )
+
+    return tuple(
+        sorted(
+            set(issues),
+            key=lambda value: value.sort_key,
+        )
+    )
+
+
+def parse_args(
+    argv: list[str] | None = None,
+) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=__doc__
+    )
+
+    parser.add_argument(
+        "--package-dir",
+        required=True,
+        type=Path,
+    )
+
+    parser.add_argument(
+        "--no-reconstruct",
+        action="store_true",
+        help=(
+            "Skip independent complete-package "
+            "reconstruction. Intended only for "
+            "builder-internal prepublication checks."
+        ),
+    )
+
+    return parser.parse_args(
+        argv
+    )
+
+
+def main(
+    argv: list[str] | None = None,
+) -> int:
+    args = parse_args(
+        argv
+    )
+
+    issues = validate_release_package(
+        args.package_dir,
+        reconstruct=(
+            not args.no_reconstruct
+        ),
+    )
+
+    if issues:
+        for issue in issues:
+            print(
+                runtime.format_issue(
+                    issue
+                )
+            )
+
+        return 1
+
+    print(
+        "SOSA-2023 release package "
+        f"validation: PASS ({args.package_dir})"
+    )
+
+    print(
+        "Regular files:",
+        len(PACKAGE_FILE_PATHS),
+    )
+
+    print(
+        "Checksummed files:",
+        len(CHECKSUM_PATHS),
+    )
+
+    print(
+        "Development artifacts checked:",
+        len(DEVELOPMENT_OUTPUT_PATHS),
+    )
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(
+        main()
+    )

--- a/tools/sosa_2023_release_manifest.py
+++ b/tools/sosa_2023_release_manifest.py
@@ -62,6 +62,9 @@ INPUT_KEY_ORDER = (
     "module_generate_sosa_next_products",
     "manifest_schema",
     "module_sosa_2023_release_manifest",
+    "module_sosa_2023_release_runtime",
+    "module_sosa_2023_build_release",
+    "module_sosa_2023_check_release",
 )
 DEPENDENCY_KEY_ORDER = (
     "sosa",
@@ -1022,6 +1025,21 @@ INPUT_POLICIES = (
         "tools/sosa_2023_release_manifest.py",
         None,
     ),
+    (
+        "module_sosa_2023_release_runtime",
+        "tools/sosa_2023_release_runtime.py",
+        None,
+    ),
+    (
+        "module_sosa_2023_build_release",
+        "tools/sosa_2023_build_release.py",
+        None,
+    ),
+    (
+        "module_sosa_2023_check_release",
+        "tools/sosa_2023_check_release.py",
+        None,
+    ),
 )
 
 DEPENDENCY_POLICIES = (
@@ -1041,7 +1059,7 @@ DEPENDENCY_POLICIES = (
         "sosa_sampling",
         "formal external SOSA Sampling ontology dependency",
         "src/sosa-next/imports/sosa-sampling.ttl",
-        "http://www.w3.org/ns/sosa/sampling/",
+        "http://www.w3.org/ns/sosa/sam/",
     ),
     (
         "merged_cco_bfo",

--- a/tools/sosa_2023_release_runtime.py
+++ b/tools/sosa_2023_release_runtime.py
@@ -1,0 +1,407 @@
+#!/usr/bin/env python3
+"""Shared verified runtime mechanics for the SOSA-2023 release package."""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import platform
+import re
+import shlex
+import shutil
+import subprocess
+from contextlib import contextmanager
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, Iterator, Mapping
+
+
+REQUIRED_RELEASE_NOTE_HEADINGS = (
+    "Release identity",
+    "Included products",
+    "Product selection guidance",
+    "Governed axiom and closure summary",
+    "Import graph",
+    "BFO projection notice",
+    "Validation summary",
+    "Known limitations",
+    "Deferred functionality",
+    "License scope",
+    "Dependencies",
+    "Reproduction",
+)
+
+
+OFFLINE_JAVA_OPTIONS = (
+    "-Djava.net.useSystemProxies=true",
+    "-Dhttp.proxyHost=127.0.0.1",
+    "-Dhttp.proxyPort=9",
+    "-Dhttps.proxyHost=127.0.0.1",
+    "-Dhttps.proxyPort=9",
+    "-Dftp.proxyHost=127.0.0.1",
+    "-Dftp.proxyPort=9",
+    "-Dhttp.nonProxyHosts=",
+)
+
+
+PROXY_ENVIRONMENT_KEYS = (
+    "HTTP_PROXY",
+    "HTTPS_PROXY",
+    "FTP_PROXY",
+    "ALL_PROXY",
+    "NO_PROXY",
+    "http_proxy",
+    "https_proxy",
+    "ftp_proxy",
+    "all_proxy",
+    "no_proxy",
+)
+
+
+def sha256_bytes(value: bytes) -> str:
+    """Return the lowercase SHA-256 digest of one byte string."""
+
+    return hashlib.sha256(value).hexdigest()
+
+
+@dataclass(frozen=True)
+class ReleasePackageIssue:
+    code: str
+    field: str
+    message: str
+
+    @property
+    def sort_key(self) -> tuple[str, str, str]:
+        return self.field, self.code, self.message
+
+
+class ReleasePackageError(ValueError):
+    """One or more deterministic release-package failures."""
+
+    def __init__(self, issues: Iterable[ReleasePackageIssue]):
+        self.issues = tuple(sorted(set(issues), key=lambda value: value.sort_key))
+        super().__init__("; ".join(format_issue(issue) for issue in self.issues))
+
+
+@dataclass(frozen=True)
+class DevelopmentSnapshot:
+    path: str
+    content: bytes
+    sha256: str
+    mtime_ns: int
+
+
+@dataclass(frozen=True)
+class ResolvedValidationToolchain:
+    java_executable: Path
+    java_vendor: str
+    java_version: str
+    java_vm_name: str
+    robot_executable: Path
+    robot_jar: Path
+    robot_artifact: str
+    robot_version: str
+    robot_jar_sha256: str
+    java_heap: str
+
+    def java_robot_command(self, *arguments: str) -> tuple[str, ...]:
+        return (
+            str(self.java_executable),
+            f"-Xmx{self.java_heap}",
+            *OFFLINE_JAVA_OPTIONS,
+            "-jar",
+            str(self.robot_jar),
+            *arguments,
+        )
+
+
+def format_issue(issue: ReleasePackageIssue) -> str:
+    return f"ERROR [{issue.code}] {issue.field}: {issue.message}"
+
+
+def package_issue(code: str, field: str, message: str) -> ReleasePackageIssue:
+    return ReleasePackageIssue(code, field, message)
+
+
+def _sha256(path: Path) -> str:
+    return sha256_bytes(path.read_bytes())
+
+
+def validate_release_notes_bytes(
+    value: bytes,
+    *,
+    template_bytes: bytes | None = None,
+) -> tuple[ReleasePackageIssue, ...]:
+    issues: list[ReleasePackageIssue] = []
+    try:
+        text = value.decode("utf-8")
+    except UnicodeDecodeError as exc:
+        return (package_issue("RELEASE_NOTES_UTF8", "release_notes", str(exc)),)
+    if not text:
+        issues.append(package_issue("RELEASE_NOTES_EMPTY", "release_notes", "notes are empty"))
+    if "\r" in text:
+        issues.append(package_issue("RELEASE_NOTES_LINE_ENDING", "release_notes", "CRLF and bare CR are prohibited"))
+    if not text.endswith("\n") or text.endswith("\n\n"):
+        issues.append(package_issue("RELEASE_NOTES_FINAL_NEWLINE", "release_notes", "expected exactly one final newline"))
+    controls = sorted({ord(character) for character in text if ord(character) < 32 and character != "\n"})
+    if controls:
+        issues.append(package_issue("RELEASE_NOTES_CONTROL", "release_notes", f"control characters are prohibited: {controls}"))
+    headings = tuple(
+        line[2:] for line in text.splitlines() if line.startswith("# ") and not line.startswith("## ")
+    )
+    for heading in REQUIRED_RELEASE_NOTE_HEADINGS:
+        if heading not in headings:
+            issues.append(package_issue("RELEASE_NOTES_HEADING", "release_notes", f"missing top-level heading {heading!r}"))
+    if template_bytes is not None and value == template_bytes:
+        issues.append(package_issue("RELEASE_NOTES_TEMPLATE", "release_notes", "unmodified template is prohibited"))
+    marker = re.search(r"(?i)(?:\bTODO\b|\bTBD\b|<release-id>)", text)
+    if marker is not None:
+        issues.append(package_issue("RELEASE_NOTES_PLACEHOLDER", "release_notes", f"unresolved marker {marker.group(0)!r}"))
+    return tuple(sorted(set(issues), key=lambda item: item.sort_key))
+
+
+def _load_toolchain(repository_root: Path) -> dict[str, str]:
+    values: dict[str, str] = {}
+    for line in (repository_root / "config/validation-toolchain.env").read_text(encoding="utf-8").splitlines():
+        if line and not line.startswith("#"):
+            key, separator, value = line.partition("=")
+            if not separator or not key or not value:
+                raise ReleasePackageError((package_issue("TOOLCHAIN_DECLARATION", "config/validation-toolchain.env", f"invalid line {line!r}"),))
+            values[key] = value
+    return values
+
+
+def offline_subprocess_environment(
+    base: Mapping[str, str] | None = None,
+) -> dict[str, str]:
+    """Return a deterministic subprocess environment that denies remote URL access."""
+
+    environment = dict(os.environ if base is None else base)
+    for key in PROXY_ENVIRONMENT_KEYS:
+        environment.pop(key, None)
+    blocked_proxy = "http://127.0.0.1:9"
+    for key in ("HTTP_PROXY", "HTTPS_PROXY", "FTP_PROXY", "ALL_PROXY"):
+        environment[key] = blocked_proxy
+        environment[key.lower()] = blocked_proxy
+    environment["NO_PROXY"] = ""
+    environment["no_proxy"] = ""
+    return environment
+
+
+def _unverified_robot_artifact(message: str) -> ReleasePackageError:
+    return ReleasePackageError(
+        (package_issue("UNVERIFIED_ROBOT_ARTIFACT", "validation_environment.robot_artifact", message),)
+    )
+
+
+def _resolve_robot_wrapper() -> tuple[Path, Path, Path]:
+    located = shutil.which("robot")
+    if located is None:
+        raise _unverified_robot_artifact("ROBOT executable not found on PATH")
+    robot_executable = Path(located).resolve()
+    try:
+        text = robot_executable.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError) as exc:
+        raise _unverified_robot_artifact(
+            f"cannot inspect resolved ROBOT wrapper {robot_executable}: {exc}"
+        ) from exc
+
+    commands: list[list[str]] = []
+    for line in text.splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        try:
+            tokens = shlex.split(stripped)
+        except ValueError as exc:
+            raise _unverified_robot_artifact(f"cannot parse ROBOT wrapper command: {exc}") from exc
+        if tokens and tokens[0] == "exec":
+            tokens = tokens[1:]
+        if "-jar" in tokens:
+            commands.append(tokens)
+    if len(commands) != 1:
+        raise _unverified_robot_artifact(
+            f"expected exactly one local Java -jar command, found {len(commands)}"
+        )
+    command = commands[0]
+    jar_index = command.index("-jar")
+    if jar_index == 0 or jar_index + 1 >= len(command):
+        raise _unverified_robot_artifact("ROBOT wrapper has an incomplete Java -jar command")
+
+    java_token = command[0]
+    if "/" in java_token:
+        java_executable = Path(java_token).expanduser().resolve()
+    else:
+        located_java = shutil.which(java_token)
+        if located_java is None:
+            raise _unverified_robot_artifact(
+                f"Java executable {java_token!r} from ROBOT wrapper is not on PATH"
+            )
+        java_executable = Path(located_java).resolve()
+    jar_text = os.path.expandvars(os.path.expanduser(command[jar_index + 1]))
+    if "$" in jar_text:
+        raise _unverified_robot_artifact("ROBOT JAR path contains an unresolved variable")
+    robot_jar = Path(jar_text)
+    if not robot_jar.is_absolute():
+        raise _unverified_robot_artifact("ROBOT JAR path is relative and therefore ambiguous")
+    robot_jar = robot_jar.resolve()
+    if not java_executable.is_file() or not os.access(java_executable, os.X_OK):
+        raise _unverified_robot_artifact("resolved Java executable is not an executable file")
+    if not robot_jar.is_file():
+        raise _unverified_robot_artifact("resolved ROBOT JAR is not a regular file")
+    return robot_executable, java_executable, robot_jar
+
+
+def _normalized_java_property(output: str, name: str) -> str:
+    match = re.search(rf"^\s*{re.escape(name)}\s*=\s*(.+?)\s*$", output, re.MULTILINE)
+    if match is None:
+        raise ReleasePackageError(
+            (package_issue("JAVA_IDENTITY", f"validation_environment.{name}", "property is absent"),)
+        )
+    value = " ".join(match.group(1).split())
+    if not value:
+        raise ReleasePackageError(
+            (package_issue("JAVA_IDENTITY", f"validation_environment.{name}", "property is empty"),)
+        )
+    return value
+
+
+def resolve_validation_toolchain(repository_root: Path) -> ResolvedValidationToolchain:
+    """Resolve and verify the exact Java executable and ROBOT JAR used for reasoning."""
+
+    repository_root = repository_root.resolve()
+    declaration = _load_toolchain(repository_root)
+    robot_executable, java_executable, robot_jar = _resolve_robot_wrapper()
+    environment = offline_subprocess_environment()
+    java = subprocess.run(
+        [str(java_executable), *OFFLINE_JAVA_OPTIONS, "-XshowSettings:properties", "-version"],
+        cwd=repository_root,
+        env=environment,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+    java_text = "\n".join(part for part in (java.stdout, java.stderr) if part).strip()
+    if java.returncode != 0:
+        raise ReleasePackageError(
+            (package_issue("JAVA_IDENTITY", "validation_environment.java", "Java identity probe failed"),)
+        )
+    java_vendor = _normalized_java_property(java_text, "java.vendor")
+    java_version = _normalized_java_property(java_text, "java.version")
+    java_vm_name = _normalized_java_property(java_text, "java.vm.name")
+    expected_java = declaration["VALIDATION_JAVA_VERSION"]
+    if java_version != expected_java and not java_version.startswith(expected_java + "."):
+        raise ReleasePackageError(
+            (
+                package_issue(
+                    "JAVA_VERSION_MISMATCH",
+                    "validation_environment.java_version",
+                    f"expected {expected_java}.x, got {java_version}",
+                ),
+            )
+        )
+    expected_python = declaration["VALIDATION_PYTHON_VERSION"]
+    python_version = platform.python_version()
+    if python_version != expected_python and not python_version.startswith(expected_python + "."):
+        raise ReleasePackageError(
+            (
+                package_issue(
+                    "PYTHON_VERSION_MISMATCH",
+                    "validation_environment.python_version",
+                    f"expected {expected_python}.x, got {python_version}",
+                ),
+            )
+        )
+
+    robot_hash = _sha256(robot_jar)
+    expected_robot_hash = declaration["VALIDATION_ROBOT_SHA256"]
+    if robot_hash != expected_robot_hash:
+        raise ReleasePackageError(
+            (
+                package_issue(
+                    "ROBOT_SHA256_MISMATCH",
+                    "validation_environment.robot_sha256",
+                    f"expected {expected_robot_hash}, got {robot_hash}",
+                ),
+            )
+        )
+    robot = subprocess.run(
+        [
+            str(java_executable),
+            *OFFLINE_JAVA_OPTIONS,
+            "-jar",
+            str(robot_jar),
+            "--version",
+        ],
+        cwd=repository_root,
+        env=environment,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+    robot_text = "\n".join(part for part in (robot.stdout, robot.stderr) if part).strip()
+    robot_match = re.search(r"ROBOT version ([0-9.]+)", robot_text)
+    if robot.returncode != 0 or robot_match is None:
+        raise _unverified_robot_artifact("unable to obtain a version from the resolved ROBOT JAR")
+    expected_robot = declaration["VALIDATION_ROBOT_VERSION"]
+    if robot_match.group(1) != expected_robot:
+        raise ReleasePackageError(
+            (
+                package_issue(
+                    "ROBOT_VERSION_MISMATCH",
+                    "validation_environment.robot_version",
+                    f"expected {expected_robot}, got {robot_match.group(1)}",
+                ),
+            )
+        )
+    return ResolvedValidationToolchain(
+        java_executable=java_executable,
+        java_vendor=java_vendor,
+        java_version=java_version,
+        java_vm_name=java_vm_name,
+        robot_executable=robot_executable,
+        robot_jar=robot_jar,
+        robot_artifact=declaration["VALIDATION_ROBOT_URL"],
+        robot_version=robot_match.group(1),
+        robot_jar_sha256=robot_hash,
+        java_heap=declaration["VALIDATION_ROBOT_JAVA_HEAP"],
+    )
+
+
+@contextmanager
+def verified_robot_launcher(
+    toolchain: ResolvedValidationToolchain,
+    temporary_root: Path,
+) -> Iterator[Path]:
+    """Expose a controlled `robot` command for COMS reasoners using the verified runtime."""
+
+    launcher_directory = temporary_root / "verified-toolchain"
+    launcher_directory.mkdir(parents=True, exist_ok=False)
+    launcher = launcher_directory / "robot"
+    command = toolchain.java_robot_command()
+    launcher.write_text(
+        "#!/bin/sh\nexec "
+        + " ".join(shlex.quote(value) for value in command)
+        + ' "$@"\n',
+        encoding="utf-8",
+    )
+    launcher.chmod(0o700)
+    updates = offline_subprocess_environment()
+    updates["PATH"] = str(launcher_directory) + os.pathsep + os.environ.get("PATH", "")
+    governed_keys = (*PROXY_ENVIRONMENT_KEYS, "PATH")
+    previous = {key: os.environ.get(key) for key in governed_keys}
+    try:
+        for key in governed_keys:
+            if key in updates:
+                os.environ[key] = updates[key]
+            else:
+                os.environ.pop(key, None)
+        yield launcher.resolve()
+    finally:
+        for key, value in previous.items():
+            if value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = value


### PR DESCRIPTION
## Summary

Adds the separate SOSA-2023 deterministic release-package construction and read-only validation layer without changing the current-track release engine.

### Package authority

- Adds independent SOSA-2023 release runtime, builder, and checker modules.
- Builds the three formal products from the packaged COMS workbook and packaged publication metadata.
- Defines a canonical 13-file complete package with 11 manifest-evidenced members and 12 checksum entries.
- Generates the canonical three-entry same-release XML catalog.
- Requires two complete independent package builds to be byte-identical.
- Supports independent read-only package reconstruction with 13/13 byte identity.
- Runs the fixed formal HermiT closures:
  - Integrated: 15,130 triples
  - Strict BFO Mapping: 15,014 triples
  - CCO Extension: 15,141 triples
- Preserves all maintained development products and pinned source ontology bytes.

### Manifest evidence

- Expands governed SOSA-2023 manifest inputs from 28 to 31 by adding the runtime, builder, and checker as byte-affecting non-packaged inputs.
- Corrects the pinned SOSA Sampling dependency ontology identity to `http://www.w3.org/ns/sosa/sam/`.
- Retains `http://www.w3.org/ns/sosa/sampling/` as the independently governed formal Integrated import.

### Validation

- Adds permanent runtime and package regression suites.
- Adds `make check-sosa-2023-package`.
- Integrates the package tests into the authoritative validation suite and hosted CI.
- Full local `make check` passes.
- Current-track release machinery and the existing SOSA-2023 formal renderer remain byte-identical.

### Scope

This milestone does not implement the SOSA-2023 archive authority, isolated release rehearsal, real release-context selection, GitHub publication, or persistent-IRI deployment.