### PR TITLE
Add SOSA-2023 archive authority

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: validate validate-write audit-write legacy-audit-write compile check check-coms check-sosa-next check-coms-row-identities check-coms-product-dispositions check-alignment-core check-strict-bfo-mapping check-cco-extension check-publication-metadata check-release-rendering check-release-package check-release-archive check-release-rehearsal check-placeholder-catalog-migration watch-coms coms-status post-merge-check status diffstat generate-sosa-next-products check-sosa-next-products check-sosa-next-consumer-stack check-sosa-2023-publication-rendering check-sosa-2023-release-manifest check-sosa-2023-package check-sosa-source-version check-product-role-policy check-sosa-release-scope
+.PHONY: validate validate-write audit-write legacy-audit-write compile check check-coms check-sosa-next check-coms-row-identities check-coms-product-dispositions check-alignment-core check-strict-bfo-mapping check-cco-extension check-publication-metadata check-release-rendering check-release-package check-release-archive check-release-rehearsal check-placeholder-catalog-migration watch-coms coms-status post-merge-check status diffstat generate-sosa-next-products check-sosa-next-products check-sosa-next-consumer-stack check-sosa-2023-publication-rendering check-sosa-2023-release-manifest check-sosa-2023-package check-sosa-2023-release-archive check-sosa-source-version check-product-role-policy check-sosa-release-scope
 
 validate:
 	PYTHONDONTWRITEBYTECODE=1 python tools/run_validation_suite.py
@@ -52,6 +52,7 @@ compile:
 		tools/sosa_2023_release_runtime.py \
 		tools/sosa_2023_build_release.py \
 		tools/sosa_2023_check_release.py \
+		tools/sosa_2023_release_archive.py \
 		tools/build_release.py \
 		tools/check_release.py \
 		tools/release_archive.py \
@@ -68,6 +69,7 @@ compile:
 		tests/test_sosa_2023_release_manifest.py \
 		tests/test_sosa_2023_release_runtime.py \
 		tests/test_sosa_2023_build_release.py \
+		tests/test_sosa_2023_release_archive.py \
 		tests/test_robot_diff_pilot.py \
 		tests/test_robot_extract_pilot.py \
 		tests/test_robot_query_equivalence_pilot.py \
@@ -150,6 +152,9 @@ check-sosa-2023-release-manifest:
 
 check-sosa-2023-package:
 	PYTHONDONTWRITEBYTECODE=1 python -m unittest tests.test_sosa_2023_release_runtime tests.test_sosa_2023_build_release
+
+check-sosa-2023-release-archive:
+	PYTHONDONTWRITEBYTECODE=1 python -m unittest tests.test_sosa_2023_release_archive
 
 check-coms:
 	PYTHONDONTWRITEBYTECODE=1 python tools/check_coms_mapping.py

--- a/docs/PRODUCT-ARCHITECTURE.md
+++ b/docs/PRODUCT-ARCHITECTURE.md
@@ -307,12 +307,15 @@ zero record padding, exactly two terminal zero-filled 512-byte records, and a
 lowercase external SHA-256 sidecar. Publication of an archive/sidecar pair uses
 one no-replace directory rename.
 
-The real-package regression builds the actual synthetic 13-file package twice
-into independent archive outputs and locks the resulting archive at 146,432
-bytes with SHA-256
-`d0cd2ffc14b7e67ae0656e5519de8226170e57fac8e27cf33f5dd4ad7f644ffc`.
-The sidecar is 140 bytes. Archive validation is read-only and preserves the
-package, archive, and sidecar bytes and mtimes.
+The real-package regression builds the actual synthetic 13-file package and
+constructs two independent archive outputs from that same package. The archive
+and sidecar pairs must be byte-identical. `manifest.json` deliberately records
+the actual validation environment, including Python and Java runtime identity,
+so a complete package—and therefore its archive digest and potentially its
+padded archive size—may differ across validated environments. No
+cross-environment whole-archive digest or byte-size lock is claimed. The
+sidecar is 140 bytes under the governed filename grammar. Archive validation is
+read-only and preserves the package, archive, and sidecar bytes and mtimes.
 
 Isolated release rehearsal, approval of an actual release context and release
 notes, and publication remain future formal-release work.

--- a/docs/PRODUCT-ARCHITECTURE.md
+++ b/docs/PRODUCT-ARCHITECTURE.md
@@ -284,8 +284,38 @@ the retained package.
 package-engineering fixture only. It is not an actual release announcement,
 tag, publication decision, or deployment.
 
-Archive authority, release rehearsal, actual release-context selection, and
-publication remain future formal-release work.
+The separate deterministic archive authority is now implemented by
+`tools/sosa_2023_release_archive.py`. It serializes the complete 13-file
+SOSA-2023 package as a canonical 16-member raw POSIX USTAR stream: one archive
+root, the immutable-track product directory, the `sources` directory, and all
+13 regular package files.
+
+Published archive evidence is track-disambiguated. For the fixed synthetic
+release context the archive and sidecar are:
+
+- `SSN2BFO-sosa-2023-af425a0454ec00512a5ebfa2873fe35a077f5fda-2099-01-02.tar`
+- `SSN2BFO-sosa-2023-af425a0454ec00512a5ebfa2873fe35a077f5fda-2099-01-02.tar.sha256`
+
+The internal archive root is `SOSA-2023-2099-01-02/`. The shorter internal
+root keeps every governed raw-USTAR member name within the 100-byte name field,
+while the three formal ontology paths inside the archive continue to carry the
+full immutable source-version identity.
+
+Archive bytes preserve the current release-engine hardening contract: fixed
+member order, canonical raw USTAR headers, fixed modes and zero timestamps,
+zero record padding, exactly two terminal zero-filled 512-byte records, and a
+lowercase external SHA-256 sidecar. Publication of an archive/sidecar pair uses
+one no-replace directory rename.
+
+The real-package regression builds the actual synthetic 13-file package twice
+into independent archive outputs and locks the resulting archive at 146,432
+bytes with SHA-256
+`d0cd2ffc14b7e67ae0656e5519de8226170e57fac8e27cf33f5dd4ad7f644ffc`.
+The sidecar is 140 bytes. Archive validation is read-only and preserves the
+package, archive, and sidecar bytes and mtimes.
+
+Isolated release rehearsal, approval of an actual release context and release
+notes, and publication remain future formal-release work.
 
 Focused validation:
 
@@ -299,6 +329,7 @@ make check-sosa-next-consumer-stack
 make check-sosa-2023-publication-rendering
 make check-sosa-2023-release-manifest
 make check-sosa-2023-package
+make check-sosa-2023-release-archive
 ```
 
 For the development and formal-rendering contract, see

--- a/docs/VALIDATION-AND-RELEASES.md
+++ b/docs/VALIDATION-AND-RELEASES.md
@@ -230,14 +230,18 @@ immutable source-version identity so that a SOSA-2023 archive cannot collide
 with a current-track archive for the same release date. The lowercase SHA-256
 sidecar remains outside the archive.
 
-For the synthetic `2099-01-02` contract, the real-package archive is exactly
-146,432 bytes with SHA-256
-`d0cd2ffc14b7e67ae0656e5519de8226170e57fac8e27cf33f5dd4ad7f644ffc`;
-the sidecar is exactly 140 bytes. The permanent regression builds the real
-13-file package, constructs the archive twice, requires byte-identical archive
-and sidecar outputs, validates the raw USTAR framing and member authority, and
-requires archive validation to leave the package, archive, and sidecar
-unchanged.
+For the synthetic `2099-01-02` contract, the permanent regression builds the
+real 13-file package, constructs the archive twice from those same package
+bytes, and requires byte-identical archive and sidecar outputs. It validates
+the raw USTAR framing and member authority and requires archive validation to
+leave the package, archive, and sidecar unchanged.
+
+The package manifest deliberately records the actual validation environment,
+including Python and Java runtime identity. Consequently, complete package
+bytes—and therefore the whole-archive SHA-256 and potentially its padded byte
+size—may differ across validated environments. The archive contract does not
+claim a cross-environment whole-archive hash or size. The sidecar remains
+exactly 140 bytes under the governed filename and checksum grammar.
 
 These gates are included in `make check` and hosted CI. Isolated SOSA-2023
 release rehearsal and actual publication remain later milestones.

--- a/docs/VALIDATION-AND-RELEASES.md
+++ b/docs/VALIDATION-AND-RELEASES.md
@@ -12,7 +12,7 @@ It includes:
 - modular-product tests
 - SOSA-next maintained-product tests
 - SOSA-next catalog consumer-stack tests
-- SOSA-2023 publication-metadata, formal-rendering, manifest, and package tests
+- SOSA-2023 publication-metadata, formal-rendering, manifest, package, and archive tests
 - publication-metadata validation
 - formal release-context and rendering tests
 - release-package, archive, and rehearsal tests
@@ -101,6 +101,7 @@ make check-sosa-next-consumer-stack
 make check-sosa-2023-publication-rendering
 make check-sosa-2023-release-manifest
 make check-sosa-2023-package
+make check-sosa-2023-release-archive
 ```
 
 `make check-sosa-source-version` validates the approved immutable source
@@ -213,13 +214,33 @@ The full reconstruction regression requires 13/13 byte identity while preserving
 the original package bytes and mtimes.
 
 `release-notes/SOSA-2023-SYNTHETIC-2099-01-02.md` is a deterministic test
-fixture only. Package tests create only temporary synthetic packages; they do
-not create a tag, GitHub release, release archive, persistent-IRI deployment,
+fixture only. Package and archive tests create only temporary synthetic
+artifacts; they do not create a tag, GitHub release, persistent-IRI deployment,
 or actual publication.
 
-These gates are included in `make check` and hosted CI. SOSA-2023 deterministic
-archive authority, isolated release rehearsal, and actual publication remain
-later milestones.
+`make check-sosa-2023-release-archive` validates the separate deterministic
+SOSA-2023 archive authority in `tools/sosa_2023_release_archive.py`. It retains
+the raw-POSIX-USTAR hardening of the current-track archive engine while binding
+it to the separate 13-file SOSA-2023 package and its exact two-directory
+internal structure.
+
+The canonical archive contains 16 members and uses the internal top level
+`SOSA-2023-<release-id>/`. The external archive filename includes the full
+immutable source-version identity so that a SOSA-2023 archive cannot collide
+with a current-track archive for the same release date. The lowercase SHA-256
+sidecar remains outside the archive.
+
+For the synthetic `2099-01-02` contract, the real-package archive is exactly
+146,432 bytes with SHA-256
+`d0cd2ffc14b7e67ae0656e5519de8226170e57fac8e27cf33f5dd4ad7f644ffc`;
+the sidecar is exactly 140 bytes. The permanent regression builds the real
+13-file package, constructs the archive twice, requires byte-identical archive
+and sidecar outputs, validates the raw USTAR framing and member authority, and
+requires archive validation to leave the package, archive, and sidecar
+unchanged.
+
+These gates are included in `make check` and hosted CI. Isolated SOSA-2023
+release rehearsal and actual publication remain later milestones.
 
 ## Publication metadata
 

--- a/reports/sosa-next-formal-release-integration-audit.md
+++ b/reports/sosa-next-formal-release-integration-audit.md
@@ -270,12 +270,16 @@ This prevents collision with the current-track
 name field while the formal ontology members themselves retain the complete
 immutable track identity.
 
-The real-package synthetic contract is fixed at 146,432 archive bytes,
-140 sidecar bytes, and archive SHA-256
-`d0cd2ffc14b7e67ae0656e5519de8226170e57fac8e27cf33f5dd4ad7f644ffc`.
-Two independent archive constructions from the actual 13-file package are
-byte-identical. Validation is read-only and leaves the package, archive, and
-sidecar unchanged.
+The real-package synthetic contract requires two independent archive
+constructions from the same actual 13-file package to be byte-identical, with
+a canonical 140-byte checksum sidecar. Validation is read-only and leaves the
+package, archive, and sidecar unchanged.
+
+The package manifest intentionally records the actual validation environment,
+including Python and Java runtime identity. Therefore complete package bytes,
+the resulting whole-archive SHA-256, and potentially the padded archive size
+are environment-specific evidence rather than a cross-environment fixed-byte
+contract.
 
 ### Release notes
 

--- a/reports/sosa-next-formal-release-integration-audit.md
+++ b/reports/sosa-next-formal-release-integration-audit.md
@@ -240,18 +240,42 @@ The package catalog maps exactly the three formal same-release version IRIs to
 the three package-relative products. It contains no development IRIs,
 `sosa-next` identity, remote dependency redirects, or editor-shell entry.
 
-### Archive
+### Archive — implemented
 
-Archive integration requires a new canonical member inventory, member count,
-directory inventory, and test authority. Existing raw-USTAR invariants should
-remain unchanged:
+The separate deterministic archive authority is implemented by
+`tools/sosa_2023_release_archive.py` with permanent regression coverage in
+`tests/test_sosa_2023_release_archive.py`.
 
-- deterministic member order;
-- fixed metadata and zero timestamps;
-- canonical octal fields;
-- zero padding;
-- exactly two terminal zero records;
-- external lowercase SHA-256 sidecar.
+The canonical archive is a raw uncompressed POSIX USTAR stream with exactly 16
+members: the archive root, two package directories, and the complete 13-file
+SOSA-2023 package. It preserves the existing release-engine invariants:
+
+- deterministic explicit member order independent of package traversal;
+- fixed file and directory modes;
+- zero uid, gid, device identifiers, and modification times;
+- canonical octal numeric fields and header checksums;
+- zero-filled file-record padding;
+- exactly two terminal zero-filled 512-byte EOF records with no trailing data;
+- rejection of duplicate, reordered, unsafe, special-type, or noncanonical
+  members;
+- an exact lowercase external SHA-256 sidecar;
+- no-replace atomic publication of the complete archive/sidecar pair.
+
+The external asset filename includes the complete immutable source-version
+identity:
+`SSN2BFO-sosa-2023-af425a0454ec00512a5ebfa2873fe35a077f5fda-<release-id>.tar`.
+This prevents collision with the current-track
+`SSN2BFO-<release-id>.tar` asset. The internal archive root is the shorter
+`SOSA-2023-<release-id>/`; this keeps all raw-USTAR names within the 100-byte
+name field while the formal ontology members themselves retain the complete
+immutable track identity.
+
+The real-package synthetic contract is fixed at 146,432 archive bytes,
+140 sidecar bytes, and archive SHA-256
+`d0cd2ffc14b7e67ae0656e5519de8226170e57fac8e27cf33f5dd4ad7f644ffc`.
+Two independent archive constructions from the actual 13-file package are
+byte-identical. Validation is read-only and leaves the package, archive, and
+sidecar unchanged.
 
 ### Release notes
 
@@ -276,8 +300,8 @@ closures, and exercises full read-only reconstruction. It does not retain or
 publish a real release artifact.
 
 Formal release rehearsal remains future work. It must build and validate
-isolated copies of the package and future archive from the exact requested
-commit with network access blocked, then compare every retained byte. A real
+isolated copies of the package and archive from the exact requested commit
+with network access blocked, then compare every retained byte. A real
 package must not be retained, tagged, uploaded, or deployed without an explicit
 approved release context and approved release notes.
 
@@ -290,8 +314,8 @@ approved release context and approved release notes.
    model.
 4. **Completed:** implement separate-package construction and read-only validation.
 5. **Completed:** implement the canonical package catalog and checksum inventory.
-6. **Next:** implement the separate package's deterministic archive authority.
-7. **Then:** add isolated release rehearsal and archive regressions.
+6. **Completed:** implement the separate package's deterministic archive authority.
+7. **Next:** add isolated release rehearsal and archive equivalence checks.
 8. **Finally:** approve a real release context and release notes, rehearse, and publish.
 
 Each stage should preserve current-track release bytes and behavior.

--- a/reports/sosa-next-product-contract.md
+++ b/reports/sosa-next-product-contract.md
@@ -379,9 +379,14 @@ The deterministic archive authority now binds the 13-file package to a
 canonical 16-member raw POSIX USTAR stream. Its external asset filename includes
 the full immutable source-version identity, while the internal archive root uses
 `SOSA-2023-<release-id>/` so all governed member names fit the canonical
-100-byte raw-USTAR name field. The fixed synthetic real-package contract is
-146,432 archive bytes, 140 sidecar bytes, and SHA-256
-`d0cd2ffc14b7e67ae0656e5519de8226170e57fac8e27cf33f5dd4ad7f644ffc`.
+100-byte raw-USTAR name field. The synthetic real-package contract requires
+two independent archives of the same complete package bytes to be identical
+and uses a canonical 140-byte sidecar.
+
+The package manifest records the actual validation environment, including
+Python and Java runtime identity. Whole-package bytes and therefore the
+whole-archive digest and potentially padded archive size are not fixed across
+different validated environments.
 
 Remaining formal-release integration work is:
 

--- a/reports/sosa-next-product-contract.md
+++ b/reports/sosa-next-product-contract.md
@@ -295,10 +295,10 @@ materialize the approved roles:
 - the catalog consumer-stack tests;
 - development and governance documentation.
 
-The SOSA-2023 release manifest and deterministic package engine are now
-implemented separately from this maintained-development surface. Deterministic
-archive authority, isolated release rehearsal, and actual publication remain
-deferred.
+The SOSA-2023 release manifest, deterministic package engine, and separate
+deterministic archive authority are now implemented independently from this
+maintained-development surface. Isolated release rehearsal and actual
+publication remain deferred.
 
 ## Acceptance gates
 
@@ -375,18 +375,25 @@ imports `http://www.w3.org/ns/sosa/sampling/`.
 package-engineering fixture, not a release announcement or publication
 decision.
 
+The deterministic archive authority now binds the 13-file package to a
+canonical 16-member raw POSIX USTAR stream. Its external asset filename includes
+the full immutable source-version identity, while the internal archive root uses
+`SOSA-2023-<release-id>/` so all governed member names fit the canonical
+100-byte raw-USTAR name field. The fixed synthetic real-package contract is
+146,432 archive bytes, 140 sidecar bytes, and SHA-256
+`d0cd2ffc14b7e67ae0656e5519de8226170e57fac8e27cf33f5dd4ad7f644ffc`.
+
 Remaining formal-release integration work is:
 
-- implement the separate package's deterministic archive authority;
 - add isolated release rehearsal and archive equivalence checks;
 - approve actual release notes and an actual release context;
 - perform the final release rehearsal before publication and persistent-IRI
   deployment.
 
 No formal SOSA-2023 package or archive is committed to the repository, and no
-tag, GitHub release, or persistent-IRI deployment is created by this package
-construction milestone. Focused tests create only temporary synthetic package
-outputs.
+tag, GitHub release, or persistent-IRI deployment is created by this archive
+authority milestone. Focused tests create only temporary synthetic package,
+archive, and sidecar outputs.
 
 ## Non-goals
 

--- a/tests/test_sosa_2023_release_archive.py
+++ b/tests/test_sosa_2023_release_archive.py
@@ -718,18 +718,8 @@ class Sosa2023RealPackageArchiveIntegrationTests(unittest.TestCase):
         )
 
         self.assertEqual(
-            len(first_bytes),
-            146432,
-        )
-
-        self.assertEqual(
             len(first_sidecar),
             140,
-        )
-
-        self.assertEqual(
-            first.archive_sha256,
-            "d0cd2ffc14b7e67ae0656e5519de8226170e57fac8e27cf33f5dd4ad7f644ffc",
         )
 
         self.assertEqual(

--- a/tests/test_sosa_2023_release_archive.py
+++ b/tests/test_sosa_2023_release_archive.py
@@ -1,0 +1,1044 @@
+#!/usr/bin/env python3
+"""Canonical SOSA-2023 raw-USTAR release archive construction and validation regressions."""
+
+from __future__ import annotations
+
+import ast
+import hashlib
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+from dataclasses import dataclass
+from pathlib import Path
+from unittest import mock
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT / "tools"))
+
+import sosa_2023_release_archive as archive  # noqa: E402
+import sosa_2023_build_release as build  # noqa: E402
+from sosa_2023_build_release import PACKAGE_FILE_PATHS  # noqa: E402
+from release_context import parse_formal_release_context  # noqa: E402
+
+
+RELEASE_ID = "2099-01-02"
+SOURCE_COMMIT = "0123456789abcdef0123456789abcdef01234567"
+RECORD = archive.USTAR_RECORD_SIZE
+TRACK_ID = archive.TRACK_ID
+EXPECTED_MEMBERS = (
+    "SOSA-2023-2099-01-02/",
+    "SOSA-2023-2099-01-02/LICENSE",
+    "SOSA-2023-2099-01-02/RELEASE-NOTES.md",
+    "SOSA-2023-2099-01-02/SHA256SUMS",
+    "SOSA-2023-2099-01-02/catalog-v001.xml",
+    "SOSA-2023-2099-01-02/manifest.json",
+    "SOSA-2023-2099-01-02/" + TRACK_ID + "/",
+    "SOSA-2023-2099-01-02/"
+    + TRACK_ID
+    + "/sosa-bfo-mapping.ttl",
+    "SOSA-2023-2099-01-02/"
+    + TRACK_ID
+    + "/sosa-cco-extension.ttl",
+    "SOSA-2023-2099-01-02/"
+    + TRACK_ID
+    + "/sosa-integrated.ttl",
+    "SOSA-2023-2099-01-02/sources/",
+    "SOSA-2023-2099-01-02/sources/SOSA-2023-to-BFO-COMS.xlsx",
+    "SOSA-2023-2099-01-02/sources/product-role-policy.toml",
+    "SOSA-2023-2099-01-02/sources/sosa-2023-publication-metadata.toml",
+    "SOSA-2023-2099-01-02/sources/sosa-release-scope.toml",
+    "SOSA-2023-2099-01-02/sources/sosa-source-version.toml",
+)
+
+
+@dataclass(frozen=True)
+class RawMember:
+    name: str
+    header_offset: int
+    data_offset: int
+    size: int
+    padding: int
+    end_offset: int
+
+
+def create_package(parent: Path) -> Path:
+    package = parent / RELEASE_ID
+    package.mkdir(parents=True)
+    for relative in PACKAGE_FILE_PATHS:
+        path = package / relative
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes((f"fixture:{relative}\n").encode("utf-8"))
+    return package
+
+
+def raw_members(value: bytes) -> tuple[RawMember, ...]:
+    result: list[RawMember] = []
+    offset = 0
+    while value[offset : offset + RECORD] != b"\0" * RECORD:
+        header = value[offset : offset + RECORD]
+        name = header[:100].split(b"\0", 1)[0].decode("ascii")
+        size = int(header[124:135].decode("ascii"), 8)
+        data_offset = offset + RECORD
+        padding = (-size) % RECORD
+        end_offset = data_offset + size + padding
+        result.append(RawMember(name, offset, data_offset, size, padding, end_offset))
+        offset = end_offset
+    return tuple(result)
+
+
+def repair_checksum(value: bytes, header_offset: int) -> bytes:
+    result = bytearray(value)
+    header = result[header_offset : header_offset + RECORD]
+    header[148:156] = b" " * 8
+    checksum = sum(header)
+    header[148:156] = f"{checksum:06o}".encode("ascii") + b"\0 "
+    result[header_offset : header_offset + RECORD] = header
+    return bytes(result)
+
+
+def mutate_header(value: bytes, member: RawMember, mutate, *, repair: bool = True) -> bytes:
+    result = bytearray(value)
+    header = result[member.header_offset : member.header_offset + RECORD]
+    mutate(header)
+    result[member.header_offset : member.header_offset + RECORD] = header
+    changed = bytes(result)
+    return repair_checksum(changed, member.header_offset) if repair else changed
+
+
+def replace_name(header: bytearray, name: str) -> None:
+    encoded = name.encode("ascii")
+    header[:100] = b"\0" * 100
+    header[: len(encoded)] = encoded
+
+
+def write_archive_and_sidecar(test: unittest.TestCase, value: bytes) -> None:
+    test.archive_path.write_bytes(value)
+    test.sidecar_path.write_bytes(archive.canonical_sidecar_bytes(RELEASE_ID, value))
+
+
+class ReleaseArchiveTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.root = Path(tempfile.mkdtemp(prefix="release-archive-tests-")).resolve()
+        self.addCleanup(shutil.rmtree, self.root, True)
+        self.package = create_package(self.root / "package-root")
+        self.value = archive.canonical_archive_bytes(self.package, RELEASE_ID)
+        self.archive_path = self.root / archive.archive_filename(RELEASE_ID)
+        self.sidecar_path = self.root / archive.sidecar_filename(RELEASE_ID)
+        write_archive_and_sidecar(self, self.value)
+
+    def validate(self):
+        with mock.patch.object(archive, "_package_validation_issues", return_value=()) as package_check, mock.patch.object(
+            archive, "_manifest_commit_issue", return_value=()
+        ) as commit_check:
+            issues = archive.validate_release_archive(
+                self.package,
+                self.archive_path,
+                self.sidecar_path,
+                RELEASE_ID,
+                SOURCE_COMMIT,
+                repository_root=REPO_ROOT,
+            )
+        return issues, package_check, commit_check
+
+    def assert_validation_code(self, value: bytes, code: str) -> None:
+        write_archive_and_sidecar(self, value)
+        issues, package_check, _ = self.validate()
+        self.assertIn(code, {issue.code for issue in issues})
+        package_check.assert_not_called()
+
+    def assert_read_only_validation(self, value: bytes, expected_code: str | None = None) -> None:
+        write_archive_and_sidecar(self, value)
+        before = (
+            self.archive_path.read_bytes(),
+            self.archive_path.stat().st_mtime_ns,
+            self.sidecar_path.read_bytes(),
+            self.sidecar_path.stat().st_mtime_ns,
+        )
+        issues, _, _ = self.validate()
+        if expected_code is None:
+            self.assertFalse(issues)
+        else:
+            self.assertIn(expected_code, {issue.code for issue in issues})
+        after = (
+            self.archive_path.read_bytes(),
+            self.archive_path.stat().st_mtime_ns,
+            self.sidecar_path.read_bytes(),
+            self.sidecar_path.stat().st_mtime_ns,
+        )
+        self.assertEqual(after, before)
+
+    def test_member_authority_is_verbatim_and_independent_of_package_sorting(self) -> None:
+        self.assertEqual(archive.ARCHIVE_MEMBER_TEMPLATES, tuple(name.replace(RELEASE_ID, "{release_id}") for name in EXPECTED_MEMBERS))
+        self.assertEqual(archive.canonical_member_names(RELEASE_ID), EXPECTED_MEMBERS)
+        self.assertEqual(len(EXPECTED_MEMBERS), 16)
+        self.assertTrue(all(name.endswith("/") for name in (EXPECTED_MEMBERS[0], EXPECTED_MEMBERS[6], EXPECTED_MEMBERS[10])))
+        self.assertEqual(archive.canonical_member_names(RELEASE_ID)[5], f"SOSA-2023-{RELEASE_ID}/manifest.json")
+
+    def test_raw_ustar_stream_has_exact_headers_metadata_and_two_record_eof(self) -> None:
+        members = raw_members(self.value)
+        self.assertEqual(tuple(member.name for member in members), EXPECTED_MEMBERS)
+        self.assertEqual(len(members), 16)
+        self.assertEqual(len(self.value) % RECORD, 0)
+        self.assertEqual(self.value[-2 * RECORD :], b"\0" * (2 * RECORD))
+        self.assertNotEqual(self.value[-3 * RECORD : -2 * RECORD], b"\0" * RECORD)
+        for member in members:
+            with self.subTest(member=member.name):
+                header = self.value[member.header_offset : member.data_offset]
+                self.assertEqual(header[257:263], b"ustar\0")
+                self.assertEqual(header[263:265], b"00")
+                self.assertEqual(header[345:500], b"\0" * 155)
+                self.assertEqual(header[500:512], b"\0" * 12)
+                self.assertEqual(header[157:257], b"\0" * 100)
+                self.assertEqual(header[265:329], b"\0" * 64)
+                self.assertEqual(header[156:157], b"5" if member.name.endswith("/") else b"0")
+                self.assertEqual(self.value[member.data_offset + member.size : member.end_offset], b"\0" * member.padding)
+
+    def build_external_output(self, output: Path):
+        with mock.patch.object(archive, "_package_validation_issues", return_value=()), mock.patch.object(
+            archive, "_manifest_commit_issue", return_value=()
+        ):
+            return archive.build_release_archive(
+                self.package,
+                output,
+                RELEASE_ID,
+                SOURCE_COMMIT,
+                repository_root=REPO_ROOT,
+            )
+
+    def test_builder_publishes_only_one_complete_no_replace_output_directory(self) -> None:
+        parent = self.root / "external"
+        parent.mkdir()
+        output = parent / "archive-output"
+        result = self.build_external_output(output)
+        archive_path = output / archive.archive_filename(RELEASE_ID)
+        sidecar_path = output / archive.sidecar_filename(RELEASE_ID)
+        self.assertEqual(result.archive_sha256, hashlib.sha256(self.value).hexdigest())
+        self.assertEqual({path.name for path in output.iterdir()}, {archive_path.name, sidecar_path.name})
+        self.assertEqual(archive_path.read_bytes(), self.value)
+        self.assertEqual(sidecar_path.read_bytes(), archive.canonical_sidecar_bytes(RELEASE_ID, self.value))
+        self.assertFalse(any(path.name.startswith(".release-archive-output-") for path in parent.iterdir()))
+
+    def test_external_builder_interruption_never_publishes_a_one_file_pair(self) -> None:
+        parent = self.root / "external"
+        parent.mkdir()
+        original_write = Path.write_bytes
+
+        def fail_only_candidate_sidecar(path: Path, value: bytes) -> int:
+            if path.name == archive.sidecar_filename(RELEASE_ID) and path.parent.name.startswith(".release-archive-output-"):
+                raise OSError("injected after archive construction")
+            return original_write(path, value)
+
+        scenarios = (
+            ("after-archive-before-sidecar", mock.patch.object(Path, "write_bytes", new=fail_only_candidate_sidecar)),
+            (
+                "after-sidecar-before-validation",
+                mock.patch.object(
+                    archive,
+                    "validate_release_archive",
+                    return_value=(archive.archive_issue("ARCHIVE_BUILD_FAILED", "candidate", "injected validation boundary"),),
+                ),
+            ),
+            ("after-validation-before-publication", mock.patch.object(archive, "atomic_rename_noreplace", side_effect=OSError("before directory publication"))),
+        )
+        for name, patcher in scenarios:
+            with self.subTest(case=name), patcher, self.assertRaises(archive.ReleaseArchiveError):
+                self.build_external_output(parent / name)
+            self.assertFalse((parent / name).exists())
+            self.assertFalse(any(path.name.startswith(".release-archive-output-") for path in parent.iterdir()))
+
+    def test_directory_publication_race_and_postpublication_error_preserve_external_content(self) -> None:
+        parent = self.root / "external"
+        parent.mkdir()
+        output = parent / "raced"
+        original = archive.atomic_rename_noreplace
+
+        def occupy_at_publication(source: Path, destination: Path) -> None:
+            destination.mkdir()
+            (destination / "sentinel").write_bytes(b"racing directory\n")
+            original(source, destination)
+
+        with mock.patch.object(archive, "atomic_rename_noreplace", side_effect=occupy_at_publication), self.assertRaises(
+            archive.ReleaseArchiveError
+        ) as raised:
+            self.build_external_output(output)
+        self.assertIn("OUTPUT_EXISTS", {issue.code for issue in raised.exception.issues})
+        self.assertEqual((output / "sentinel").read_bytes(), b"racing directory\n")
+        self.assertFalse(any(path.name.startswith(".release-archive-output-") for path in parent.iterdir()))
+
+        published = parent / "published"
+
+        def publish_then_raise(source: Path, destination: Path) -> None:
+            original(source, destination)
+            raise RuntimeError("injected after successful publication")
+
+        with mock.patch.object(archive, "atomic_rename_noreplace", side_effect=publish_then_raise), self.assertRaises(
+            archive.ReleaseArchiveError
+        ) as raised:
+            self.build_external_output(published)
+        self.assertIn("ATOMIC_PUBLICATION_FAILED", {issue.code for issue in raised.exception.issues})
+        self.assertEqual(
+            {path.name for path in published.iterdir()},
+            {archive.archive_filename(RELEASE_ID), archive.sidecar_filename(RELEASE_ID)},
+        )
+        self.assertFalse(any(path.name.startswith(".release-archive-output-") for path in parent.iterdir()))
+
+    def test_builder_rejects_invalid_package_before_creating_any_output(self) -> None:
+        parent = self.root / "invalid-parent"
+        parent.mkdir()
+        output = parent / "invalid-output"
+        invalid = archive.archive_issue("PACKAGE_FILE_SET", "package", "injected invalid package")
+        with mock.patch.object(archive, "_package_validation_issues", return_value=(invalid,)), mock.patch.object(
+            archive, "_manifest_commit_issue", return_value=()
+        ), self.assertRaises(archive.ReleaseArchiveError) as raised:
+            archive.build_release_archive(
+                self.package,
+                output,
+                RELEASE_ID,
+                SOURCE_COMMIT,
+                repository_root=REPO_ROOT,
+            )
+        self.assertIn("PACKAGE_FILE_SET", {issue.code for issue in raised.exception.issues})
+        self.assertFalse(output.exists())
+        self.assertFalse(any(parent.iterdir()))
+
+    def test_archive_output_preflight_rejects_and_preserves_hidden_staging_siblings(self) -> None:
+        parent = self.root / "external"
+        parent.mkdir()
+        sentinel_target = self.root / "sentinel-target"
+        sentinel_target.mkdir()
+        (sentinel_target / "sentinel").write_bytes(b"target\n")
+        cases = (
+            ("directory", lambda path: (path.mkdir(), (path / "sentinel").write_bytes(b"directory\n"))),
+            ("file", lambda path: path.write_bytes(b"file\n")),
+            ("symlink", lambda path: path.symlink_to(sentinel_target, target_is_directory=True)),
+            ("multiple", lambda path: (path.mkdir(), (parent / ".release-archive-output-second").write_bytes(b"second\n"))),
+        )
+        for name, create in cases:
+            with self.subTest(case=name):
+                sibling = parent / ".release-archive-output-unrelated"
+                create(sibling)
+                before = {
+                    path.name: (path.lstat().st_mode, path.readlink() if path.is_symlink() else path.read_bytes() if path.is_file() else None)
+                    for path in parent.iterdir()
+                }
+                with self.assertRaises(archive.ReleaseArchiveError) as raised:
+                    self.build_external_output(parent / f"output-{name}")
+                self.assertIn("OUTPUT_EXISTS", {issue.code for issue in raised.exception.issues})
+                after = {
+                    path.name: (path.lstat().st_mode, path.readlink() if path.is_symlink() else path.read_bytes() if path.is_file() else None)
+                    for path in parent.iterdir()
+                }
+                self.assertEqual(after, before)
+                for path in list(parent.iterdir()):
+                    if path.is_symlink() or path.is_file():
+                        path.unlink()
+                    else:
+                        shutil.rmtree(path)
+
+        ordinary = parent / "ordinary-sibling"
+        ordinary.write_bytes(b"ordinary\n")
+        output = parent / "accepted"
+        self.build_external_output(output)
+        self.assertEqual(ordinary.read_bytes(), b"ordinary\n")
+
+    def test_owned_archive_staging_refuses_replacement_symlink_after_publication_error(self) -> None:
+        parent = self.root / "external"
+        parent.mkdir()
+        output = parent / "published"
+        replacement = self.root / "replacement"
+        replacement.mkdir()
+        (replacement / "sentinel").write_bytes(b"preserve me\n")
+        original = archive.atomic_rename_noreplace
+
+        def publish_replace_and_raise(source: Path, destination: Path) -> None:
+            original(source, destination)
+            shutil.rmtree(destination)
+            destination.symlink_to(replacement, target_is_directory=True)
+            raise RuntimeError("postpublication replacement")
+
+        with mock.patch.object(archive, "atomic_rename_noreplace", side_effect=publish_replace_and_raise), self.assertRaises(
+            archive.ReleaseArchiveError
+        ) as raised:
+            self.build_external_output(output)
+        self.assertTrue({"ATOMIC_PUBLICATION_FAILED", "CLEANUP_FAILED"} <= {issue.code for issue in raised.exception.issues})
+        self.assertTrue(output.is_symlink())
+        self.assertEqual((replacement / "sentinel").read_bytes(), b"preserve me\n")
+
+    def test_header_mutation_matrix_is_rejected_before_extraction(self) -> None:
+        first = raw_members(self.value)[1]
+        scenarios = (
+            ("checksum", mutate_header(self.value, first, lambda header: header.__setitem__(100, ord("7")), repair=False), "ARCHIVE_METADATA_MISMATCH"),
+            ("numeric", mutate_header(self.value, first, lambda header: header.__setitem__(107, ord(" "))), "ARCHIVE_METADATA_MISMATCH"),
+            ("magic", mutate_header(self.value, first, lambda header: header.__setitem__(257, ord("X"))), "ARCHIVE_METADATA_MISMATCH"),
+            ("version", mutate_header(self.value, first, lambda header: header.__setitem__(263, ord("9"))), "ARCHIVE_METADATA_MISMATCH"),
+            ("unused", mutate_header(self.value, first, lambda header: header.__setitem__(500, 1)), "ARCHIVE_METADATA_MISMATCH"),
+        )
+        for name, changed, code in scenarios:
+            with self.subTest(case=name):
+                self.assert_validation_code(changed, code)
+
+    def test_framing_mutation_matrix_rejects_noncanonical_eof_padding_and_concatenation(self) -> None:
+        file_member = next(member for member in raw_members(self.value) if member.padding)
+        padding = bytearray(self.value)
+        padding[file_member.data_offset + file_member.size] = 1
+        scenarios = (
+            ("nonzero-padding", bytes(padding), "ARCHIVE_METADATA_MISMATCH"),
+            ("missing-first-eof", self.value[:-2 * RECORD] + b"x" * RECORD + b"\0" * RECORD, "ARCHIVE_METADATA_MISMATCH"),
+            ("missing-second-eof", self.value[:-RECORD], "ARCHIVE_METADATA_MISMATCH"),
+            ("extra-zero-eof", self.value + b"\0" * RECORD, "ARCHIVE_METADATA_MISMATCH"),
+            ("nonzero-trailing", self.value + b"x" * RECORD, "ARCHIVE_METADATA_MISMATCH"),
+            ("concatenated", self.value + self.value, "ARCHIVE_METADATA_MISMATCH"),
+            ("truncated-header", self.value[:-1], "ARCHIVE_PARSE_FAILED"),
+        )
+        final_file = raw_members(self.value)[-1]
+        truncated_body = mutate_header(
+            self.value,
+            final_file,
+            lambda header: header.__setitem__(slice(124, 136), archive._octal_field(final_file.size + 4096, 12)),
+        )
+        scenarios += (("truncated-body", truncated_body, "ARCHIVE_PARSE_FAILED"),)
+        for name, changed, code in scenarios:
+            with self.subTest(case=name):
+                self.assert_validation_code(changed, code)
+
+    def test_member_order_duplicate_type_and_unsafe_path_mutations_are_rejected(self) -> None:
+        members = raw_members(self.value)
+        duplicate = mutate_header(self.value, members[1], lambda header: replace_name(header, members[0].name))
+        unsafe = mutate_header(self.value, members[1], lambda header: replace_name(header, "../escape"))
+        first_record = self.value[members[0].header_offset : members[0].end_offset]
+        second_record = self.value[members[1].header_offset : members[1].end_offset]
+        reordered = second_record + first_record + self.value[members[1].end_offset :]
+        extra_header = archive._canonical_header(f"SOSA-2023-{RELEASE_ID}/extra", is_directory=False, size=1)
+        extra = self.value[:-2 * RECORD] + extra_header + b"x" + b"\0" * (RECORD - 1) + b"\0" * (2 * RECORD)
+        scenarios = (
+            ("duplicate", duplicate, "DUPLICATE_ARCHIVE_MEMBER"),
+            ("unsafe", unsafe, "UNSAFE_ARCHIVE_MEMBER"),
+            ("reordered", reordered, "ARCHIVE_MEMBER_ORDER"),
+            ("extra", extra, "ARCHIVE_MEMBER_ORDER"),
+        )
+        for name, changed, code in scenarios:
+            with self.subTest(case=name):
+                self.assert_validation_code(changed, code)
+        for type_flag in (b"1", b"2", b"3", b"4", b"6", b"7", b"g", b"x", b"L", b"K"):
+            with self.subTest(type_flag=type_flag):
+                special = mutate_header(
+                    self.value,
+                    members[1],
+                    lambda header, selected=type_flag: header.__setitem__(156, selected[0]),
+                )
+                self.assert_validation_code(special, "ARCHIVE_MEMBER_TYPE")
+
+    def test_content_and_metadata_mismatches_are_rejected_after_raw_validation(self) -> None:
+        file_member = next(member for member in raw_members(self.value) if not member.name.endswith("/"))
+        changed_content = bytearray(self.value)
+        changed_content[file_member.data_offset] ^= 1
+        self.assert_validation_code(bytes(changed_content), "ARCHIVE_CONTENT_MISMATCH")
+
+        changed_mode = mutate_header(
+            self.value,
+            file_member,
+            lambda header: header.__setitem__(slice(100, 108), archive._octal_field(0o600, 8)),
+        )
+        self.assert_validation_code(changed_mode, "ARCHIVE_METADATA_MISMATCH")
+
+    def test_sidecar_grammar_matrix_is_exact(self) -> None:
+        digest = hashlib.sha256(self.value).hexdigest()
+        filename = archive.archive_filename(RELEASE_ID)
+        values = (
+            ("uppercase", f"{digest.upper()}  {filename}\n".encode("ascii")),
+            ("wrong-digest", b"0" * 64 + f"  {filename}\n".encode("ascii")),
+            ("wrong-filename", f"{digest}  wrong.tar\n".encode("ascii")),
+            ("qualified-filename", f"{digest}  nested/{filename}\n".encode("ascii")),
+            ("one-space", f"{digest} {filename}\n".encode("ascii")),
+            ("three-spaces", f"{digest}   {filename}\n".encode("ascii")),
+            ("tab", f"{digest}\t{filename}\n".encode("ascii")),
+            ("crlf", f"{digest}  {filename}\r\n".encode("ascii")),
+            ("missing-lf", f"{digest}  {filename}".encode("ascii")),
+            ("two-lfs", f"{digest}  {filename}\n\n".encode("ascii")),
+            ("leading-blank", b"\n" + f"{digest}  {filename}\n".encode("ascii")),
+            ("trailing-blank", f"{digest}  {filename}\n\n".encode("ascii")),
+            ("second-entry", f"{digest}  {filename}\n{digest}  {filename}\n".encode("ascii")),
+            ("non-ascii", f"{digest}  {filename}\n".encode("ascii") + b"\xff"),
+        )
+        for name, value in values:
+            with self.subTest(case=name):
+                self.sidecar_path.write_bytes(value)
+                issues, package_check, _ = self.validate()
+                self.assertIn("ARCHIVE_CHECKSUM_MISMATCH", {issue.code for issue in issues})
+                package_check.assert_not_called()
+
+    def test_validator_is_read_only_for_valid_and_failure_paths(self) -> None:
+        self.assert_read_only_validation(self.value)
+        self.assert_read_only_validation(self.value + b"\0" * RECORD, "ARCHIVE_METADATA_MISMATCH")
+        unsafe = mutate_header(self.value, raw_members(self.value)[1], lambda header: replace_name(header, "../escape"))
+        self.assert_read_only_validation(unsafe, "UNSAFE_ARCHIVE_MEMBER")
+        metadata = mutate_header(
+            self.value,
+            raw_members(self.value)[1],
+            lambda header: header.__setitem__(slice(100, 108), archive._octal_field(0o600, 8)),
+        )
+        self.assert_read_only_validation(metadata, "ARCHIVE_METADATA_MISMATCH")
+        content = bytearray(self.value)
+        member = raw_members(self.value)[1]
+        content[member.data_offset] ^= 1
+        self.assert_read_only_validation(bytes(content), "ARCHIVE_CONTENT_MISMATCH")
+        self.sidecar_path.write_bytes(b"invalid sidecar\n")
+        before = (
+            self.archive_path.read_bytes(),
+            self.archive_path.stat().st_mtime_ns,
+            self.sidecar_path.read_bytes(),
+            self.sidecar_path.stat().st_mtime_ns,
+        )
+        issues, _, _ = self.validate()
+        self.assertIn("ARCHIVE_CHECKSUM_MISMATCH", {issue.code for issue in issues})
+        self.assertEqual(
+            (
+                self.archive_path.read_bytes(),
+                self.archive_path.stat().st_mtime_ns,
+                self.sidecar_path.read_bytes(),
+                self.sidecar_path.stat().st_mtime_ns,
+            ),
+            before,
+        )
+
+    def test_validator_preserves_primary_and_extraction_cleanup_diagnostics(self) -> None:
+        changed = bytearray(self.value)
+        member = raw_members(self.value)[1]
+        changed[member.data_offset] ^= 1
+        write_archive_and_sidecar(self, bytes(changed))
+        original = archive._cleanup_owned_directory
+
+        def cleanup_with_issue(path: Path | None, field: str):
+            original(path, field)
+            return (archive.archive_issue("CLEANUP_FAILED", field, "injected cleanup failure"),)
+
+        with mock.patch.object(archive, "_package_validation_issues", return_value=()), mock.patch.object(
+            archive, "_manifest_commit_issue", return_value=()
+        ), mock.patch.object(archive, "_cleanup_owned_directory", side_effect=cleanup_with_issue):
+            issues = archive.validate_release_archive(
+                self.package,
+                self.archive_path,
+                self.sidecar_path,
+                RELEASE_ID,
+                SOURCE_COMMIT,
+                repository_root=REPO_ROOT,
+            )
+        self.assertTrue({"ARCHIVE_CONTENT_MISMATCH", "CLEANUP_FAILED"} <= {issue.code for issue in issues})
+
+    def test_fresh_process_determinism_survives_hash_seed_locale_timezone_umask_and_source_metadata(self) -> None:
+        script = '''
+import os
+import sys
+from pathlib import Path
+sys.path.insert(0, sys.argv[2])
+from sosa_2023_build_release import PACKAGE_FILE_PATHS
+from sosa_2023_release_archive import canonical_archive_bytes, canonical_sidecar_bytes
+root = Path(sys.argv[1])
+variation = int(sys.argv[4])
+package = root / "2099-01-02"
+package.mkdir(parents=True)
+for index, relative in enumerate(PACKAGE_FILE_PATHS):
+    path = package / relative
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(("fixture:" + relative + "\\n").encode("utf-8"))
+    os.chmod(path, 0o600 if (index + variation) % 2 else 0o644)
+    os.utime(path, ns=(index + variation + 1, index + variation + 2))
+os.umask(int(sys.argv[3], 8))
+value = canonical_archive_bytes(package, "2099-01-02")
+sys.stdout.buffer.write(value + canonical_sidecar_bytes("2099-01-02", value))
+'''
+        settings = (
+            ("0", "UTC", "C", "022"),
+            ("1", "America/New_York", "C.UTF-8", "077"),
+            ("42", "UTC", "C", "002"),
+            ("random", "America/Los_Angeles", "C.UTF-8", "027"),
+        )
+        outputs: list[bytes] = []
+        for index, (seed, timezone, locale, mask) in enumerate(settings):
+            with self.subTest(seed=seed, timezone=timezone, locale=locale, umask=mask):
+                root = self.root / f"fresh-process-{index}"
+                environment = os.environ.copy()
+                environment.update(
+                    {
+                        "PYTHONDONTWRITEBYTECODE": "1",
+                        "PYTHONHASHSEED": seed,
+                        "TZ": timezone,
+                        "LC_ALL": locale,
+                        "LANG": locale,
+                    }
+                )
+                completed = subprocess.run(
+                    [sys.executable, "-B", "-c", script, str(root), str(REPO_ROOT / "tools"), mask, str(index)],
+                    env=environment,
+                    cwd=self.root,
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.PIPE,
+                    check=False,
+                )
+                self.assertEqual(completed.returncode, 0, completed.stderr.decode("utf-8", errors="replace"))
+                outputs.append(completed.stdout)
+        self.assertEqual(len(set(outputs)), 1)
+
+    def test_output_filename_and_sidecar_bytes_are_exact(self) -> None:
+        self.assertEqual(archive.archive_filename(RELEASE_ID), "SSN2BFO-sosa-2023-af425a0454ec00512a5ebfa2873fe35a077f5fda-2099-01-02.tar")
+        self.assertEqual(archive.sidecar_filename(RELEASE_ID), "SSN2BFO-sosa-2023-af425a0454ec00512a5ebfa2873fe35a077f5fda-2099-01-02.tar.sha256")
+        digest = hashlib.sha256(self.value).hexdigest()
+        self.assertEqual(
+            archive.canonical_sidecar_bytes(RELEASE_ID, self.value),
+            f"{digest}  SSN2BFO-sosa-2023-af425a0454ec00512a5ebfa2873fe35a077f5fda-2099-01-02.tar\n".encode("ascii"),
+        )
+
+
+class Sosa2023RealPackageArchiveIntegrationTests(unittest.TestCase):
+    def test_real_package_build_archives_twice_exactly_and_validates_read_only(
+        self,
+    ) -> None:
+        context = parse_formal_release_context(
+            "2099-01-02",
+            "2099-01-02",
+            "v2099-01-02",
+            "0123456789abcdef0123456789abcdef01234567",
+        )
+
+        notes = (
+            REPO_ROOT
+            / "release-notes/SOSA-2023-SYNTHETIC-2099-01-02.md"
+        )
+
+        development_before = (
+            build.snapshot_development_outputs(
+                REPO_ROOT
+            )
+        )
+
+        root = Path(
+            tempfile.mkdtemp(
+                prefix="sosa-2023-real-archive-integration-"
+            )
+        ).resolve()
+
+        self.addCleanup(
+            shutil.rmtree,
+            root,
+            True,
+        )
+
+        package = (
+            root
+            / "package"
+            / context.release_identifier
+        )
+
+        package.parent.mkdir()
+
+        result = build.build_release_package(
+            context,
+            notes,
+            package,
+            REPO_ROOT,
+        )
+
+        self.assertEqual(
+            result.manifest.source_commit,
+            context.source_commit,
+        )
+
+        def package_state():
+            return {
+                file_path.relative_to(
+                    package
+                ).as_posix(): (
+                    hashlib.sha256(
+                        file_path.read_bytes()
+                    ).hexdigest(),
+                    file_path.stat().st_size,
+                    file_path.stat().st_mtime_ns,
+                )
+                for file_path in package.rglob("*")
+                if file_path.is_file()
+            }
+
+        baseline = package_state()
+
+        self.assertEqual(
+            set(baseline),
+            set(PACKAGE_FILE_PATHS),
+        )
+
+        first_parent = root / "first"
+        second_parent = root / "second"
+
+        first_parent.mkdir()
+        second_parent.mkdir()
+
+        first = archive.build_release_archive(
+            package,
+            first_parent / "published",
+            context.release_identifier,
+            context.source_commit,
+            repository_root=REPO_ROOT,
+        )
+
+        self.assertEqual(
+            package_state(),
+            baseline,
+        )
+
+        second = archive.build_release_archive(
+            package,
+            second_parent / "published",
+            context.release_identifier,
+            context.source_commit,
+            repository_root=REPO_ROOT,
+        )
+
+        self.assertEqual(
+            package_state(),
+            baseline,
+        )
+
+        first_bytes = first.archive_path.read_bytes()
+        second_bytes = second.archive_path.read_bytes()
+
+        first_sidecar = first.sidecar_path.read_bytes()
+        second_sidecar = second.sidecar_path.read_bytes()
+
+        self.assertEqual(
+            first_bytes,
+            second_bytes,
+        )
+
+        self.assertEqual(
+            first_sidecar,
+            second_sidecar,
+        )
+
+        self.assertEqual(
+            len(first_bytes),
+            146432,
+        )
+
+        self.assertEqual(
+            len(first_sidecar),
+            140,
+        )
+
+        self.assertEqual(
+            first.archive_sha256,
+            "d0cd2ffc14b7e67ae0656e5519de8226170e57fac8e27cf33f5dd4ad7f644ffc",
+        )
+
+        self.assertEqual(
+            hashlib.sha256(
+                first_bytes
+            ).hexdigest(),
+            first.archive_sha256,
+        )
+
+        self.assertEqual(
+            second.archive_sha256,
+            first.archive_sha256,
+        )
+
+        self.assertEqual(
+            first.member_names,
+            archive.canonical_member_names(
+                context.release_identifier
+            ),
+        )
+
+        self.assertEqual(
+            len(first.member_names),
+            16,
+        )
+
+        self.assertFalse(
+            any(
+                "sosa-next" in member
+                for member in first.member_names
+            )
+        )
+
+        self.assertTrue(
+            any(
+                archive.TRACK_ID in member
+                for member in first.member_names
+            )
+        )
+
+        self.assertEqual(
+            first_sidecar,
+            archive.canonical_sidecar_bytes(
+                context.release_identifier,
+                first_bytes,
+            ),
+        )
+
+        archive_state_before = (
+            first.archive_path.read_bytes(),
+            first.archive_path.stat().st_size,
+            first.archive_path.stat().st_mtime_ns,
+            first.sidecar_path.read_bytes(),
+            first.sidecar_path.stat().st_size,
+            first.sidecar_path.stat().st_mtime_ns,
+        )
+
+        issues = archive.validate_release_archive(
+            package,
+            first.archive_path,
+            first.sidecar_path,
+            context.release_identifier,
+            context.source_commit,
+            repository_root=REPO_ROOT,
+        )
+
+        self.assertEqual(
+            issues,
+            (),
+        )
+
+        archive_state_after = (
+            first.archive_path.read_bytes(),
+            first.archive_path.stat().st_size,
+            first.archive_path.stat().st_mtime_ns,
+            first.sidecar_path.read_bytes(),
+            first.sidecar_path.stat().st_size,
+            first.sidecar_path.stat().st_mtime_ns,
+        )
+
+        self.assertEqual(
+            archive_state_after,
+            archive_state_before,
+        )
+
+        self.assertEqual(
+            package_state(),
+            baseline,
+        )
+
+        members = archive._parse_raw_archive(
+            first_bytes,
+            context.release_identifier,
+        )
+
+        self.assertEqual(
+            len(members),
+            16,
+        )
+
+        self.assertEqual(
+            len(first_bytes)
+            % archive.USTAR_RECORD_SIZE,
+            0,
+        )
+
+        self.assertEqual(
+            first_bytes[
+                -2
+                * archive.USTAR_RECORD_SIZE:
+            ],
+            b"\0"
+            * (
+                2
+                * archive.USTAR_RECORD_SIZE
+            ),
+        )
+
+        self.assertLessEqual(
+            max(
+                len(
+                    member.encode(
+                        "ascii"
+                    )
+                )
+                for member in first.member_names
+            ),
+            100,
+        )
+
+        self.assertEqual(
+            build.development_snapshot_issues(
+                REPO_ROOT,
+                development_before,
+            ),
+            (),
+        )
+
+
+class Sosa2023ArchiveAuthorityContractTests(unittest.TestCase):
+    def test_archive_identity_is_track_disambiguated(self) -> None:
+        self.assertEqual(
+            archive.archive_filename(RELEASE_ID),
+            "SSN2BFO-" + TRACK_ID + "-2099-01-02.tar",
+        )
+        self.assertEqual(
+            archive.sidecar_filename(RELEASE_ID),
+            "SSN2BFO-" + TRACK_ID + "-2099-01-02.tar.sha256",
+        )
+        self.assertEqual(
+            archive.archive_top_level(RELEASE_ID),
+            "SOSA-2023-2099-01-02",
+        )
+        self.assertNotEqual(
+            archive.archive_filename(RELEASE_ID),
+            "SSN2BFO-2099-01-02.tar",
+        )
+
+    def test_exact_archive_authority_matches_package_inventory(self) -> None:
+        members = archive.canonical_member_names(
+            RELEASE_ID
+        )
+
+        self.assertEqual(
+            len(members),
+            16,
+        )
+
+        top = archive.archive_top_level(
+            RELEASE_ID
+        )
+
+        files = {
+            value[len(top) + 1 :]
+            for value in members
+            if not value.endswith("/")
+        }
+
+        self.assertEqual(
+            files,
+            set(PACKAGE_FILE_PATHS),
+        )
+
+        self.assertEqual(
+            archive.EXPECTED_DIRECTORIES,
+            (
+                TRACK_ID,
+                "sources",
+            ),
+        )
+
+        self.assertLessEqual(
+            max(
+                len(value.encode("ascii"))
+                for value in members
+            ),
+            100,
+        )
+
+    def test_package_validation_uses_sosa_checker_without_reconstruction(
+        self,
+    ) -> None:
+        package = Path(
+            "/tmp/synthetic-sosa-2023-package"
+        )
+
+        with mock.patch.object(
+            archive,
+            "validate_release_package",
+            return_value=(),
+        ) as validator:
+            issues = (
+                archive
+                ._package_validation_issues(
+                    package,
+                    REPO_ROOT,
+                )
+            )
+
+        self.assertEqual(
+            issues,
+            (),
+        )
+
+        validator.assert_called_once_with(
+            package,
+            repository_root=REPO_ROOT,
+            reconstruct=False,
+        )
+
+    def test_archive_module_has_no_current_track_engine_dependency(
+        self,
+    ) -> None:
+        source = (
+            REPO_ROOT
+            / "tools/sosa_2023_release_archive.py"
+        ).read_text(
+            encoding="utf-8"
+        )
+
+        tree = ast.parse(
+            source
+        )
+
+        imports = []
+
+        for node in tree.body:
+            if isinstance(
+                node,
+                ast.Import,
+            ):
+                imports.extend(
+                    alias.name
+                    for alias in node.names
+                )
+
+            elif isinstance(
+                node,
+                ast.ImportFrom,
+            ):
+                imports.append(
+                    node.module or ""
+                )
+
+        self.assertFalse(
+            {
+                "build_release",
+                "check_release",
+                "release_manifest",
+                "release_archive",
+            }.intersection(
+                imports
+            )
+        )
+
+    def test_current_archive_and_sosa_package_authorities_remain_byte_locked(
+        self,
+    ) -> None:
+        expected = {
+            "tools/release_archive.py":
+                "8928d921ac7b850f5ff52449c12013fa2c394b6d1acaff83972134b81741c974",
+            "tests/test_release_archive.py":
+                "f2a89e4f1a34e3bdec443de687c74fd6d5ed4c938da09d8fef2cdc0fdac927d5",
+            "tools/sosa_2023_release_runtime.py":
+                "c515000306cdf114f648c447305946e7c2a39f33f7c45b5d79d99255a554d939",
+            "tools/sosa_2023_build_release.py":
+                "f4735bf7f748e3851624b091533e413e74565a508ab6099740403def3575269d",
+            "tools/sosa_2023_check_release.py":
+                "65a4debcfe73ccd6998310fe0be685fee7ef080d0707fedbe24a0aab814dea1b",
+            "tools/sosa_2023_release_manifest.py":
+                "8b0a1d18f7fb2da4851dc13cf4409c1a9903fd6e493abcf7953b0aea782c5c86",
+            "config/sosa-2023-release-manifest-schema-v1.json":
+                "44cef35154bd3650f26ca500d7afcf9b5131b336a8a862da78ace401ee6345af",
+        }
+
+        for relative, digest in expected.items():
+            with self.subTest(
+                path=relative
+            ):
+                self.assertEqual(
+                    hashlib.sha256(
+                        (
+                            REPO_ROOT
+                            / relative
+                        ).read_bytes()
+                    ).hexdigest(),
+                    digest,
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/run_validation_suite.py
+++ b/tools/run_validation_suite.py
@@ -424,6 +424,7 @@ def compile_check() -> StepResult:
             "tools/sosa_2023_release_runtime.py",
             "tools/sosa_2023_build_release.py",
             "tools/sosa_2023_check_release.py",
+            "tools/sosa_2023_release_archive.py",
             "tools/build_release.py",
             "tools/check_release.py",
             "tools/release_archive.py",
@@ -440,6 +441,7 @@ def compile_check() -> StepResult:
             "tests/test_sosa_2023_release_manifest.py",
             "tests/test_sosa_2023_release_runtime.py",
             "tests/test_sosa_2023_build_release.py",
+            "tests/test_sosa_2023_release_archive.py",
             "tests/test_robot_template_generation_pilot.py",
             "tests/test_robot_property_chain_generation_pilot.py",
             "tests/test_robot_diff_pilot.py",
@@ -679,6 +681,18 @@ def run_validation_suite(args: argparse.Namespace) -> int:
                     "unittest",
                     "tests.test_sosa_2023_release_runtime",
                     "tests.test_sosa_2023_build_release",
+                ],
+            )
+        )
+    if results[-1].passed:
+        results.append(
+            run_command(
+                "SOSA-2023 release-archive focused tests",
+                [
+                    sys.executable,
+                    "-m",
+                    "unittest",
+                    "tests.test_sosa_2023_release_archive",
                 ],
             )
         )

--- a/tools/sosa_2023_release_archive.py
+++ b/tools/sosa_2023_release_archive.py
@@ -1,0 +1,983 @@
+#!/usr/bin/env python3
+"""Build and validate the canonical uncompressed SOSA-2023 release-package USTAR archive."""
+
+from __future__ import annotations
+
+import argparse
+import ctypes
+import errno
+import hashlib
+import os
+import shutil
+import stat
+import sys
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
+from typing import Iterable
+from urllib.parse import urlsplit
+
+from sosa_2023_build_release import PACKAGE_FILE_PATHS
+from sosa_2023_check_release import _expected_directories, validate_release_package
+from release_context import SOURCE_COMMIT_PATTERN, validate_release_identifier
+from sosa_2023_release_manifest import TRACK_ID, load_and_validate_release_manifest
+
+EXPECTED_DIRECTORIES = _expected_directories()
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+ARCHIVE_FILENAME_PREFIX = f"SSN2BFO-{TRACK_ID}-"
+ARCHIVE_TOP_LEVEL_PREFIX = "SOSA-2023-"
+DIRECTORY_MODE = 0o755
+FILE_MODE = 0o644
+CANONICAL_MTIME = 0
+USTAR_RECORD_SIZE = 512
+USTAR_MAGIC = b"ustar\0"
+USTAR_VERSION = b"00"
+USTAR_EOF = b"\0" * (USTAR_RECORD_SIZE * 2)
+AT_FDCWD = -100
+RENAME_NOREPLACE = 1
+RENAME_EXCL = 0x00000004
+
+# This is intentionally independent from package traversal and lexical sorting.
+ARCHIVE_MEMBER_TEMPLATES = (
+    "SOSA-2023-{release_id}/",
+    "SOSA-2023-{release_id}/LICENSE",
+    "SOSA-2023-{release_id}/RELEASE-NOTES.md",
+    "SOSA-2023-{release_id}/SHA256SUMS",
+    "SOSA-2023-{release_id}/catalog-v001.xml",
+    "SOSA-2023-{release_id}/manifest.json",
+    "SOSA-2023-{release_id}/" + TRACK_ID + "/",
+    "SOSA-2023-{release_id}/"
+    + TRACK_ID
+    + "/sosa-bfo-mapping.ttl",
+    "SOSA-2023-{release_id}/"
+    + TRACK_ID
+    + "/sosa-cco-extension.ttl",
+    "SOSA-2023-{release_id}/"
+    + TRACK_ID
+    + "/sosa-integrated.ttl",
+    "SOSA-2023-{release_id}/sources/",
+    "SOSA-2023-{release_id}/sources/SOSA-2023-to-BFO-COMS.xlsx",
+    "SOSA-2023-{release_id}/sources/product-role-policy.toml",
+    "SOSA-2023-{release_id}/sources/sosa-2023-publication-metadata.toml",
+    "SOSA-2023-{release_id}/sources/sosa-release-scope.toml",
+    "SOSA-2023-{release_id}/sources/sosa-source-version.toml",
+)
+
+
+@dataclass(frozen=True)
+class ReleaseArchiveIssue:
+    code: str
+    field: str
+    message: str
+
+    @property
+    def sort_key(self) -> tuple[str, str, str]:
+        return self.field, self.code, self.message
+
+
+@dataclass(frozen=True)
+class ReleaseArchiveResult:
+    archive_path: Path
+    sidecar_path: Path
+    archive_sha256: str
+    member_names: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class _RawArchiveMember:
+    name: str
+    content: bytes
+    is_directory: bool
+
+
+@dataclass(frozen=True)
+class _OwnedDirectory:
+    """A directory created by this process and safe to remove only by identity."""
+
+    path: Path
+    st_dev: int
+    st_ino: int
+    file_type: int
+
+
+class ReleaseArchiveError(ValueError):
+    """One or more deterministic archive construction or validation failures."""
+
+    def __init__(self, issues: Iterable[ReleaseArchiveIssue]):
+        self.issues = tuple(sorted(set(issues), key=lambda value: value.sort_key))
+        super().__init__("; ".join(format_issue(issue) for issue in self.issues))
+
+
+class AtomicNoReplaceUnsupportedError(OSError):
+    """The host cannot provide the required no-replace rename primitive."""
+
+
+def format_issue(issue: ReleaseArchiveIssue) -> str:
+    return f"ERROR [{issue.code}] {issue.field}: {issue.message}"
+
+
+def archive_issue(code: str, field: str, message: str) -> ReleaseArchiveIssue:
+    return ReleaseArchiveIssue(code, field, message)
+
+
+def archive_filename(release_identifier: str) -> str:
+    return f"{ARCHIVE_FILENAME_PREFIX}{validate_release_identifier(release_identifier)}.tar"
+
+
+def sidecar_filename(release_identifier: str) -> str:
+    return archive_filename(release_identifier) + ".sha256"
+
+
+def archive_top_level(release_identifier: str) -> str:
+    return f"{ARCHIVE_TOP_LEVEL_PREFIX}{validate_release_identifier(release_identifier)}"
+
+
+def canonical_member_names(release_identifier: str) -> tuple[str, ...]:
+    release_id = validate_release_identifier(release_identifier)
+    return tuple(template.format(release_id=release_id) for template in ARCHIVE_MEMBER_TEMPLATES)
+
+
+def canonical_directory_names(release_identifier: str) -> frozenset[str]:
+    return frozenset(name for name in canonical_member_names(release_identifier) if name.endswith("/"))
+
+
+def canonical_sidecar_bytes(release_identifier: str, archive_bytes: bytes) -> bytes:
+    digest = hashlib.sha256(archive_bytes).hexdigest()
+    return f"{digest}  {archive_filename(release_identifier)}\n".encode("ascii")
+
+
+def _package_layout_issues(package_dir: Path) -> tuple[ReleaseArchiveIssue, ...]:
+    issues: list[ReleaseArchiveIssue] = []
+    if not package_dir.is_dir() or package_dir.is_symlink():
+        return (archive_issue("PACKAGE_DIRECTORY", "package_dir", "expected real directory"),)
+    files: list[str] = []
+    directories: list[str] = []
+    for path in sorted(package_dir.rglob("*"), key=lambda value: value.relative_to(package_dir).as_posix()):
+        relative = path.relative_to(package_dir).as_posix()
+        if path.is_symlink():
+            issues.append(archive_issue("PACKAGE_SYMLINK", relative, "symlinks are prohibited"))
+        elif path.is_dir():
+            directories.append(relative)
+        elif path.is_file():
+            files.append(relative)
+        else:
+            issues.append(archive_issue("PACKAGE_SPECIAL_FILE", relative, "unsupported filesystem entry"))
+    if tuple(files) != PACKAGE_FILE_PATHS:
+        issues.append(archive_issue("PACKAGE_FILE_SET", "package", "regular-file inventory differs"))
+    if tuple(directories) != EXPECTED_DIRECTORIES:
+        issues.append(archive_issue("PACKAGE_DIRECTORY_SET", "package", "directory inventory differs"))
+    return tuple(sorted(set(issues), key=lambda value: value.sort_key))
+
+
+def _archive_layout_authority_issues(release_identifier: str) -> tuple[ReleaseArchiveIssue, ...]:
+    top = archive_top_level(release_identifier)
+    members = canonical_member_names(release_identifier)
+    files = tuple(name[len(top) + 1 :] for name in members if not name.endswith("/"))
+    directories = tuple(name[len(top) + 1 : -1] for name in members if name.endswith("/") and name != top + "/")
+    issues: list[ReleaseArchiveIssue] = []
+    if frozenset(files) != frozenset(PACKAGE_FILE_PATHS) or len(files) != len(PACKAGE_FILE_PATHS):
+        issues.append(archive_issue("ARCHIVE_LAYOUT_AUTHORITY", "archive", "file authority differs from package authority"))
+    if directories != EXPECTED_DIRECTORIES:
+        issues.append(archive_issue("ARCHIVE_LAYOUT_AUTHORITY", "archive", "directory authority differs from package authority"))
+    expected_member_count = (
+        1
+        + len(EXPECTED_DIRECTORIES)
+        + len(PACKAGE_FILE_PATHS)
+    )
+    if (
+        len(members) != expected_member_count
+        or len(set(members)) != expected_member_count
+    ):
+        issues.append(
+            archive_issue(
+                "ARCHIVE_LAYOUT_AUTHORITY",
+                "archive",
+                f"expected exactly {expected_member_count} unique members",
+            )
+        )
+    return tuple(sorted(set(issues), key=lambda value: value.sort_key))
+
+
+def _octal_field(value: int, width: int) -> bytes:
+    if value < 0 or value >= 8 ** (width - 1):
+        raise ValueError(f"value {value} does not fit {width}-byte octal field")
+    return f"{value:0{width - 1}o}".encode("ascii") + b"\0"
+
+
+def _checksum_field(value: int) -> bytes:
+    if value < 0 or value >= 8**6:
+        raise ValueError(f"checksum {value} does not fit canonical field")
+    return f"{value:06o}".encode("ascii") + b"\0 "
+
+
+def _canonical_header(name: str, *, is_directory: bool, size: int) -> bytes:
+    encoded_name = name.encode("ascii")
+    if len(encoded_name) > 100:
+        raise ReleaseArchiveError((archive_issue("ARCHIVE_NAME_OVERFLOW", name, "USTAR name field exceeds 100 bytes"),))
+    if is_directory:
+        if not name.endswith("/") or size != 0:
+            raise ReleaseArchiveError((archive_issue("ARCHIVE_METADATA_MISMATCH", name, "invalid directory metadata"),))
+        mode = DIRECTORY_MODE
+        type_flag = b"5"
+    else:
+        if name.endswith("/"):
+            raise ReleaseArchiveError((archive_issue("ARCHIVE_METADATA_MISMATCH", name, "regular file name ends with slash"),))
+        mode = FILE_MODE
+        type_flag = b"0"
+
+    header = bytearray(USTAR_RECORD_SIZE)
+    header[0 : len(encoded_name)] = encoded_name
+    header[100:108] = _octal_field(mode, 8)
+    header[108:116] = _octal_field(0, 8)
+    header[116:124] = _octal_field(0, 8)
+    header[124:136] = _octal_field(size, 12)
+    header[136:148] = _octal_field(CANONICAL_MTIME, 12)
+    header[148:156] = b" " * 8
+    header[156:157] = type_flag
+    header[257:263] = USTAR_MAGIC
+    header[263:265] = USTAR_VERSION
+    header[329:337] = _octal_field(0, 8)
+    header[337:345] = _octal_field(0, 8)
+    checksum = sum(header)
+    header[148:156] = _checksum_field(checksum)
+    return bytes(header)
+
+
+def canonical_archive_bytes(package_dir: Path, release_identifier: str) -> bytes:
+    """Serialize one exact validated package layout as canonical raw POSIX USTAR."""
+
+    package_dir = Path(package_dir)
+    issues = (*_archive_layout_authority_issues(release_identifier), *_package_layout_issues(package_dir))
+    if issues:
+        raise ReleaseArchiveError(issues)
+    expected_name = validate_release_identifier(release_identifier)
+    if package_dir.name != expected_name:
+        raise ReleaseArchiveError(
+            (archive_issue("PACKAGE_BASENAME", "package_dir", f"expected {expected_name!r}"),)
+        )
+
+    top = archive_top_level(release_identifier)
+    parts: list[bytes] = []
+    for member_name in canonical_member_names(release_identifier):
+        is_directory = member_name.endswith("/")
+        if is_directory:
+            parts.append(_canonical_header(member_name, is_directory=True, size=0))
+            continue
+        relative = member_name[len(top) + 1 :]
+        content = (package_dir / relative).read_bytes()
+        parts.append(_canonical_header(member_name, is_directory=False, size=len(content)))
+        parts.append(content)
+        padding = (-len(content)) % USTAR_RECORD_SIZE
+        if padding:
+            parts.append(b"\0" * padding)
+    parts.append(USTAR_EOF)
+    return b"".join(parts)
+
+
+def _safe_archive_name(value: str) -> bool:
+    if not value or "\\" in value or value.startswith("/"):
+        return False
+    try:
+        value.encode("ascii")
+    except UnicodeEncodeError:
+        return False
+    normalized = value[:-1] if value.endswith("/") else value
+    if not normalized or urlsplit(normalized).scheme:
+        return False
+    parts = normalized.split("/")
+    if any(part in {"", ".", ".."} or part.startswith(".") for part in parts):
+        return False
+    return PurePosixPath(normalized).as_posix() == normalized
+
+
+def _validate_output_paths(
+    archive_path: Path,
+    sidecar_path: Path,
+    release_identifier: str,
+    *,
+    require_absent: bool,
+) -> tuple[ReleaseArchiveIssue, ...]:
+    issues: list[ReleaseArchiveIssue] = []
+    expected_archive = archive_filename(release_identifier)
+    expected_sidecar = sidecar_filename(release_identifier)
+    if archive_path.name != expected_archive:
+        issues.append(archive_issue("ARCHIVE_FILENAME", "archive", f"expected {expected_archive!r}"))
+    if sidecar_path.name != expected_sidecar:
+        issues.append(archive_issue("ARCHIVE_SIDECAR_FILENAME", "sidecar", f"expected {expected_sidecar!r}"))
+    if archive_path.parent != sidecar_path.parent:
+        issues.append(archive_issue("ARCHIVE_OUTPUT_PARENT", "output", "archive and sidecar must share a parent"))
+    if not archive_path.parent.is_dir() or archive_path.parent.is_symlink():
+        issues.append(archive_issue("ARCHIVE_OUTPUT_PARENT", "output", "expected real existing parent"))
+    if require_absent:
+        for path, field in ((archive_path, "archive"), (sidecar_path, "sidecar")):
+            if os.path.lexists(path):
+                issues.append(archive_issue("OUTPUT_EXISTS", field, "output already exists"))
+    return tuple(sorted(set(issues), key=lambda value: value.sort_key))
+
+
+def _package_validation_issues(package_dir: Path, repository_root: Path) -> tuple[ReleaseArchiveIssue, ...]:
+    return tuple(
+        archive_issue("PACKAGE_VALIDATION_FAILED", value.field, f"[{value.code}] {value.message}")
+        for value in validate_release_package(package_dir, repository_root=repository_root, reconstruct=False)
+    )
+
+
+def _manifest_commit_issue(package_dir: Path, source_commit: str) -> tuple[ReleaseArchiveIssue, ...]:
+    try:
+        manifest = load_and_validate_release_manifest(package_dir / "manifest.json")
+    except Exception as exc:
+        return (archive_issue("PACKAGE_VALIDATION_FAILED", "manifest.json", str(exc)),)
+    if manifest.source_commit == source_commit:
+        return ()
+    return (
+        archive_issue(
+            "SOURCE_EVIDENCE_MISMATCH",
+            "manifest.source_commit",
+            f"expected {source_commit}, got {manifest.source_commit}",
+        ),
+    )
+
+
+def _rename_noreplace_syscall(source: Path, destination: Path) -> None:
+    """Rename exactly once without overwrite, or fail closed when unsupported."""
+
+    libc = ctypes.CDLL(None, use_errno=True)
+    source_bytes = os.fsencode(source)
+    destination_bytes = os.fsencode(destination)
+    if sys.platform.startswith("linux"):
+        function = getattr(libc, "renameat2", None)
+        if function is None:
+            raise AtomicNoReplaceUnsupportedError(errno.ENOSYS, "renameat2 is unavailable")
+        function.argtypes = (ctypes.c_int, ctypes.c_char_p, ctypes.c_int, ctypes.c_char_p, ctypes.c_uint)
+        function.restype = ctypes.c_int
+        result = function(AT_FDCWD, source_bytes, AT_FDCWD, destination_bytes, RENAME_NOREPLACE)
+    elif sys.platform == "darwin":
+        function = getattr(libc, "renamex_np", None)
+        if function is None:
+            raise AtomicNoReplaceUnsupportedError(errno.ENOSYS, "renamex_np is unavailable")
+        function.argtypes = (ctypes.c_char_p, ctypes.c_char_p, ctypes.c_uint)
+        function.restype = ctypes.c_int
+        result = function(source_bytes, destination_bytes, RENAME_EXCL)
+    else:
+        raise AtomicNoReplaceUnsupportedError(errno.ENOSYS, f"no no-replace rename for {sys.platform}")
+    if result != 0:
+        error = ctypes.get_errno()
+        raise OSError(error, os.strerror(error), str(destination))
+
+
+def atomic_rename_noreplace(source: Path, destination: Path) -> None:
+    """Publish one file or directory atomically without ever replacing a destination."""
+
+    _rename_noreplace_syscall(Path(source), Path(destination))
+
+
+def _capture_owned_directory(path: Path, field: str) -> _OwnedDirectory:
+    """Capture the non-following identity of a directory created by this process."""
+
+    try:
+        status = os.lstat(path)
+    except OSError as exc:
+        raise ReleaseArchiveError((archive_issue("CLEANUP_FAILED", field, str(exc)),)) from exc
+    file_type = stat.S_IFMT(status.st_mode)
+    if file_type != stat.S_IFDIR:
+        raise ReleaseArchiveError(
+            (archive_issue("CLEANUP_FAILED", field, "created path is not a real directory"),)
+        )
+    return _OwnedDirectory(path=path, st_dev=status.st_dev, st_ino=status.st_ino, file_type=file_type)
+
+
+def _owned_directory_matches(owned: _OwnedDirectory, path: Path | None = None) -> bool:
+    """Check ownership with lstat so a replacement symlink is never followed."""
+
+    try:
+        status = os.lstat(owned.path if path is None else path)
+    except OSError:
+        return False
+    return (
+        status.st_dev == owned.st_dev
+        and status.st_ino == owned.st_ino
+        and stat.S_IFMT(status.st_mode) == owned.file_type
+    )
+
+
+def _cleanup_owned_directory(owned: _OwnedDirectory | None, field: str) -> tuple[ReleaseArchiveIssue, ...]:
+    """Remove only a directory which still identifies the path we created."""
+
+    if owned is None:
+        return ()
+    try:
+        status = os.lstat(owned.path)
+    except FileNotFoundError:
+        return (archive_issue("CLEANUP_FAILED", field, "owned directory path is missing"),)
+    except OSError as exc:
+        return (archive_issue("CLEANUP_FAILED", field, str(exc)),)
+    if (
+        status.st_dev != owned.st_dev
+        or status.st_ino != owned.st_ino
+        or stat.S_IFMT(status.st_mode) != owned.file_type
+        or not stat.S_ISDIR(status.st_mode)
+    ):
+        return (archive_issue("CLEANUP_FAILED", field, "path no longer identifies the owned directory"),)
+    if not shutil.rmtree.avoids_symlink_attacks:
+        return (archive_issue("CLEANUP_FAILED", field, "platform cannot safely remove an owned directory"),)
+    try:
+        shutil.rmtree(owned.path)
+    except OSError as exc:
+        return (archive_issue("CLEANUP_FAILED", field, str(exc)),)
+    if os.path.lexists(owned.path):
+        return (archive_issue("CLEANUP_FAILED", field, "owned directory remains"),)
+    return ()
+
+
+def _archive_output_issues(
+    output_dir: Path,
+    *,
+    repository_root: Path,
+    ignored_staging: Path | None = None,
+) -> tuple[ReleaseArchiveIssue, ...]:
+    """Validate an absent external output directory without adopting siblings."""
+
+    issues: list[ReleaseArchiveIssue] = []
+    if not output_dir.is_absolute():
+        return (archive_issue("ARCHIVE_OUTPUT_PATH", "output_dir", "expected absolute path"),)
+    if os.path.lexists(output_dir):
+        issues.append(archive_issue("OUTPUT_EXISTS", "output_dir", "destination already exists"))
+    parent = output_dir.parent
+    if not parent.is_dir() or parent.is_symlink():
+        issues.append(archive_issue("ARCHIVE_OUTPUT_PARENT", "output_dir", "expected real existing parent"))
+        return tuple(sorted(set(issues), key=lambda value: value.sort_key))
+    current = Path(parent.anchor)
+    for component in parent.parts[1:]:
+        current = current / component
+        if current.is_symlink():
+            issues.append(archive_issue("ARCHIVE_OUTPUT_PATH", "output_dir", "parent path contains a symlink"))
+            break
+    try:
+        output_dir.relative_to(repository_root.resolve())
+    except ValueError:
+        pass
+    else:
+        issues.append(archive_issue("ARCHIVE_OUTPUT_PATH", "output_dir", "destination must be external to the repository"))
+    try:
+        for sibling in parent.iterdir():
+            if sibling == ignored_staging:
+                continue
+            if sibling.name.startswith(".release-archive-output-"):
+                issues.append(
+                    archive_issue("OUTPUT_EXISTS", "output_dir", "unrelated archive staging sibling exists")
+                )
+                break
+    except OSError as exc:
+        issues.append(archive_issue("ARCHIVE_OUTPUT_PARENT", "output_dir", str(exc)))
+    return tuple(sorted(set(issues), key=lambda value: value.sort_key))
+
+
+def _candidate_layout_issues(candidate_dir: Path, release_identifier: str) -> tuple[ReleaseArchiveIssue, ...]:
+    expected = {archive_filename(release_identifier), sidecar_filename(release_identifier)}
+    observed: set[str] = set()
+    issues: list[ReleaseArchiveIssue] = []
+    try:
+        for path in candidate_dir.iterdir():
+            observed.add(path.name)
+            if path.is_symlink() or not path.is_file():
+                issues.append(archive_issue("ARCHIVE_OUTPUT_LAYOUT", path.name, "expected regular evidence file"))
+    except OSError as exc:
+        return (archive_issue("ARCHIVE_OUTPUT_LAYOUT", "candidate_dir", str(exc)),)
+    if observed != expected:
+        issues.append(
+            archive_issue(
+                "ARCHIVE_OUTPUT_LAYOUT",
+                "candidate_dir",
+                f"missing={sorted(expected - observed)!r}; extra={sorted(observed - expected)!r}",
+            )
+        )
+    return tuple(sorted(set(issues), key=lambda value: value.sort_key))
+
+
+def build_archive_candidate(
+    package_dir: Path,
+    candidate_dir: Path,
+    release_identifier: str,
+    source_commit: str,
+    *,
+    repository_root: Path = REPO_ROOT,
+) -> ReleaseArchiveResult:
+    """Construct and validate a pair inside a caller-owned private directory.
+
+    This function deliberately does not publish anything externally.  The
+    caller owns candidate_dir and is responsible for identity-safe cleanup.
+    """
+
+    if SOURCE_COMMIT_PATTERN.fullmatch(source_commit) is None:
+        raise ReleaseArchiveError(
+            (archive_issue("SOURCE_COMMIT_FORMAT", "source_commit", "expected 40 lowercase hexadecimal characters"),)
+        )
+    package_dir = Path(package_dir)
+    candidate_dir = Path(candidate_dir)
+    issues: list[ReleaseArchiveIssue] = []
+    try:
+        candidate_status = os.lstat(candidate_dir)
+    except OSError as exc:
+        issues.append(archive_issue("ARCHIVE_CANDIDATE_DIRECTORY", "candidate_dir", str(exc)))
+    else:
+        if not stat.S_ISDIR(candidate_status.st_mode) or stat.S_ISLNK(candidate_status.st_mode):
+            issues.append(archive_issue("ARCHIVE_CANDIDATE_DIRECTORY", "candidate_dir", "expected empty real directory"))
+        else:
+            try:
+                if any(candidate_dir.iterdir()):
+                    issues.append(archive_issue("ARCHIVE_CANDIDATE_DIRECTORY", "candidate_dir", "expected empty directory"))
+            except OSError as exc:
+                issues.append(archive_issue("ARCHIVE_CANDIDATE_DIRECTORY", "candidate_dir", str(exc)))
+    issues.extend(_package_validation_issues(package_dir, Path(repository_root).resolve()))
+    issues.extend(_manifest_commit_issue(package_dir, source_commit))
+    if issues:
+        raise ReleaseArchiveError(issues)
+
+    archive_bytes = canonical_archive_bytes(package_dir, release_identifier)
+    sidecar_bytes = canonical_sidecar_bytes(release_identifier, archive_bytes)
+    archive_path = candidate_dir / archive_filename(release_identifier)
+    sidecar_path = candidate_dir / sidecar_filename(release_identifier)
+    try:
+        archive_path.write_bytes(archive_bytes)
+        sidecar_path.write_bytes(sidecar_bytes)
+    except OSError as exc:
+        raise ReleaseArchiveError((archive_issue("ARCHIVE_BUILD_FAILED", "candidate_dir", str(exc)),)) from exc
+
+    validation_issues = validate_release_archive(
+        package_dir,
+        archive_path,
+        sidecar_path,
+        release_identifier,
+        source_commit,
+        repository_root=repository_root,
+    )
+    layout_issues = _candidate_layout_issues(candidate_dir, release_identifier)
+    byte_issues: list[ReleaseArchiveIssue] = []
+    if archive_path.read_bytes() != archive_bytes:
+        byte_issues.append(archive_issue("ARCHIVE_CONTENT_MISMATCH", "archive", "candidate archive differs from constructed bytes"))
+    if sidecar_path.read_bytes() != sidecar_bytes:
+        byte_issues.append(archive_issue("ARCHIVE_CHECKSUM_MISMATCH", "sidecar", "candidate sidecar differs from constructed bytes"))
+    if validation_issues or layout_issues or byte_issues:
+        raise ReleaseArchiveError((*validation_issues, *layout_issues, *byte_issues))
+    return ReleaseArchiveResult(
+        archive_path=archive_path,
+        sidecar_path=sidecar_path,
+        archive_sha256=hashlib.sha256(archive_bytes).hexdigest(),
+        member_names=canonical_member_names(release_identifier),
+    )
+
+
+def build_release_archive(
+    package_dir: Path,
+    output_dir: Path,
+    release_identifier: str,
+    source_commit: str,
+    *,
+    repository_root: Path = REPO_ROOT,
+) -> ReleaseArchiveResult:
+    """Publish a complete validated archive pair by one no-replace directory rename."""
+
+    output_dir = Path(output_dir)
+    repository_root = Path(repository_root).resolve()
+    if SOURCE_COMMIT_PATTERN.fullmatch(source_commit) is None:
+        raise ReleaseArchiveError(
+            (archive_issue("SOURCE_COMMIT_FORMAT", "source_commit", "expected 40 lowercase hexadecimal characters"),)
+        )
+    preflight = _archive_output_issues(output_dir, repository_root=repository_root)
+    if preflight:
+        raise ReleaseArchiveError(preflight)
+    try:
+        staging_path = Path(tempfile.mkdtemp(prefix=".release-archive-output-", dir=output_dir.parent))
+        staging: _OwnedDirectory | None = _capture_owned_directory(staging_path, "archive_staging")
+    except ReleaseArchiveError:
+        raise
+    except OSError as exc:
+        raise ReleaseArchiveError(
+            (archive_issue("ATOMIC_PUBLICATION_FAILED", "output_dir", f"unable to create archive staging directory: {exc}"),)
+        ) from exc
+
+    primary: tuple[ReleaseArchiveIssue, ...] = ()
+    result: ReleaseArchiveResult | None = None
+    try:
+        candidate = build_archive_candidate(
+            package_dir,
+            staging.path,
+            release_identifier,
+            source_commit,
+            repository_root=repository_root,
+        )
+        late_preflight = _archive_output_issues(
+            output_dir,
+            repository_root=repository_root,
+            ignored_staging=staging.path,
+        )
+        if late_preflight:
+            primary = late_preflight
+        else:
+            try:
+                atomic_rename_noreplace(staging.path, output_dir)
+            except FileExistsError:
+                primary = (archive_issue("OUTPUT_EXISTS", "output_dir", "destination appeared before publication"),)
+            except AtomicNoReplaceUnsupportedError as exc:
+                primary = (archive_issue("ATOMIC_PUBLICATION_FAILED", "output_dir", str(exc)),)
+            except OSError as exc:
+                primary = (archive_issue("ATOMIC_PUBLICATION_FAILED", "output_dir", str(exc)),)
+            except Exception as exc:
+                primary = (archive_issue("ATOMIC_PUBLICATION_FAILED", "output_dir", str(exc)),)
+            else:
+                # The same directory inode now has an external name.  It is no
+                # longer temporary cleanup-owned, even if later reporting fails.
+                staging = None
+                result = ReleaseArchiveResult(
+                    archive_path=output_dir / candidate.archive_path.name,
+                    sidecar_path=output_dir / candidate.sidecar_path.name,
+                    archive_sha256=candidate.archive_sha256,
+                    member_names=candidate.member_names,
+                )
+    except ReleaseArchiveError as exc:
+        primary = exc.issues
+    except OSError as exc:
+        primary = (archive_issue("ARCHIVE_BUILD_FAILED", "archive", str(exc)),)
+    except Exception as exc:
+        primary = (archive_issue("ARCHIVE_BUILD_FAILED", "archive", str(exc)),)
+
+    # A test hook or platform wrapper can report an error after the syscall
+    # succeeds.  Relinquish only when the destination still has our inode;
+    # otherwise retain the external replacement and report unsafe cleanup.
+    if primary and staging is not None and not os.path.lexists(staging.path):
+        if _owned_directory_matches(staging, output_dir):
+            staging = None
+
+    cleanup = _cleanup_owned_directory(staging, "archive_staging")
+    if primary or cleanup:
+        raise ReleaseArchiveError((*primary, *cleanup))
+    assert result is not None
+    return result
+
+
+def _parse_numeric(field: bytes, width: int, name: str, member_name: str) -> int:
+    if len(field) != width or field[-1:] != b"\0" or any(value < ord("0") or value > ord("7") for value in field[:-1]):
+        raise ReleaseArchiveError(
+            (archive_issue("ARCHIVE_METADATA_MISMATCH", member_name, f"noncanonical {name} numeric field"),)
+        )
+    value = int(field[:-1].decode("ascii"), 8)
+    try:
+        canonical = _octal_field(value, width)
+    except ValueError as exc:
+        raise ReleaseArchiveError(
+            (archive_issue("ARCHIVE_METADATA_MISMATCH", member_name, f"{name} numeric field overflows canonical encoding"),)
+        ) from exc
+    if field != canonical:
+        raise ReleaseArchiveError(
+            (archive_issue("ARCHIVE_METADATA_MISMATCH", member_name, f"noncanonical {name} numeric encoding"),)
+        )
+    return value
+
+
+def _parse_checksum(header: bytes, member_name: str) -> int:
+    field = header[148:156]
+    if len(field) != 8 or field[6:] != b"\0 " or any(value < ord("0") or value > ord("7") for value in field[:6]):
+        raise ReleaseArchiveError(
+            (archive_issue("ARCHIVE_METADATA_MISMATCH", member_name, "noncanonical checksum field"),)
+        )
+    declared = int(field[:6].decode("ascii"), 8)
+    if field != _checksum_field(declared):
+        raise ReleaseArchiveError(
+            (archive_issue("ARCHIVE_METADATA_MISMATCH", member_name, "noncanonical checksum encoding"),)
+        )
+    calculated = sum(header[:148] + b" " * 8 + header[156:])
+    if declared != calculated:
+        raise ReleaseArchiveError(
+            (archive_issue("ARCHIVE_METADATA_MISMATCH", member_name, "header checksum differs"),)
+        )
+    return declared
+
+
+def _parse_name(header: bytes) -> str:
+    field = header[0:100]
+    try:
+        terminator = field.index(0)
+    except ValueError as exc:
+        raise ReleaseArchiveError(
+            (archive_issue("ARCHIVE_METADATA_MISMATCH", "archive", "name field lacks NUL terminator"),)
+        ) from exc
+    if any(field[terminator + 1 :]):
+        raise ReleaseArchiveError(
+            (archive_issue("ARCHIVE_METADATA_MISMATCH", "archive", "name field has nonzero unused bytes"),)
+        )
+    try:
+        return field[:terminator].decode("ascii")
+    except UnicodeDecodeError as exc:
+        raise ReleaseArchiveError(
+            (archive_issue("UNSAFE_ARCHIVE_MEMBER", "archive", "member name is not ASCII"),)
+        ) from exc
+
+
+def _parse_raw_archive(archive_bytes: bytes, release_identifier: str) -> tuple[_RawArchiveMember, ...]:
+    if len(archive_bytes) % USTAR_RECORD_SIZE:
+        raise ReleaseArchiveError(
+            (archive_issue("ARCHIVE_PARSE_FAILED", "archive", "archive length is not a multiple of 512"),)
+        )
+    expected = canonical_member_names(release_identifier)
+    expected_directories = canonical_directory_names(release_identifier)
+    members: list[_RawArchiveMember] = []
+    seen: set[str] = set()
+    offset = 0
+    while True:
+        if offset + USTAR_RECORD_SIZE > len(archive_bytes):
+            raise ReleaseArchiveError(
+                (archive_issue("ARCHIVE_PARSE_FAILED", "archive", "archive ends before EOF records"),)
+            )
+        header = archive_bytes[offset : offset + USTAR_RECORD_SIZE]
+        if header == b"\0" * USTAR_RECORD_SIZE:
+            if len(archive_bytes) < offset + len(USTAR_EOF) or archive_bytes[offset : offset + len(USTAR_EOF)] != USTAR_EOF:
+                raise ReleaseArchiveError(
+                    (archive_issue("ARCHIVE_METADATA_MISMATCH", "archive", "archive must end with exactly two zero records"),)
+                )
+            if len(archive_bytes) != offset + len(USTAR_EOF):
+                raise ReleaseArchiveError(
+                    (archive_issue("ARCHIVE_METADATA_MISMATCH", "archive", "data follows the governed two-record EOF"),)
+                )
+            break
+
+        member_name = _parse_name(header)
+        if not _safe_archive_name(member_name):
+            raise ReleaseArchiveError(
+                (archive_issue("UNSAFE_ARCHIVE_MEMBER", member_name or "archive", "unsafe member name"),)
+            )
+        if member_name in seen:
+            raise ReleaseArchiveError(
+                (archive_issue("DUPLICATE_ARCHIVE_MEMBER", member_name, "member name is not unique"),)
+            )
+        seen.add(member_name)
+        index = len(members)
+        if index >= len(expected) or member_name != expected[index]:
+            raise ReleaseArchiveError(
+                (archive_issue("ARCHIVE_MEMBER_ORDER", member_name, "member differs from canonical order"),)
+            )
+        is_directory = member_name in expected_directories
+        type_flag = header[156:157]
+        expected_type = b"5" if is_directory else b"0"
+        if type_flag != expected_type:
+            raise ReleaseArchiveError(
+                (archive_issue("ARCHIVE_MEMBER_TYPE", member_name, "type flag differs from canonical member type"),)
+            )
+        _parse_checksum(header, member_name)
+        if header[257:263] != USTAR_MAGIC or header[263:265] != USTAR_VERSION:
+            raise ReleaseArchiveError(
+                (archive_issue("ARCHIVE_METADATA_MISMATCH", member_name, "magic or version differs from POSIX USTAR"),)
+            )
+        if any(header[345:500]) or any(header[500:512]):
+            raise ReleaseArchiveError(
+                (archive_issue("ARCHIVE_METADATA_MISMATCH", member_name, "prefix or unused bytes are nonzero"),)
+            )
+        if any(header[157:257]) or any(header[265:329]):
+            raise ReleaseArchiveError(
+                (archive_issue("ARCHIVE_METADATA_MISMATCH", member_name, "link or owner name field is nonempty"),)
+            )
+        mode = _parse_numeric(header[100:108], 8, "mode", member_name)
+        uid = _parse_numeric(header[108:116], 8, "uid", member_name)
+        gid = _parse_numeric(header[116:124], 8, "gid", member_name)
+        size = _parse_numeric(header[124:136], 12, "size", member_name)
+        mtime = _parse_numeric(header[136:148], 12, "mtime", member_name)
+        device_major = _parse_numeric(header[329:337], 8, "device major", member_name)
+        device_minor = _parse_numeric(header[337:345], 8, "device minor", member_name)
+        expected_mode = DIRECTORY_MODE if is_directory else FILE_MODE
+        if mode != expected_mode or uid != 0 or gid != 0 or mtime != CANONICAL_MTIME or device_major != 0 or device_minor != 0:
+            raise ReleaseArchiveError(
+                (archive_issue("ARCHIVE_METADATA_MISMATCH", member_name, "member metadata differs from canonical values"),)
+            )
+        if is_directory and (not member_name.endswith("/") or size != 0):
+            raise ReleaseArchiveError(
+                (archive_issue("ARCHIVE_METADATA_MISMATCH", member_name, "directory metadata differs from canonical values"),)
+            )
+        expected_header = _canonical_header(member_name, is_directory=is_directory, size=size)
+        if header != expected_header:
+            raise ReleaseArchiveError(
+                (archive_issue("ARCHIVE_METADATA_MISMATCH", member_name, "raw header differs from canonical USTAR bytes"),)
+            )
+        offset += USTAR_RECORD_SIZE
+        if offset + size > len(archive_bytes):
+            raise ReleaseArchiveError(
+                (archive_issue("ARCHIVE_PARSE_FAILED", member_name, "regular-file body is truncated"),)
+            )
+        content = archive_bytes[offset : offset + size]
+        offset += size
+        padding = (-size) % USTAR_RECORD_SIZE
+        if offset + padding > len(archive_bytes):
+            raise ReleaseArchiveError(
+                (archive_issue("ARCHIVE_PARSE_FAILED", member_name, "regular-file padding is truncated"),)
+            )
+        if any(archive_bytes[offset : offset + padding]):
+            raise ReleaseArchiveError(
+                (archive_issue("ARCHIVE_METADATA_MISMATCH", member_name, "regular-file padding is nonzero"),)
+            )
+        offset += padding
+        members.append(_RawArchiveMember(member_name, content, is_directory))
+    if tuple(member.name for member in members) != expected:
+        raise ReleaseArchiveError(
+            (archive_issue("ARCHIVE_MEMBER_ORDER", "archive", f"expected exact {len(expected)}-member inventory"),)
+        )
+    return tuple(members)
+
+
+def _materialize_package(
+    members: tuple[_RawArchiveMember, ...],
+    release_identifier: str,
+    package_dir: Path,
+) -> tuple[_OwnedDirectory, Path | None, tuple[ReleaseArchiveIssue, ...]]:
+    extraction_path = Path(tempfile.mkdtemp(prefix="release-archive-validation-"))
+    extraction_root = _capture_owned_directory(extraction_path, "archive_extraction")
+    extracted = extraction_root.path / release_identifier
+    top = archive_top_level(release_identifier)
+    try:
+        extracted.mkdir(mode=DIRECTORY_MODE)
+        for relative in EXPECTED_DIRECTORIES:
+            (extracted / relative).mkdir(mode=DIRECTORY_MODE)
+        for member in members:
+            if member.is_directory:
+                continue
+            relative = member.name[len(top) + 1 :]
+            expected = (package_dir / relative).read_bytes()
+            if member.content != expected:
+                return extraction_root, None, (archive_issue("ARCHIVE_CONTENT_MISMATCH", member.name, "bytes differ from package"),)
+            destination = extracted / relative
+            destination.write_bytes(member.content)
+            destination.chmod(FILE_MODE)
+        return extraction_root, extracted, ()
+    except OSError as exc:
+        return extraction_root, None, (archive_issue("ARCHIVE_PARSE_FAILED", "archive", str(exc)),)
+
+
+def validate_release_archive(
+    package_dir: Path,
+    archive_path: Path,
+    sidecar_path: Path,
+    release_identifier: str,
+    source_commit: str,
+    *,
+    repository_root: Path = REPO_ROOT,
+) -> tuple[ReleaseArchiveIssue, ...]:
+    """Read-only raw USTAR and sidecar validation before safe materialization."""
+
+    package_dir = Path(package_dir)
+    archive_path = Path(archive_path)
+    sidecar_path = Path(sidecar_path)
+    repository_root = Path(repository_root).resolve()
+    issues: list[ReleaseArchiveIssue] = list(_archive_layout_authority_issues(release_identifier))
+    issues.extend(_validate_output_paths(archive_path, sidecar_path, release_identifier, require_absent=False))
+    issues.extend(_package_layout_issues(package_dir))
+    if SOURCE_COMMIT_PATTERN.fullmatch(source_commit) is None:
+        issues.append(archive_issue("SOURCE_COMMIT_FORMAT", "source_commit", "expected 40 lowercase hexadecimal characters"))
+    if not archive_path.is_file() or archive_path.is_symlink():
+        issues.append(archive_issue("ARCHIVE_MISSING", "archive", "expected regular archive file"))
+    if not sidecar_path.is_file() or sidecar_path.is_symlink():
+        issues.append(archive_issue("ARCHIVE_SIDECAR_MISSING", "sidecar", "expected regular sidecar file"))
+    if issues:
+        return tuple(sorted(set(issues), key=lambda value: value.sort_key))
+
+    archive_bytes = archive_path.read_bytes()
+    sidecar_bytes = sidecar_path.read_bytes()
+    expected_sidecar = canonical_sidecar_bytes(release_identifier, archive_bytes)
+    if sidecar_bytes != expected_sidecar:
+        return (archive_issue("ARCHIVE_CHECKSUM_MISMATCH", "sidecar", "bytes differ from canonical checksum sidecar"),)
+    try:
+        members = _parse_raw_archive(archive_bytes, release_identifier)
+    except ReleaseArchiveError as exc:
+        return exc.issues
+
+    extraction_root: _OwnedDirectory | None = None
+    primary_issues: list[ReleaseArchiveIssue] = []
+    try:
+        extraction_root, extracted, materialization_issues = _materialize_package(members, release_identifier, package_dir)
+        if materialization_issues:
+            primary_issues.extend(materialization_issues)
+        else:
+            assert extracted is not None
+            primary_issues.extend(_package_validation_issues(extracted, repository_root))
+            primary_issues.extend(_manifest_commit_issue(extracted, source_commit))
+            regenerated = canonical_archive_bytes(extracted, release_identifier)
+            if regenerated != archive_bytes:
+                primary_issues.append(archive_issue("ARCHIVE_METADATA_MISMATCH", "archive", "canonical regeneration differs"))
+            if canonical_sidecar_bytes(release_identifier, regenerated) != sidecar_bytes:
+                primary_issues.append(archive_issue("ARCHIVE_CHECKSUM_MISMATCH", "sidecar", "canonical regeneration differs"))
+    except ReleaseArchiveError as exc:
+        primary_issues.extend(exc.issues)
+    finally:
+        cleanup_issues = _cleanup_owned_directory(extraction_root, "archive_extraction")
+        primary_issues.extend(cleanup_issues)
+    return tuple(sorted(set(primary_issues), key=lambda value: value.sort_key))
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    build = subparsers.add_parser("build")
+    build.add_argument("--package-dir", required=True, type=Path)
+    build.add_argument("--output-dir", required=True, type=Path)
+    build.add_argument("--release-id", required=True)
+    build.add_argument("--source-commit", required=True)
+
+    candidate = subparsers.add_parser("build-candidate")
+    candidate.add_argument("--package-dir", required=True, type=Path)
+    candidate.add_argument("--candidate-dir", required=True, type=Path)
+    candidate.add_argument("--release-id", required=True)
+    candidate.add_argument("--source-commit", required=True)
+
+    validate = subparsers.add_parser("validate")
+    validate.add_argument("--package-dir", required=True, type=Path)
+    validate.add_argument("--archive", required=True, type=Path)
+    validate.add_argument("--sidecar", required=True, type=Path)
+    validate.add_argument("--release-id", required=True)
+    validate.add_argument("--source-commit", required=True)
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    try:
+        if args.command == "build":
+            result = build_release_archive(
+                args.package_dir,
+                args.output_dir,
+                args.release_id,
+                args.source_commit,
+            )
+            print("SOSA-2023 release archive build: PASS")
+            print(f"Archive SHA-256: {result.archive_sha256}")
+            print(f"Archive members: {len(result.member_names)}")
+            return 0
+        if args.command == "build-candidate":
+            result = build_archive_candidate(
+                args.package_dir,
+                args.candidate_dir,
+                args.release_id,
+                args.source_commit,
+            )
+            print("SOSA-2023 release archive candidate build: PASS")
+            print(f"Archive SHA-256: {result.archive_sha256}")
+            print(f"Archive members: {len(result.member_names)}")
+            return 0
+        issues = validate_release_archive(
+            args.package_dir,
+            args.archive,
+            args.sidecar,
+            args.release_id,
+            args.source_commit,
+        )
+        if issues:
+            for issue in issues:
+                print(format_issue(issue))
+            return 1
+        print("SOSA-2023 release archive validation: PASS")
+        print(f"Archive members: {len(canonical_member_names(args.release_id))}")
+        return 0
+    except Exception as exc:
+        print(str(exc))
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Adds the separate deterministic SOSA-2023 release-archive authority without changing the existing current-track archive or package machinery.

### Archive authority

- Adds `tools/sosa_2023_release_archive.py` as a separate SOSA-2023 raw POSIX USTAR archive engine.
- Binds the exact 13-file SOSA-2023 package to a canonical 16-member archive inventory.
- Preserves the hardened current archive invariants:
  - explicit deterministic member order;
  - canonical raw USTAR headers;
  - fixed file and directory modes;
  - zero uid, gid, device identifiers, and mtimes;
  - canonical octal fields and checksums;
  - zero-filled record padding;
  - exactly two terminal zero-filled 512-byte EOF records;
  - rejection of unsafe, duplicate, reordered, special-type, and noncanonical members;
  - exact lowercase SHA-256 sidecar;
  - atomic no-replace publication of the complete archive/sidecar pair.
- Uses a track-disambiguated external archive filename containing the full immutable source-version identity.
- Uses `SOSA-2023-<release-id>/` as the internal archive root so all raw-USTAR member names remain within the 100-byte name field.
- Does not import or modify the current-track archive, package, checker, or manifest engines.

### Determinism contract

For the governed synthetic release context:

- package files: 13
- archive members: 16
- longest member name: 94 bytes
- checksum sidecar: 140 bytes

Two independent archives constructed from the **same complete package bytes** must be byte-identical, and their sidecars must be byte-identical and match the canonical SHA-256 sidecar grammar.

The complete package manifest deliberately records the actual validation environment, including Python and Java runtime identity. Accordingly, package bytes—and therefore the whole-archive SHA-256 and potentially its padded archive size—may differ across validated environments. No cross-environment fixed whole-archive SHA-256 or byte-size contract is claimed.

The archive serializer itself has independent regression coverage proving deterministic output across hash seeds, locale, timezone, umask, and source filesystem metadata for identical package content.

### Validation

- Adds 23 permanent SOSA-2023 archive regressions.
- Adds `make check-sosa-2023-release-archive`.
- Integrates the archive module and regression into Python compilation and the authoritative validation suite.
- Full local `make check` passed before the portability correction.
- The exact CI-failing archive regression now passes locally after replacing the nonportable cross-environment digest assertion with same-package deterministic assertions.
- Existing current-track release machinery and SOSA-2023 package authorities remain byte-identical.

### Scope

This milestone does not implement isolated SOSA-2023 release rehearsal, select or approve a real release context or real release notes, create a tag or GitHub release, or deploy persistent IRIs.
